### PR TITLE
COM-933 - fix bill slip creation

### DIFF
--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -24,6 +24,7 @@ exports.getBillSlipNumber = async (endDate, company) => {
 
 exports.createBillSlips = async (billList, endDate, company) => {
   const month = moment(endDate).format('MM-YYYY');
+  const prefix = moment(endDate).format('MMYY');
   const tppIds = [...new Set(billList.filter(bill => bill.client).map(bill => bill.client))];
   const billSlipList = await BillSlip.find({ thirdPartyPayer: { $in: tppIds }, month, company: company._id }).lean();
 
@@ -41,6 +42,6 @@ exports.createBillSlips = async (billList, endDate, company) => {
 
   await Promise.all([
     BillSlip.insertMany(list),
-    BillSlipNumber.updateOne({ prefix: month, company: company._id }, { $set: { seq } }),
+    BillSlipNumber.updateOne({ prefix, company: company._id }, { $set: { seq } }),
   ]);
 };

--- a/src/models/BillSlip.js
+++ b/src/models/BillSlip.js
@@ -6,7 +6,7 @@ const BillSlipSchema = mongoose.Schema({
   month: { type: String, required: true, validate: /^([0]{1}[1-9]{1}|[1]{1}[0-2]{1})-[2]{1}[0]{1}[0-9]{2}$/ },
   number: { type: String, required: true, validate: /BORD-[0-9]{12}/ },
   company: { type: mongoose.Types.ObjectId, required: true },
-}, { timestamp: true });
+}, { timestamps: true });
 
 BillSlipSchema.pre('validate', validatePayload);
 BillSlipSchema.pre('find', validateQuery);

--- a/src/models/BillSlipNumber.js
+++ b/src/models/BillSlipNumber.js
@@ -5,7 +5,7 @@ const BillSlipNumberSchema = mongoose.Schema({
   prefix: { type: String, required: true },
   seq: { type: Number, default: 1 },
   company: { type: mongoose.Types.ObjectId, required: true },
-}, { timestamp: true });
+}, { timestamps: true });
 
 BillSlipNumberSchema.pre('validate', validatePayload);
 BillSlipNumberSchema.pre('find', validateQuery);

--- a/tests/unit/helpers/billSlips.test.js
+++ b/tests/unit/helpers/billSlips.test.js
@@ -128,7 +128,7 @@ describe('createBillSlips', () => {
     sinon.assert.calledWithExactly(formatBillSlipNumber.getCall(1), 129, 'ASD', 13);
     sinon.assert.calledWithExactly(
       updateOneBillSlipNumber,
-      { prefix: '09-2019', company: company._id },
+      { prefix: '0919', company: company._id },
       { $set: { seq: 14 } }
     );
     BillSlipMock.verify();


### PR DESCRIPTION
NB : ce qui n'allait pas : 
- la collection `BillSlipNumber` n'etait pas mise a jour apres la creation des bordereaux
- les bordereaux etaient créés en doublon
- la page n'etait pas triee par mois