### PR TITLE
COM-990 refacto authentication

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -16,7 +16,7 @@ const Contract = require('../models/Contract');
 const translate = require('./translate');
 const GdriveStorage = require('./gdriveStorage');
 const RolesHelper = require('./roles');
-const { encode } = require('./authentication');
+const AuthenticationHelper = require('./authentication');
 const { AUXILIARY, PLANNING_REFERENT } = require('./constants');
 const SectorHistoriesHelper = require('./sectorHistories');
 
@@ -29,8 +29,8 @@ exports.authenticate = async (payload) => {
   const correctPassword = await bcrypt.compare(payload.password, user.local.password);
   if (!correctPassword) throw Boom.unauthorized();
 
-  const tokenPayload = pickBy({ _id: user._id, role: user.role.name });
-  const token = encode(tokenPayload, TOKEN_EXPIRE_TIME);
+  const tokenPayload = pickBy({ _id: user._id.toHexString(), role: user.role.name });
+  const token = AuthenticationHelper.encode(tokenPayload, TOKEN_EXPIRE_TIME);
 
   return { token, refreshToken: user.refreshToken, expiresIn: TOKEN_EXPIRE_TIME, user: tokenPayload };
 };
@@ -39,8 +39,8 @@ exports.refreshToken = async (payload) => {
   const user = await User.findOne({ refreshToken: payload.refreshToken }).lean({ autopopulate: true });
   if (!user) throw Boom.unauthorized();
 
-  const tokenPayload = pickBy({ _id: user._id, role: user.role.name });
-  const token = encode(tokenPayload, TOKEN_EXPIRE_TIME);
+  const tokenPayload = pickBy({ _id: user._id.toHexString(), role: user.role.name });
+  const token = AuthenticationHelper.encode(tokenPayload, TOKEN_EXPIRE_TIME);
 
   return { token, refreshToken: user.refreshToken, expiresIn: TOKEN_EXPIRE_TIME, user: tokenPayload };
 };

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const Boom = require('boom');
 const moment = require('moment');
+const bcrypt = require('bcrypt');
 const pickBy = require('lodash/pickBy');
 const get = require('lodash/get');
 const has = require('lodash/has');
@@ -10,14 +11,39 @@ const uuidv4 = require('uuid/v4');
 const Role = require('../models/Role');
 const User = require('../models/User');
 const Task = require('../models/Task');
+const { TOKEN_EXPIRE_TIME } = require('../models/User');
 const Contract = require('../models/Contract');
 const translate = require('./translate');
 const GdriveStorage = require('./gdriveStorage');
 const RolesHelper = require('./roles');
+const { encode } = require('./authentication');
 const { AUXILIARY, PLANNING_REFERENT } = require('./constants');
-const SectorHistoriesHelper = require('../helpers/sectorHistories');
+const SectorHistoriesHelper = require('./sectorHistories');
 
 const { language } = translate;
+
+exports.authenticate = async (payload) => {
+  const user = await User.findOne({ 'local.email': payload.email.toLowerCase() }).lean({ autopopulate: true });
+  if (!user || !user.refreshToken) throw Boom.unauthorized();
+
+  const correctPassword = await bcrypt.compare(payload.password, user.local.password);
+  if (!correctPassword) throw Boom.unauthorized();
+
+  const tokenPayload = pickBy({ _id: user._id, role: user.role.name });
+  const token = encode(tokenPayload, TOKEN_EXPIRE_TIME);
+
+  return { token, refreshToken: user.refreshToken, expiresIn: TOKEN_EXPIRE_TIME, user: tokenPayload };
+};
+
+exports.refreshToken = async (payload) => {
+  const user = await User.findOne({ refreshToken: payload.refreshToken }).lean({ autopopulate: true });
+  if (!user) throw Boom.unauthorized();
+
+  const tokenPayload = pickBy({ _id: user._id, role: user.role.name });
+  const token = encode(tokenPayload, TOKEN_EXPIRE_TIME);
+
+  return { token, refreshToken: user.refreshToken, expiresIn: TOKEN_EXPIRE_TIME, user: tokenPayload };
+};
 
 exports.getUsersList = async (query, credentials) => {
   const params = {
@@ -46,6 +72,7 @@ exports.getUsersList = async (query, credentials) => {
     .populate('contracts')
     .lean({ virtuals: true, autopopulate: true });
 };
+
 exports.getUsersListWithSectorHistories = async (credentials) => {
   const roles = await Role.find({ name: { $in: [AUXILIARY, PLANNING_REFERENT] } }).lean();
   const roleIds = roles.map(role => role._id);

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,19 +1,8 @@
 const moment = require('moment-timezone');
-const _ = require('lodash');
+const omit = require('lodash/omit');
+const isEmpty = require('lodash/isEmpty');
 const Intl = require('intl');
 const { CIVILITY_LIST } = require('./constants');
-
-exports.clean = (obj) => {
-  for (const k in obj) {
-    if (obj[k] === undefined || obj[k] === '' ||
-      (typeof obj[k] === 'object' && Object.keys(obj[k].length === 0)) ||
-      (Array.isArray(obj[k]) && obj[k].length === 0)) {
-      delete obj[k];
-    }
-  }
-
-  return obj;
-};
 
 exports.getLastVersion = (versions, dateKey) => {
   if (!Array.isArray(versions)) throw new Error('versions must be an array !');
@@ -26,7 +15,8 @@ exports.getLastVersion = (versions, dateKey) => {
 exports.mergeLastVersionWithBaseObject = (baseObj, dateKey) => {
   const lastVersion = exports.getLastVersion(baseObj.versions, dateKey);
   if (!lastVersion) throw new Error('Unable to find last version from base object !');
-  return { ...lastVersion, ..._.omit(baseObj, ['versions', 'createdAt']) };
+
+  return { ...lastVersion, ...omit(baseObj, ['versions', 'createdAt']) };
 };
 
 // `obj` should by sort in descending order
@@ -35,16 +25,28 @@ exports.getMatchingVersion = (date, obj, dateKey) => {
   if (obj.versions.length === 0) return null;
 
   const matchingVersion = [...obj.versions]
-    .filter(ver => moment(ver.startDate).isSameOrBefore(date, 'd') && (!ver.endDate || moment(ver.endDate).isSameOrAfter(date, 'd')))
+    .filter(ver => moment(ver.startDate).isSameOrBefore(date, 'd') &&
+      (!ver.endDate || moment(ver.endDate).isSameOrAfter(date, 'd')))
     .sort((a, b) => new Date(b[dateKey]) - new Date(a[dateKey]))[0];
   if (!matchingVersion) return null;
 
-  return { ..._.omit(obj, 'versions'), ..._.omit(matchingVersion, ['_id', 'createdAt']), versionId: matchingVersion._id };
+  return {
+    ...omit(obj, 'versions'),
+    ...omit(matchingVersion, ['_id', 'createdAt']),
+    versionId: matchingVersion._id,
+  };
 };
 
 exports.getDateQuery = (dates) => {
-  if (dates.startDate && dates.endDate) return { $lte: moment(dates.endDate).endOf('day').toISOString(), $gte: moment(dates.startDate).startOf('day').toISOString() };
+  if (dates.startDate && dates.endDate) {
+    return {
+      $lte: moment(dates.endDate).endOf('day').toISOString(),
+      $gte: moment(dates.startDate).startOf('day').toISOString(),
+    };
+  }
+
   if (dates.startDate) return { $gte: dates.startDate };
+
   return { $lt: dates.endDate };
 };
 
@@ -93,7 +95,7 @@ exports.getFullTitleFromIdentity = (identity) => {
     lastname.toUpperCase(),
   ];
 
-  fullTitle = fullTitle.filter(value => !_.isEmpty(value));
+  fullTitle = fullTitle.filter(value => !isEmpty(value));
 
   return fullTitle.join(' ');
 };
@@ -119,7 +121,8 @@ exports.getDaysRatioBetweenTwoDates = (start, end) => {
 
   const range = Array.from(moment().range(start, end).by('days'));
   for (const day of range) {
-    if (day.startOf('d').isHoliday() && day.day() !== 0) holidays += 1; // startOf('day') is necessery to check fr holidays in business day
+    // startOf('day') is necessery to check fr holidays in business day
+    if (day.startOf('d').isHoliday() && day.day() !== 0) holidays += 1;
     else if (day.day() !== 0) businessDays += 1;
     else sundays += 1;
   }

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -13,6 +13,7 @@ const { AUXILIARY, PLANNING_REFERENT, COMPANY_CONTRACT } = require('../helpers/c
 const { validateQuery, validatePayload, validateAggregation } = require('./preHooks/validate');
 
 const SALT_WORK_FACTOR = 10;
+const TOKEN_EXPIRE_TIME = 86400;
 
 const procedureSchema = mongoose.Schema({
   task: { type: mongoose.Schema.Types.ObjectId, ref: 'Task' },
@@ -259,3 +260,4 @@ UserSchema.plugin(mongooseLeanVirtuals);
 UserSchema.plugin(autopopulate);
 
 module.exports = mongoose.model('User', UserSchema);
+module.exports.TOKEN_EXPIRE_TIME = TOKEN_EXPIRE_TIME;

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -199,7 +199,7 @@ describe('USERS ROUTES', () => {
         token: expect.any(String),
         refreshToken: expect.any(String),
         expiresIn: expect.any(Number),
-        user: expect.objectContaining({ _id: expect.any(String), role: expect.any(String) }),
+        user: expect.objectContaining({ _id: expect.any(ObjectID), role: expect.any(String) }),
       }));
     });
 

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -199,7 +199,7 @@ describe('USERS ROUTES', () => {
         token: expect.any(String),
         refreshToken: expect.any(String),
         expiresIn: expect.any(Number),
-        user: expect.objectContaining({ _id: expect.any(ObjectID), role: expect.any(String) }),
+        user: expect.objectContaining({ _id: expect.any(String), role: expect.any(String) }),
       }));
     });
 
@@ -227,7 +227,7 @@ describe('USERS ROUTES', () => {
         url: '/users/authenticate',
         payload: { email: 'test@alenvi.io', password: '123456' },
       });
-      expect(res.statusCode).toBe(404);
+      expect(res.statusCode).toBe(401);
     });
 
     it('should not authenticate a user if wrong password', async () => {
@@ -246,7 +246,7 @@ describe('USERS ROUTES', () => {
         url: '/users/authenticate',
         payload: { email: 'white@alenvi.io', password: '123456' },
       });
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(401);
     });
   });
 
@@ -863,7 +863,7 @@ describe('USERS ROUTES', () => {
         url: '/users/refreshToken',
         payload: { refreshToken: 'b171c888-6874-45fd-9c4e-1a9daf0231ba' },
       });
-      expect(res.statusCode).toBe(404);
+      expect(res.statusCode).toBe(401);
     });
   });
 

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -132,28 +132,6 @@ describe('getMatchingVersion', () => {
   });
 });
 
-describe('clean', () => {
-  it('should delete undefined value', () => {
-    const result = UtilsHelper.clean({ _id: 1, value: undefined });
-    expect(result.value).not.toBeDefined();
-  });
-
-  it('should delete empty array', () => {
-    const result = UtilsHelper.clean({ _id: 1, value: [] });
-    expect(result.value).not.toBeDefined();
-  });
-
-  it('should delete empty object', () => {
-    const result = UtilsHelper.clean({ _id: 1, value: {} });
-    expect(result.value).not.toBeDefined();
-  });
-
-  it('should delete empty string', () => {
-    const result = UtilsHelper.clean({ _id: 1, value: '' });
-    expect(result.value).not.toBeDefined();
-  });
-});
-
 describe('getFixedNumber', () => {
   it('should return number to string with number of decimals as provided by parameter', () => {
     const result = UtilsHelper.getFixedNumber(10, 2);


### PR DESCRIPTION
En lisant des articles sur l'authentification, je suis repassé sur le code qu'on avait et je me suis permise une petite refacto. N'hesitez pas si vous voyez d'autres pistes d'améliorations
Idem pour le front


pour info par rapport au `forbidden` et `unauthorized `
"In summary, a 401 Unauthorized response should be used for missing or bad authentication, and a 403 Forbidden response should be used afterwards, when the user is authenticated but isn’t authorized to perform the requested operation on the given resource."

https://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses