### PR TITLE
COM-701 - Should not check conflicts on not affected events

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -222,7 +222,7 @@ exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
     Repetition.updateMany({ auxiliary: contract.user }, { $unset: { auxiliary: '' } })
   );
 
-  await Promise.all(promises);
+  return Promise.all(promises);
 };
 
 exports.removeEventsExceptInterventionsOnContractEnd = async (contract, credentials) => {

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -28,7 +28,7 @@ exports.formatRepeatedPayload = async (event, momentDay) => {
     endDate: moment(event.endDate).add(step, 'd'),
   };
 
-  if (event.type === INTERVENTION && await EventsValidationHelper.hasConflicts(payload)) {
+  if (event.type === INTERVENTION && event.auxiliary && await EventsValidationHelper.hasConflicts(payload)) {
     delete payload.auxiliary;
     delete payload.repetition;
   }

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -165,17 +165,17 @@ exports.createFutureEventBasedOnRepetition = async (repetition) => {
   const endDateObj = moment(endDate).toObject();
   const newEventStartDate = moment().add(90, 'd').set(pick(startDateObj, ['hours', 'minutes', 'seconds', 'milliseconds'])).toDate();
   const newEventEndDate = moment().add(90, 'd').set(pick(endDateObj, ['hours', 'minutes', 'seconds', 'milliseconds'])).toDate();
-  const newEventPayload = {
+  const newEvent = {
     ...pick(repetition, ['type', 'customer', 'subscription', 'auxiliary', 'sector', 'status', 'misc', 'internalHour', 'address']),
     startDate: newEventStartDate,
     endDate: newEventEndDate,
     repetition: { frequency, parentId },
   };
 
-  if (newEventPayload.type === INTERVENTION && await EventsValidationHelper.hasConflicts(newEventPayload)) {
-    delete newEventPayload.auxiliary;
-    delete newEventPayload.repetition;
+  if (newEvent.type === INTERVENTION && newEvent.auxiliary && await EventsValidationHelper.hasConflicts(newEvent)) {
+    delete newEvent.auxiliary;
+    delete newEvent.repetition;
   }
 
-  return new Event(newEventPayload);
+  return new Event(newEvent);
 };

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const get = require('lodash/get');
 const omit = require('lodash/omit');
+const cloneDeep = require('lodash/cloneDeep');
 const pick = require('lodash/pick');
 const momentRange = require('moment-range');
 const {
@@ -23,14 +24,14 @@ momentRange.extendMoment(moment);
 exports.formatRepeatedPayload = async (event, momentDay) => {
   const step = momentDay.diff(event.startDate, 'd');
   const payload = {
-    ...omit(event, '_id'),
+    ...cloneDeep(omit(event, '_id')), // cloneDeep necessary to copy repetition
     startDate: moment(event.startDate).add(step, 'd'),
     endDate: moment(event.endDate).add(step, 'd'),
   };
 
   if (event.type === INTERVENTION && event.auxiliary && await EventsValidationHelper.hasConflicts(payload)) {
     delete payload.auxiliary;
-    delete payload.repetition;
+    payload.repetition.frequency = NEVER;
   }
 
   return new Event(payload);
@@ -113,6 +114,7 @@ exports.updateRepetition = async (event, eventPayload) => {
 
   const events = await Event.find({
     'repetition.parentId': event.repetition.parentId,
+    'repetition.frequency': { $not: { $eq: NEVER } },
     startDate: { $gte: new Date(event.startDate) },
   });
 
@@ -174,7 +176,7 @@ exports.createFutureEventBasedOnRepetition = async (repetition) => {
 
   if (newEvent.type === INTERVENTION && newEvent.auxiliary && await EventsValidationHelper.hasConflicts(newEvent)) {
     delete newEvent.auxiliary;
-    delete newEvent.repetition;
+    newEvent.repetition.frequency = NEVER;
   }
 
   return new Event(newEvent);

--- a/src/jobs/eventRepetitions.js
+++ b/src/jobs/eventRepetitions.js
@@ -25,19 +25,16 @@ const eventRepetitions = {
               newEvents.push(futureEvent);
             }
             break;
-
           case EVERY_WEEK:
             if (moment(startDate).day() === newEventStartDate.day()) {
               futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition);
               newEvents.push(futureEvent);
             }
             break;
-
           case EVERY_DAY:
             futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition);
             newEvents.push(futureEvent);
             break;
-
           case EVERY_WEEK_DAY:
             if (newEventStartDate.day() !== 0 && newEventStartDate.day() !== 6) {
               futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition);
@@ -59,7 +56,7 @@ const eventRepetitions = {
       if (errors && errors.length) {
         server.log(['error', 'cron', 'oncomplete'], errors);
       }
-      server.log(['cron', 'oncomplete'], `Event repetitions: ${results.length} répétitions traitées.`);
+      server.log(['cron', 'oncomplete'], `Event repetitions: ${results.length} évènements créés.`);
       EmailHelper.completeEventRepScriptEmail(results.length, errors);
     } catch (e) {
       server.log(['error', 'cron', 'oncomplete'], e);

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -52,7 +52,7 @@ describe('formatRepeatedPayload', () => {
       endDate: moment('2019-07-15').startOf('d'),
       auxiliary: auxiliaryId,
       type: 'intervention',
-      repetition: { frequency: 'eevry_week' },
+      repetition: { frequency: 'every_week' },
     };
 
     hasConflicts.returns(true);

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -79,6 +79,21 @@ describe('formatRepeatedPayload', () => {
     expect(result).toBeDefined();
     expect(result.auxiliary).toBeDefined();
   });
+
+  it('should not called hasConflicts if event is not affected', async () => {
+    const day = moment('2019-07-17', 'YYYY-MM-DD');
+    const event = {
+      startDate: moment('2019-07-14').startOf('d'),
+      endDate: moment('2019-07-15').startOf('d'),
+      type: 'intervention',
+    };
+
+    const result = await EventsRepetitionHelper.formatRepeatedPayload(event, day);
+
+    expect(result).toBeDefined();
+    expect(result.auxiliary).not.toBeDefined();
+    sinon.assert.notCalled(hasConflicts);
+  });
 });
 
 describe('createRepetitionsEveryDay', () => {

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -52,6 +52,7 @@ describe('formatRepeatedPayload', () => {
       endDate: moment('2019-07-15').startOf('d'),
       auxiliary: auxiliaryId,
       type: 'intervention',
+      repetition: { frequency: 'eevry_week' },
     };
 
     hasConflicts.returns(true);
@@ -61,6 +62,7 @@ describe('formatRepeatedPayload', () => {
     expect(result.startDate).toEqual(moment('2019-07-17').startOf('d').toDate());
     expect(result.endDate).toEqual(moment('2019-07-18').startOf('d').toDate());
     expect(result.auxiliary).not.toBeDefined();
+    expect(result.repetition.frequency).toEqual('never');
   });
 
   it('should format internal hour with auxiliary', async () => {
@@ -264,7 +266,14 @@ describe('updateRepetition', () => {
 
     await EventsRepetitionHelper.updateRepetition(event, payload);
 
-    sinon.assert.calledWith(findEvent, { 'repetition.parentId': 'qwertyuiop', startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') } });
+    sinon.assert.calledWith(
+      findEvent,
+      {
+        'repetition.parentId': 'qwertyuiop',
+        'repetition.frequency': { $not: { $eq: 'never' } },
+        startDate: { $gte: new Date('2019-03-23T09:00:00.000Z') }
+      }
+    );
     sinon.assert.calledThrice(hasConflicts);
     sinon.assert.calledThrice(findOneAndUpdateEvent);
     sinon.assert.calledWith(updateRepetitions, payload, 'qwertyuiop');


### PR DESCRIPTION
Objectif de la PR :
- Ne pas verifier les conflits si l'evenement n'est pas affecté
- pour les repetitions, on passe a NEVER la frequence quand un evenement sort de la repetition mais on n'enleve pas son parentId
- quand on met fin a un contrat, il faut passer tous les objets Repetition de l'auxiliaire en "A affecter"