### PR TITLE
Com 908 event

### DIFF
--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -1,5 +1,6 @@
 const Boom = require('boom');
 const moment = require('moment');
+const omit = require('lodash/omit');
 const translate = require('../helpers/translate');
 const EventsHelper = require('../helpers/events');
 const { isEditionAllowed } = require('../helpers/eventsValidation');
@@ -16,9 +17,9 @@ const list = async (req) => {
 
     let events;
     if (groupBy === CUSTOMER) {
-      events = await getEventsGroupedByCustomers(query);
+      events = await getEventsGroupedByCustomers(omit(query, 'company'), query.company);
     } else if (groupBy === AUXILIARY) {
-      events = await getEventsGroupedByAuxiliaries(query);
+      events = await getEventsGroupedByAuxiliaries(omit(query, 'company'), query.company);
     } else {
       events = await getEventList(query);
       events = await EventsHelper.populateEvents(events);

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -31,14 +31,14 @@ exports.getCustomerBySector = async (query, credentials) => {
     sector: query.sector,
   }, credentials);
   const companyId = get(credentials, 'company._id', null);
-  return EventRepository.getCustomersFromEvent({ ...queryCustomer, company: new ObjectID(companyId) });
+  return EventRepository.getCustomersFromEvent(queryCustomer, companyId);
 };
 
 exports.getCustomersWithBilledEvents = async (credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  const query = { isBilled: true, type: INTERVENTION, company: new ObjectID(companyId) };
+  const query = { isBilled: true, type: INTERVENTION };
 
-  return EventRepository.getCustomerWithBilledEvents(query);
+  return EventRepository.getCustomersWithBilledEvents(query, companyId);
 };
 
 exports.getCustomers = async (query, credentials) => {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -278,7 +278,7 @@ exports.deleteList = async (customer, startDate, endDate, credentials) => {
   if (endDate) query.startDate.$lte = moment(endDate).endOf('d').toDate();
   if (await Event.countDocuments({ ...query, isBilled: true }) > 0) throw Boom.conflict('Some events are already billed');
 
-  const eventsGroupedByParentId = await EventRepository.getEventsGroupedByParentId(query);
+  const eventsGroupedByParentId = await EventRepository.getEventsGroupedByParentId(_.omit(query, 'company'), companyId);
   for (const group of eventsGroupedByParentId) {
     if (!group._id || endDate) await exports.deleteEvents(group.events, credentials);
     else {

--- a/src/models/preHooks/validate.js
+++ b/src/models/preHooks/validate.js
@@ -15,10 +15,17 @@ module.exports = {
     next();
   },
   validateAggregation(next) {
+<<<<<<< HEAD
     if (get(this, 'options.allCompanies', null)) return next();
     const companyId = get(this, 'options.company', null);
     if (!companyId) next(Boom.badRequest());
     this.pipeline().unshift({ $match: { company: new ObjectID(companyId) } });
+=======
+    if (get(this, 'options.allCompanies', null)) next();
+    const companyId = get(this, 'options.company', null);
+    if (!companyId) next(Boom.badRequest());
+    this.pipeline().unshift({ $match: { company: companyId } });
+>>>>>>> COM-908 add prehandler for bills
     next();
   },
 };

--- a/src/models/preHooks/validate.js
+++ b/src/models/preHooks/validate.js
@@ -15,17 +15,10 @@ module.exports = {
     next();
   },
   validateAggregation(next) {
-<<<<<<< HEAD
     if (get(this, 'options.allCompanies', null)) return next();
     const companyId = get(this, 'options.company', null);
     if (!companyId) next(Boom.badRequest());
     this.pipeline().unshift({ $match: { company: new ObjectID(companyId) } });
-=======
-    if (get(this, 'options.allCompanies', null)) next();
-    const companyId = get(this, 'options.company', null);
-    if (!companyId) next(Boom.badRequest());
-    this.pipeline().unshift({ $match: { company: companyId } });
->>>>>>> COM-908 add prehandler for bills
     next();
   },
 };

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -11,7 +11,7 @@ const {
   NOT_INVOICED_AND_NOT_PAID,
 } = require('../helpers/constants');
 
-const getEventsGroupedBy = async (rules, groupById) => Event.aggregate([
+const getEventsGroupedBy = async (rules, groupById, companyId) => Event.aggregate([
   { $match: rules },
   {
     $lookup: {
@@ -93,11 +93,11 @@ const getEventsGroupedBy = async (rules, groupById) => Event.aggregate([
       events: { $push: '$$ROOT' },
     },
   },
-]);
+]).option({ company: companyId });
 
-exports.getEventsGroupedByAuxiliaries = async rules => getEventsGroupedBy(rules, { $ifNull: ['$auxiliary._id', '$sector'] });
+exports.getEventsGroupedByAuxiliaries = async (rules, companyId) => getEventsGroupedBy(rules, { $ifNull: ['$auxiliary._id', '$sector'] }, companyId);
 
-exports.getEventsGroupedByCustomers = async rules => getEventsGroupedBy(rules, '$customer._id');
+exports.getEventsGroupedByCustomers = async (rules, companyId) => getEventsGroupedBy(rules, '$customer._id', companyId);
 
 exports.getEventList = rules => Event.find(rules)
   .populate({
@@ -168,7 +168,6 @@ exports.updateEvent = async (eventId, set, unset, credentials) => Event
 
 exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
   const rules = [
-    { company: new ObjectID(companyId) },
     { type: { $in: [INTERVENTION, INTERNAL_HOUR] } },
     {
       $or: [
@@ -252,7 +251,7 @@ exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
       },
     },
     { $sort: { startDate: -1 } },
-  ]);
+  ]).option({ company: companyId });
 };
 
 exports.getAbsencesForExport = async (start, end, credentials) => {
@@ -274,7 +273,6 @@ exports.getCustomerSubscriptions = (contract, companyId) => Event.aggregate([
   {
     $match: {
       $and: [
-        { company: new ObjectID(companyId) },
         { startDate: { $gt: new Date(contract.endDate) } },
         { auxiliary: new ObjectID(contract.user) },
         { $or: [{ isBilled: false }, { isBilled: { $exists: false } }] },
@@ -319,9 +317,9 @@ exports.getCustomerSubscriptions = (contract, companyId) => Event.aggregate([
       sub: 1,
     },
   },
-]);
+]).option({ company: companyId });
 
-exports.getEventsGroupedByParentId = async rules => Event.aggregate([
+exports.getEventsGroupedByParentId = async (rules, companyId) => Event.aggregate([
   { $match: rules },
   {
     $group: {
@@ -334,23 +332,21 @@ exports.getEventsGroupedByParentId = async rules => Event.aggregate([
   {
     $group: { _id: '$_id', events: { $push: '$events' } },
   },
-]);
+]).option({ company: companyId });
 
 
 exports.getUnassignedInterventions = async (maxDate, auxiliary, subIds, companyId) => exports.getEventsGroupedByParentId({
   startDate: { $gt: maxDate },
   auxiliary,
-  company: new ObjectID(companyId),
   subscription: { $in: subIds },
   $or: [{ isBilled: false }, { isBilled: { $exists: false } }],
-});
+}, companyId);
 
 exports.getEventsExceptInterventions = async (startDate, auxiliary, companyId) => exports.getEventsGroupedByParentId({
   startDate: { $gt: startDate },
   auxiliary,
-  company: new ObjectID(companyId),
   subscription: { $exists: false },
-});
+}, companyId);
 
 exports.getAbsences = async (auxiliaryId, maxEndDate, companyId) => Event.find({
   type: ABSENCE,
@@ -362,7 +358,6 @@ exports.getAbsences = async (auxiliaryId, maxEndDate, companyId) => Event.find({
 
 exports.getEventsToPay = async (start, end, auxiliaries, companyId) => {
   const rules = [
-    { company: new ObjectID(companyId) },
     { startDate: { $lt: end } },
     { endDate: { $gt: start } },
     {
@@ -473,12 +468,11 @@ exports.getEventsToPay = async (start, end, auxiliaries, companyId) => {
   return Event.aggregate([
     ...match,
     ...group,
-  ]);
+  ]).option({ company: companyId });
 };
 
 exports.getEventsToBill = async (dates, customerId, companyId) => {
   const rules = [
-    { company: new ObjectID(companyId) },
     { endDate: { $lt: dates.endDate } },
     { $or: [{ isBilled: false }, { isBilled: { $exists: false } }] },
     { auxiliary: { $exists: true, $ne: '' } },
@@ -574,10 +568,10 @@ exports.getEventsToBill = async (dates, customerId, companyId) => {
       },
     },
     { $sort: { 'customer.identity.lastname': 1 } },
-  ]);
+  ]).option({ company: companyId });
 };
 
-exports.getCustomersFromEvent = async query => Event.aggregate([
+exports.getCustomersFromEvent = async (query, companyId) => Event.aggregate([
   { $match: query },
   {
     $lookup: {
@@ -649,9 +643,9 @@ exports.getCustomersFromEvent = async query => Event.aggregate([
   },
   { $addFields: { 'customer.subscriptions': '$subscriptions' } },
   { $replaceRoot: { newRoot: '$customer' } },
-]);
+]).option({ company: companyId });
 
-exports.getCustomerWithBilledEvents = async query => Event.aggregate([
+exports.getCustomersWithBilledEvents = async (query, companyId) => Event.aggregate([
   { $match: query },
   { $group: { _id: { SUBS: '$subscription', CUSTOMER: '$customer', TPP: '$bills.thirdPartyPayer' } } },
   {
@@ -732,7 +726,13 @@ exports.getCustomerWithBilledEvents = async query => Event.aggregate([
       'sub.service.version': 0,
     },
   },
-  { $group: { _id: { CUS: '$customer' }, subscriptions: { $addToSet: '$sub' }, thirdPartyPayers: { $addToSet: '$thirdPartyPayer' } } },
+  {
+    $group: {
+      _id: { CUS: '$customer' },
+      subscriptions: { $addToSet: '$sub' },
+      thirdPartyPayers: { $addToSet: '$thirdPartyPayer' },
+    },
+  },
   {
     $project: {
       _id: '$_id.CUS._id',
@@ -741,12 +741,11 @@ exports.getCustomerWithBilledEvents = async query => Event.aggregate([
       thirdPartyPayers: 1,
     },
   },
-]);
+]).option({ company: companyId });
 
 exports.getCustomersWithIntervention = async companyId => Event.aggregate([
   {
     $match: {
-      company: new ObjectID(companyId),
       type: INTERVENTION,
       $or: [{ isBilled: false }, { isBilled: { $exists: false } }],
     },
@@ -763,4 +762,4 @@ exports.getCustomersWithIntervention = async companyId => Event.aggregate([
   { $unwind: { path: '$customer' } },
   { $replaceRoot: { newRoot: '$customer' } },
   { $project: { _id: 1, identity: { firstname: 1, lastname: 1 } } },
-]);
+]).option({ company: companyId });

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -270,7 +270,10 @@ describe('CUSTOMERS ROUTES', () => {
       });
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customers).toBeDefined();
-      const areAllCustomersFromCompany = res.result.data.customers.every(customer => customer.company._id.toHexString() === otherCompany._id.toHexString());
+      const areAllCustomersFromCompany = res.result.data.customers.every(async (customer) => {
+        const customerFromDB = await Customer.find({ _id: customer._id, company: otherCompany._id });
+        return customerFromDB;
+      });
       expect(areAllCustomersFromCompany).toBe(true);
     });
   });

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -43,23 +43,26 @@ describe('getCustomerBySector', () => {
     const queryBySector = { ...query, endDate, sector };
     await CustomerHelper.getCustomerBySector(queryBySector, credentials);
     sinon.assert.calledWith(getListQuery, { startDate, endDate, sector, type: 'intervention' });
-    sinon.assert.calledWith(getCustomersFromEvent, { ...query, company: companyId });
+    sinon.assert.calledWith(getCustomersFromEvent, query, companyId);
   });
 });
 
 describe('getCustomersWithBilledEvents', () => {
-  let getCustomerWithBilledEvents;
+  let getCustomersWithBilledEvents;
   beforeEach(() => {
-    getCustomerWithBilledEvents = sinon.stub(EventRepository, 'getCustomerWithBilledEvents');
+    getCustomersWithBilledEvents = sinon.stub(EventRepository, 'getCustomersWithBilledEvents');
   });
   afterEach(() => {
-    getCustomerWithBilledEvents.restore();
+    getCustomersWithBilledEvents.restore();
   });
 
   it('should return customer by sector', async () => {
     const credentials = { company: { _id: new ObjectID() } };
     await CustomerHelper.getCustomersWithBilledEvents(credentials);
-    sinon.assert.calledWith(getCustomerWithBilledEvents, { isBilled: true, type: 'intervention', company: credentials.company._id });
+    sinon.assert.calledWith(
+      getCustomersWithBilledEvents,
+      { isBilled: true, type: 'intervention' }, credentials.company._id
+    );
   });
 });
 

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -42,8 +42,8 @@ describe('getCustomerBySector', () => {
 
     const queryBySector = { ...query, endDate, sector };
     await CustomerHelper.getCustomerBySector(queryBySector, credentials);
-    sinon.assert.calledWith(getListQuery, { startDate, endDate, sector, type: 'intervention' });
-    sinon.assert.calledWith(getCustomersFromEvent, query, companyId);
+    sinon.assert.calledWithExactly(getListQuery, { startDate, endDate, sector, type: 'intervention' }, credentials);
+    sinon.assert.calledWithExactly(getCustomersFromEvent, query, companyId);
   });
 });
 
@@ -59,7 +59,7 @@ describe('getCustomersWithBilledEvents', () => {
   it('should return customer by sector', async () => {
     const credentials = { company: { _id: new ObjectID() } };
     await CustomerHelper.getCustomersWithBilledEvents(credentials);
-    sinon.assert.calledWith(
+    sinon.assert.calledWithExactly(
       getCustomersWithBilledEvents,
       { isBilled: true, type: 'intervention' }, credentials.company._id
     );
@@ -83,12 +83,13 @@ describe('getCustomers', () => {
 
   it('should return empty array if no customer', async () => {
     const companyId = new ObjectID();
-    const query = { role: 'qwertyuiop', company: companyId };
+    const credentials = { company: { _id: companyId } };
+    const query = { role: 'qwertyuiop' };
     getCustomersList.returns([]);
-    const result = await CustomerHelper.getCustomers(query);
+    const result = await CustomerHelper.getCustomers(query, credentials);
 
     expect(result).toEqual([]);
-    sinon.assert.calledWith(getCustomersList, query);
+    sinon.assert.calledWithExactly(getCustomersList, query, companyId);
     sinon.assert.notCalled(subscriptionsAccepted);
     sinon.assert.notCalled(formatIdentity);
   });
@@ -194,7 +195,7 @@ describe('getCustomersWithCustomerContractSubscriptions', () => {
     const result = await CustomerHelper.getCustomersWithCustomerContractSubscriptions(credentials);
 
     expect(result).toEqual([]);
-    sinon.assert.calledWith(getCustomersWithSubscriptions, { 'subscriptions.service': { $in: ['1234567890'] } });
+    sinon.assert.calledWithExactly(getCustomersWithSubscriptions, { 'subscriptions.service': { $in: ['1234567890'] } }, companyId);
     sinon.assert.notCalled(subscriptionsAccepted);
     ServiceMock.verify();
   });
@@ -222,7 +223,7 @@ describe('getCustomersWithCustomerContractSubscriptions', () => {
       { identity: { firstname: 'Emmanuel' }, subscriptionsAccepted: true, company: companyId },
       { identity: { firstname: 'Brigitte' }, subscriptionsAccepted: true, company: companyId },
     ]);
-    sinon.assert.calledWith(getCustomersWithSubscriptions, { 'subscriptions.service': { $in: ['1234567890'] } });
+    sinon.assert.calledWithExactly(getCustomersWithSubscriptions, { 'subscriptions.service': { $in: ['1234567890'] } }, companyId);
     sinon.assert.calledTwice(subscriptionsAccepted);
     ServiceMock.verify();
   });
@@ -585,7 +586,7 @@ describe('updateCustomer', () => {
 
     const result = await CustomerHelper.updateCustomer(customerId, payload);
 
-    sinon.assert.calledWith(
+    sinon.assert.calledWithExactly(
       updateMany,
       { 'address.fullAddress': customer.contact.primaryAddress.fullAddress, startDate: { $gte: moment().startOf('day').toDate() } },
       { $set: { address: payload.contact.primaryAddress } },
@@ -629,7 +630,7 @@ describe('updateCustomer', () => {
 
     const result = await CustomerHelper.updateCustomer(customerId, payload);
 
-    sinon.assert.calledWith(
+    sinon.assert.calledWithExactly(
       updateMany,
       { 'address.fullAddress': customer.contact.secondaryAddress.fullAddress, startDate: { $gte: moment().startOf('day').toDate() } },
       { $set: { address: payload.contact.secondaryAddress } },
@@ -715,7 +716,7 @@ describe('updateCustomer', () => {
 
     const result = await CustomerHelper.updateCustomer(customerId, payload);
 
-    sinon.assert.calledWith(
+    sinon.assert.calledWithExactly(
       updateMany,
       { 'address.fullAddress': customer.contact.secondaryAddress.fullAddress, startDate: { $gte: moment().startOf('day').toDate() } },
       { $set: { address: customer.contact.primaryAddress } },

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -172,7 +172,7 @@ describe('getDraftPay', () => {
       },
       moment('2019-05-31T23:59:59').endOf('d').toDate(),
       'finalpays',
-      '1234567890'
+      credentials.company._id
     );
   });
 

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1746,7 +1746,7 @@ describe('getAuxiliariesToPay', () => {
       },
       end,
       'pays',
-      '1234567890'
+      credentials.company._id
     );
   });
 });

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -713,7 +713,6 @@ describe('deleteList', () => {
     const startDate = '2019-10-10';
     const endDate = '2019-10-19';
     const query = {
-      company: credentials.company._id,
       customer: customerId,
       startDate: { $gte: moment('2019-10-10').toDate(), $lte: moment('2019-10-19').endOf('d').toDate() },
     };
@@ -755,7 +754,7 @@ describe('deleteList', () => {
       },
     ];
     EventModel.expects('countDocuments')
-      .withExactArgs({ ...query, isBilled: true })
+      .withExactArgs({ ...query, isBilled: true, company: credentials.company._id })
       .once()
       .returns(0);
 
@@ -765,7 +764,7 @@ describe('deleteList', () => {
 
     await EventHelper.deleteList(customerId, startDate, endDate, credentials);
     sinon.assert.calledWithExactly(deleteEventsStub, eventsGroupedByParentId[0].events, credentials);
-    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query);
+    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query, credentials.company._id);
     sinon.assert.notCalled(deleteRepetitionStub);
   });
 
@@ -774,7 +773,6 @@ describe('deleteList', () => {
     const query = {
       customer: customerId,
       startDate: { $gte: moment('2019-10-07').toDate() },
-      company: credentials.company._id,
     };
     const repetitionParentId = new ObjectID();
     const events = [
@@ -815,7 +813,7 @@ describe('deleteList', () => {
       },
     ];
     EventModel.expects('countDocuments')
-      .withExactArgs({ ...query, isBilled: true })
+      .withExactArgs({ ...query, isBilled: true, company: credentials.company._id })
       .once()
       .returns(0);
 
@@ -827,7 +825,7 @@ describe('deleteList', () => {
 
     await EventHelper.deleteList(customerId, startDate, undefined, credentials);
     sinon.assert.calledWithExactly(deleteEventsStub, eventsGroupedByParentId[0].events, credentials);
-    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query);
+    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query, credentials.company._id);
     sinon.assert.calledWithExactly(deleteRepetitionStub, eventsGroupedByParentId[1].events[0], credentials);
   });
 
@@ -836,7 +834,6 @@ describe('deleteList', () => {
     const query = {
       customer: customerId,
       startDate: { $gte: moment('2019-10-07').toDate() },
-      company: credentials.company._id,
     };
     const repetitionParentId = new ObjectID();
     const events = [
@@ -860,7 +857,7 @@ describe('deleteList', () => {
       },
     ];
     EventModel.expects('countDocuments')
-      .withExactArgs({ ...query, isBilled: true })
+      .withExactArgs({ ...query, isBilled: true, company: credentials.company._id })
       .once()
       .returns(0);
 
@@ -871,7 +868,7 @@ describe('deleteList', () => {
 
     await EventHelper.deleteList(customerId, startDate, undefined, credentials);
     sinon.assert.notCalled(deleteEventsStub);
-    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query);
+    sinon.assert.calledWithExactly(getEventsGroupedByParentIdStub, query, credentials.company._id);
     sinon.assert.calledWithExactly(
       deleteRepetitionStub,
       { ...eventsGroupedByParentId[0].events[0], repetition: { frequency: EVERY_WEEK, parentId: eventsGroupedByParentId[0].events[0].repetition.parentId } },


### PR DESCRIPTION
ajout du prehook sur les aggregations des evenements:
- getEventGroupedBy --> planning
- getWorkingEventsForExport --> export
- getCustomerSubscriptions --> utilise lors de la fin d'un contrat pour mettre les evenements en a affecter
- getEventsGroupedByParentId --> suppression en masse des evenements
- getEventsToPay --> paie 
- getEventsToBill --> facturation
- getCustomersFromEvent --> planning beneficiaire
- getCustomersWithBilledEvents --> avoir
- getCustomersWithIntervention --> repertoire beneficiaire