### PR TITLE
COM-776 Fix credit note creation

### DIFF
--- a/src/controllers/creditNoteController.js
+++ b/src/controllers/creditNoteController.js
@@ -39,11 +39,10 @@ const list = async (req) => {
 
 const create = async (req) => {
   try {
-    const creditNotes = await createCreditNotes(req.payload);
+    await createCreditNotes(req.payload);
 
     return {
       message: translate[language].creditNoteCreated,
-      data: { creditNotes },
     };
   } catch (e) {
     req.log('error', e);

--- a/src/helpers/creditNotes.js
+++ b/src/helpers/creditNotes.js
@@ -74,13 +74,9 @@ exports.createCreditNotes = async (payload) => {
   } else if (tppCreditNote) creditNotes = [tppCreditNote];
   else creditNotes = [customerCreditNote];
 
-  promises.push(CreditNote.insertMany(creditNotes));
+  promises.push(CreditNote.insertMany(creditNotes), CreditNoteNumber.findOneAndUpdate(query, { $set: { seq } }));
   if (payload.events) promises.push(exports.updateEventAndFundingHistory(payload.events, false));
-  const [newCreditNotes] = await Promise.all(promises);
-
-  await CreditNoteNumber.findOneAndUpdate(query, { $set: { seq } });
-
-  return newCreditNotes;
+  return Promise.all(promises);
 };
 
 exports.updateCreditNotes = async (creditNoteFromDB, payload) => {

--- a/src/helpers/creditNotes.js
+++ b/src/helpers/creditNotes.js
@@ -66,6 +66,7 @@ exports.createCreditNotes = async (payload) => {
   }
 
   let creditNotes = [];
+  const promises = [];
   if (tppCreditNote && customerCreditNote) {
     customerCreditNote.linkedCreditNote = tppCreditNote._id;
     tppCreditNote.linkedCreditNote = customerCreditNote._id;
@@ -73,12 +74,13 @@ exports.createCreditNotes = async (payload) => {
   } else if (tppCreditNote) creditNotes = [tppCreditNote];
   else creditNotes = [customerCreditNote];
 
-  creditNotes = await CreditNote.insertMany(creditNotes);
+  promises.push(CreditNote.insertMany(creditNotes));
+  if (payload.events) promises.push(exports.updateEventAndFundingHistory(payload.events, false));
+  const [newCreditNotes] = await Promise.all(promises);
 
-  if (payload.events) await exports.updateEventAndFundingHistory(payload.events, false);
   await CreditNoteNumber.findOneAndUpdate(query, { $set: { seq } });
 
-  return creditNotes;
+  return newCreditNotes;
 };
 
 exports.updateCreditNotes = async (creditNoteFromDB, payload) => {

--- a/tests/integration/creditNotes.test.js
+++ b/tests/integration/creditNotes.test.js
@@ -60,7 +60,6 @@ describe('CREDIT NOTES ROUTES - POST /creditNotes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.creditNotes.length).toEqual(2);
       const creditNotes = await CreditNote.find();
       expect(creditNotes.filter(cn => cn.linkedCreditNote)).toBeDefined();
       expect(creditNotes.filter(cn => cn.linkedCreditNote).length).toEqual(2);
@@ -77,7 +76,6 @@ describe('CREDIT NOTES ROUTES - POST /creditNotes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.creditNotes[0].number).toBeDefined();
       const creditNotes = await CreditNote.find();
       expect(creditNotes.length).toEqual(initialCreditNotesNumber + 1);
     });


### PR DESCRIPTION
Pendant back de la COM-776 sur la migration de la page des avoirs. (lié également aux scripts)
Ce petit fix empêchera la création d'avoirs s'il y a un problème au niveau même de la création ou à la mise à jour des events/fundings (ce qui m'est arrivé -> création des avoirs mais échec du reste).