### PR TITLE
COM-562 pdf no more blob

### DIFF
--- a/src/controllers/billsController.js
+++ b/src/controllers/billsController.js
@@ -83,7 +83,9 @@ const generateBillPdf = async (req, h) => {
     const data = formatPDF(bill, company);
     const pdf = await generatePdf(data, './src/data/bill.html');
 
-    return h.response(pdf).type('application/pdf');
+    return h.response(pdf)
+      .header('content-disposition', `inline; filename=${bill.number}.pdf`)
+      .type('application/pdf');
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/controllers/creditNoteController.js
+++ b/src/controllers/creditNoteController.js
@@ -103,7 +103,9 @@ const generateCreditNotePdf = async (req, h) => {
     const data = formatPDF(creditNote, company);
     const pdf = await generatePdf(data, './src/data/creditNote.html');
 
-    return h.response(pdf).type('application/pdf');
+    return h.response(pdf)
+      .header('content-disposition', `inline; filename=${creditNote.number}.pdf`)
+      .type('application/pdf');
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/plugins/hapiAuthJwt2.js
+++ b/src/plugins/hapiAuthJwt2.js
@@ -9,6 +9,7 @@ exports.plugin = {
 
     server.auth.strategy('jwt', 'jwt', {
       key: process.env.TOKEN_SECRET,
+      urlKey: 'x-access-token',
       headerKey: 'x-access-token',
       verifyOptions: { algorithms: ['HS256'] },
       validate,


### PR DESCRIPTION
Actuellement, on génère un blob sur la webapp afin de l'afficher dans le navigateur. Cela pose trop de problèmes en fonction des différents navigateurs (affichage, téléchargement, ...) comparé à l'utilisation d'un pdf natif. Etant donné, que l'API renvoie un PDF je mets son lien directement ds la webapp afin d'obtenir le PDF original.