### PR TITLE
COM-459 change auxiliary role on contract creation

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -10,13 +10,14 @@ const cloneDeep = require('lodash/cloneDeep');
 const Contract = require('../models/Contract');
 const User = require('../models/User');
 const Customer = require('../models/Customer');
+const Role = require('../models/Role');
 const Drive = require('../models/Google/Drive');
 const ESign = require('../models/ESign');
 const EventHelper = require('./events');
 const CustomerHelper = require('./customers');
 const UtilsHelper = require('./utils');
 const GDriveStorageHelper = require('./gdriveStorage');
-const { CUSTOMER_CONTRACT, COMPANY_CONTRACT } = require('./constants');
+const { CUSTOMER_CONTRACT, COMPANY_CONTRACT, AUXILIARY } = require('./constants');
 const { createAndReadFile } = require('./file');
 const ESignHelper = require('./eSign');
 const UserHelper = require('./users');
@@ -78,9 +79,11 @@ exports.createContract = async (contractPayload, credentials) => {
 
   const newContract = await Contract.create(payload);
 
+  const role = await Role.findOne({ name: AUXILIARY }).lean();
+
   const user = await User.findOneAndUpdate(
     { _id: newContract.user },
-    { $push: { contracts: newContract._id }, $unset: { inactivityDate: '' } }
+    { $push: { contracts: newContract._id }, $unset: { inactivityDate: '' }, $set: { role: role._id } }
   )
     .populate({ path: 'sector', match: { company: companyId } })
     .lean({ autopopulate: true, virtuals: true });

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -12,8 +12,9 @@ const ESignHelper = require('../../../src/helpers/eSign');
 const CustomerHelper = require('../../../src/helpers/customers');
 const UserHelper = require('../../../src/helpers/users');
 const GDriveStorageHelper = require('../../../src/helpers/gdriveStorage');
-const { RESIGNATION, COMPANY_CONTRACT, CUSTOMER_CONTRACT } = require('../../../src/helpers/constants');
+const { RESIGNATION, COMPANY_CONTRACT, CUSTOMER_CONTRACT, AUXILIARY } = require('../../../src/helpers/constants');
 const Contract = require('../../../src/models/Contract');
+const Role = require('../../../src/models/Role');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
 const EventRepository = require('../../../src/repositories/EventRepository');
@@ -89,6 +90,7 @@ describe('createContract', () => {
   let generateSignatureRequestStub;
   let UserMock;
   let CustomerMock;
+  let RoleMock;
   let createHistoryOnContractCreation;
 
   beforeEach(() => {
@@ -97,6 +99,7 @@ describe('createContract', () => {
     createHistoryOnContractCreation = sinon.stub(SectorHistoryHelper, 'createHistoryOnContractCreation');
     ContractMock = sinon.mock(Contract);
     UserMock = sinon.mock(User);
+    RoleMock = sinon.mock(Role);
     CustomerMock = sinon.mock(Customer);
   });
 
@@ -106,6 +109,7 @@ describe('createContract', () => {
     createHistoryOnContractCreation.restore();
     ContractMock.restore();
     UserMock.restore();
+    RoleMock.restore();
     CustomerMock.restore();
   });
 
@@ -125,8 +129,15 @@ describe('createContract', () => {
     ContractMock.expects('create')
       .withExactArgs(contract)
       .returns(contract);
+
+    const role = { _id: new ObjectID() };
+    RoleMock.expects('findOne').withExactArgs({ name: AUXILIARY }).chain('lean').returns(role);
+
     UserMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: payload.user }, { $push: { contracts: payload._id }, $unset: { inactivityDate: '' } })
+      .withExactArgs(
+        { _id: payload.user },
+        { $push: { contracts: payload._id }, $unset: { inactivityDate: '' }, $set: { role: role._id } }
+      )
       .chain('populate')
       .withExactArgs({ path: 'sector', match: { company: credentials.company._id } })
       .chain('lean')
@@ -174,8 +185,15 @@ describe('createContract', () => {
     ContractMock.expects('create')
       .withExactArgs(contractWithDoc)
       .returns(contractWithDoc);
+
+    const role = { _id: new ObjectID() };
+    RoleMock.expects('findOne').withExactArgs({ name: AUXILIARY }).chain('lean').returns(role);
+
     UserMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: contract.user }, { $push: { contracts: contract._id }, $unset: { inactivityDate: '' } })
+      .withExactArgs(
+        { _id: contract.user },
+        { $push: { contracts: contract._id }, $unset: { inactivityDate: '' }, $set: { role: role._id } }
+      )
       .chain('populate')
       .withExactArgs({ path: 'sector', match: { company: credentials.company._id } })
       .chain('lean')
@@ -212,8 +230,15 @@ describe('createContract', () => {
     ContractMock.expects('create')
       .withExactArgs(contract)
       .returns(contract);
+
+    const role = { _id: new ObjectID() };
+    RoleMock.expects('findOne').withExactArgs({ name: AUXILIARY }).chain('lean').returns(role);
+
     UserMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: contract.user }, { $push: { contracts: contract._id }, $unset: { inactivityDate: '' } })
+      .withExactArgs(
+        { _id: contract.user },
+        { $push: { contracts: contract._id }, $unset: { inactivityDate: '' }, $set: { role: role._id } }
+      )
       .chain('populate')
       .withExactArgs({ path: 'sector', match: { company: credentials.company._id } })
       .chain('lean')
@@ -251,9 +276,16 @@ describe('createContract', () => {
     ContractMock.expects('create')
       .withExactArgs(contract)
       .returns(contract);
+
+    const role = { _id: new ObjectID() };
+    RoleMock.expects('findOne').withExactArgs({ name: AUXILIARY }).chain('lean').returns(role);
+
     const user = { name: 'toto', sector: new ObjectID(), _id: new ObjectID() };
     UserMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: payload.user }, { $push: { contracts: payload._id }, $unset: { inactivityDate: '' } })
+      .withExactArgs(
+        { _id: payload.user },
+        { $push: { contracts: payload._id }, $unset: { inactivityDate: '' }, $set: { role: role._id } }
+      )
       .chain('populate')
       .withExactArgs({ path: 'sector', match: { company: credentials.company._id } })
       .chain('lean')


### PR DESCRIPTION
- [ ]  J'ai verifié la fonctionnalite sur mobile - non pertinent
- [x]  Mon code est testé unitairement
- [ ]  Mon code est testé avec des tests d'intégration - non pertinent

- Périmetre interface : coach

- Périmetre pages : page contrat auxiliaire

- Cas d'usage : Creer un contrat pour une auxiliaire qui est inactive, elle doit alors avoir un role auxiliaire 
