### PR TITLE
Com 583 start date

### DIFF
--- a/controllers/contractController.js
+++ b/controllers/contractController.js
@@ -6,8 +6,8 @@ const User = require('../models/User');
 const Customer = require('../models/Customer');
 const ESign = require('../models/ESign');
 const translate = require('../helpers/translate');
-const { endContract, createAndSaveFile, saveCompletedContract, updateVersion } = require('../helpers/contracts');
-const { generateSignatureRequest } = require('../helpers/generateSignatureRequest');
+const { createVersion, endContract, createAndSaveFile, saveCompletedContract, updateVersion } = require('../helpers/contracts');
+const { generateSignatureRequest } = require('../helpers/eSign');
 
 const { language } = translate;
 
@@ -112,16 +112,7 @@ const remove = async (req) => {
 
 const createContractVersion = async (req) => {
   try {
-    if (req.payload.signature) {
-      const doc = await generateSignatureRequest(req.payload.signature);
-      if (doc.data.error) return Boom.badRequest(`Eversign: ${doc.data.error.type}`);
-      req.payload.signature = { eversignId: doc.data.document_hash };
-    }
-    const contract = await Contract.findOneAndUpdate(
-      { _id: req.params._id },
-      { $push: { versions: req.payload } },
-      { new: true, autopopulate: false }
-    );
+    const contract = createVersion(req.params._id, req.payload);
 
     return { message: translate[language].contractVersionAdded, data: { contract } };
   } catch (e) {

--- a/controllers/contractController.js
+++ b/controllers/contractController.js
@@ -113,6 +113,7 @@ const remove = async (req) => {
 const createContractVersion = async (req) => {
   try {
     const contract = createVersion(req.params._id, req.payload);
+    if (!contract) return Boom.notFound(translate[language].contractNotFound);
 
     return { message: translate[language].contractVersionAdded, data: { contract } };
   } catch (e) {

--- a/controllers/customerController.js
+++ b/controllers/customerController.js
@@ -14,7 +14,7 @@ const { populateSubscriptionsServices } = require('../helpers/subscriptions');
 const { generateRum } = require('../helpers/generateRum');
 const { createFolder, addFile } = require('../helpers/gdriveStorage');
 const { createAndReadFile } = require('../helpers/file');
-const { generateSignatureRequest } = require('../helpers/generateSignatureRequest');
+const { generateSignatureRequest } = require('../helpers/eSign');
 const {
   createAndSaveFile,
   getCustomerBySector,

--- a/helpers/contracts.js
+++ b/helpers/contracts.js
@@ -54,7 +54,7 @@ exports.createVersion = async (contractId, newVersion) => {
     { _id: contractId },
     { $push: { versions: newVersion } },
     { new: true, autopopulate: false }
-  );
+  ).lean();
 
   if (contract.versions.length > 1) {
     await exports.updatePreviousVersion(contract, contract.versions.length - 1, newVersion.startDate);
@@ -64,12 +64,10 @@ exports.createVersion = async (contractId, newVersion) => {
 };
 
 exports.updatePreviousVersion = async (contract, versionIndex, versionStartDate) => {
-  const previousVersionId = contract.versions[versionIndex - 1]._id;
   const previousVersionStartDate = moment(versionStartDate).subtract(1, 'd').endOf('d').toISOString();
-  await Contract.updateOne(
+  await Contract.findOneAndUpdate(
     { _id: contract._id },
-    { $set: { 'versions.$[version].endDate': previousVersionStartDate } },
-    { arrayFilters: [{ 'version._id': mongoose.Types.ObjectId(previousVersionId) }] }
+    { $set: { [`versions.${versionIndex - 1}.endDate`]: previousVersionStartDate } }
   );
 };
 

--- a/helpers/contracts.js
+++ b/helpers/contracts.js
@@ -55,6 +55,7 @@ exports.createVersion = async (contractId, newVersion) => {
     { $push: { versions: newVersion } },
     { new: true, autopopulate: false }
   ).lean();
+  if (!contract) return null;
 
   if (contract.versions.length > 1) {
     await exports.updatePreviousVersion(contract, contract.versions.length - 1, newVersion.startDate);
@@ -81,6 +82,7 @@ exports.updateVersion = async (contractId, versionId, versionToUpdate) => {
       arrayFilters: [{ 'version._id': mongoose.Types.ObjectId(versionId) }],
     }
   ).lean();
+  if (!contract) return null;
 
   if (versionToUpdate.startDate) {
     const index = contract.versions.findIndex(ver => ver._id.toHexString() === versionId);

--- a/helpers/eSign.js
+++ b/helpers/eSign.js
@@ -22,5 +22,6 @@ exports.generateSignatureRequest = async (params) => {
     redirect: params.redirect || '',
     redirect_decline: params.redirectDecline || '',
   };
+
   return ESign.createDocument(payload);
 };

--- a/routes/contracts.js
+++ b/routes/contracts.js
@@ -166,6 +166,7 @@ exports.plugin = {
             versionId: Joi.objectId().required(),
           },
           payload: {
+            startDate: Joi.date(),
             endDate: Joi.date(),
             grossHourlyRate: Joi.number(),
           },

--- a/routes/contracts.js
+++ b/routes/contracts.js
@@ -99,7 +99,6 @@ exports.plugin = {
         validate: {
           params: { _id: Joi.objectId().required() },
           payload: {
-            startDate: Joi.date(),
             endDate: Joi.date(),
             endReason: Joi.string().valid(END_CONTRACT_REASONS),
             otherMisc: Joi.string(),

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -2,96 +2,95 @@ const sinon = require('sinon');
 const expect = require('expect');
 const moment = require('moment');
 const { ObjectID } = require('mongodb');
-require('sinon-mongoose');
-
+const EventHelper = require('../../../helpers/events');
 const ContractHelper = require('../../../helpers/contracts');
 const Contract = require('../../../models/Contract');
 const User = require('../../../models/User');
+require('sinon-mongoose');
 
 describe('endContract', () => {
-  let ContractFindByIdStub;
+  let ContractFindOneStub;
   let ContractFindStub;
   let UserfindOneAndUpdateStub;
-  let newContract;
   let contractSaveStub;
-  const contractId1 = new ObjectID();
-  const contractId2 = new ObjectID();
+  let unassignInterventionsOnContractEnd;
+  let removeEventsExceptInterventionsOnContractEnd;
+  let updateAbsencesOnContractEnd;
   const payload = {
-    endDate: moment().toDate(),
-    endNotificationDate: moment().toDate(),
+    endDate: moment('2018-12-03T23:00:00').toDate(),
+    endNotificationDate: moment('2018-12-03T23:00:00').toDate(),
     endReason: 'test',
     otherMisc: 'test',
   };
-
-  const contracts = [{
+  let newContract = {
+    _id: new ObjectID(),
     endDate: null,
     user: new ObjectID(),
-    startDate: moment('2018-12-03T23:00:00.000Z').toDate(),
+    startDate: moment('2018-12-03T23:00:00').toDate(),
     status: 'contract_with_company',
-    _id: contractId1,
-    versions: [
-      {
-        createdAt: moment('2018-12-04T16:34:04.144Z').toDate(),
-        endDate: null,
-        _id: new ObjectID(),
-        signature: {
-          signedBy: { auxiliary: false, other: false },
-        },
-      },
-    ],
-  }, {
-    endDate: null,
+    versions: [{ _id: new ObjectID() }],
+  };
+  const userContracts = [{
     user: new ObjectID(),
-    startDate: moment('2019-05-06T23:00:00.000Z').toDate(),
+    endDate: moment('2019-08-06T23:00:00').toDate(),
+    startDate: moment('2019-05-06T23:00:00').toDate(),
     status: 'contract_with_customer',
-    _id: contractId2,
-    versions: [
-      {
-        createdAt: moment('2019-05-04T16:34:04.144Z').toDate(),
-        endDate: null,
-        _id: new ObjectID(),
-        signature: {
-          signedBy: { auxiliary: false, other: false },
-        },
-      },
-    ],
   }];
+  const updatedContract = {
+    ...newContract[0],
+    ...payload,
+    versions: [{ ...newContract.versions[0], endDate: payload.endDate }],
+  };
+  const credentials = { _id: new ObjectID() };
   beforeEach(() => {
-    newContract = new Contract(contracts[0]);
+    newContract = new Contract(newContract);
     contractSaveStub = sinon.stub(newContract, 'save');
-    ContractFindByIdStub = sinon.stub(Contract, 'findById');
+    ContractFindOneStub = sinon.stub(Contract, 'findOne');
     ContractFindStub = sinon.stub(Contract, 'find');
     UserfindOneAndUpdateStub = sinon.stub(User, 'findOneAndUpdate');
+    unassignInterventionsOnContractEnd = sinon.stub(EventHelper, 'unassignInterventionsOnContractEnd');
+    removeEventsExceptInterventionsOnContractEnd = sinon.stub(EventHelper, 'removeEventsExceptInterventionsOnContractEnd');
+    updateAbsencesOnContractEnd = sinon.stub(EventHelper, 'updateAbsencesOnContractEnd');
   });
   afterEach(() => {
-    ContractFindByIdStub.restore();
+    ContractFindOneStub.restore();
     ContractFindStub.restore();
     contractSaveStub.restore();
     UserfindOneAndUpdateStub.restore();
+    unassignInterventionsOnContractEnd.restore();
+    removeEventsExceptInterventionsOnContractEnd.restore();
+    updateAbsencesOnContractEnd.restore();
   });
 
   it('should end contract', async () => {
-    ContractFindByIdStub.returns(newContract);
-    const updatedContract = { ...contracts[0], ...payload, versions: [{ ...contracts[0].versions[0], endDate: payload.endDate }] };
-    contractSaveStub.returns(updatedContract);
-    ContractFindStub.returns([updatedContract, contracts[1]]);
-    const result = await ContractHelper.endContract(contractId1, payload);
-    sinon.assert.called(ContractFindByIdStub);
+    ContractFindOneStub.returns(newContract);
+    ContractFindStub.returns([updatedContract]);
+
+    const result = await ContractHelper.endContract(newContract._id, payload, credentials);
+
+    sinon.assert.called(ContractFindOneStub);
     sinon.assert.called(contractSaveStub);
-    sinon.assert.calledWith(ContractFindStub, { user: contracts[0].user });
-    expect(result.toObject()).toEqual(expect.objectContaining(updatedContract));
+    sinon.assert.calledWith(ContractFindStub, { user: newContract.user });
+    sinon.assert.calledWith(unassignInterventionsOnContractEnd);
+    sinon.assert.called(removeEventsExceptInterventionsOnContractEnd);
+    sinon.assert.called(updateAbsencesOnContractEnd);
+    expect(result.toObject()).toMatchObject(updatedContract);
   });
 
   it('should end contract and set inactivity date for user if all contracts are ended', async () => {
-    ContractFindByIdStub.returns(newContract);
-    const updatedContract = { ...contracts[0], ...payload, versions: [{ ...contracts[0].versions[0], endDate: payload.endDate }] };
-    contractSaveStub.returns(updatedContract);
-    ContractFindStub.returns([updatedContract, { ...contracts[1], endDate: moment().toDate }]);
-    const result = await ContractHelper.endContract(contractId1, payload);
-    sinon.assert.called(ContractFindByIdStub);
+    ContractFindOneStub.returns(newContract);
+    ContractFindStub.returns(userContracts);
+
+    const result = await ContractHelper.endContract(newContract._id, payload, credentials);
+
+    sinon.assert.called(ContractFindOneStub);
     sinon.assert.called(contractSaveStub);
-    sinon.assert.calledWith(ContractFindStub, { user: contracts[0].user });
-    sinon.assert.calledWith(UserfindOneAndUpdateStub, { _id: contracts[0].user }, { $set: { inactivityDate: moment().add('1', 'months').startOf('M').toDate() } });
-    expect(result.toObject()).toEqual(expect.objectContaining(updatedContract));
+    sinon.assert.calledWith(ContractFindStub, { user: newContract.user });
+    sinon.assert.calledWith(
+      UserfindOneAndUpdateStub,
+      { _id: newContract.user },
+      { $set: { inactivityDate: moment().add('1', 'months').startOf('M').toDate() } }
+    );
+    expect(result.toObject()).toMatchObject(updatedContract);
   });
 });


### PR DESCRIPTION
Dans cette PR : 
- Edition de la date d'effet d'un contrat/avenant
-- Si contrat : on met a jour le champ `startDate` dans le premier objet de `versions` et le champ a la racine de `contract`
-- Si avenant : on met a jour le champ `startDate` dans l'objet courant de `versions` et du précédant
- Refacto des routes `contracts` pour les mettre dans l'helper