### PR TITLE
COM-1005 sort before lookups

### DIFF
--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -217,7 +217,8 @@ exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
 
   return Event.aggregate([
     { $match: { $and: rules } },
-    { $lookup: { from: 'customers', localField: 'customer', foreignField: '_id', as: 'customer', }, },
+    { $sort: { startDate: -1 } },
+    { $lookup: { from: 'customers', localField: 'customer', foreignField: '_id', as: 'customer' } },
     { $unwind: { path: '$customer', preserveNullAndEmptyArrays: true } },
     {
       $addFields: {
@@ -294,7 +295,6 @@ exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
         sector: 1,
       },
     },
-    { $sort: { startDate: -1 } },
   ]).option({ company: companyId });
 };
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -32,13 +32,18 @@ describe('EXPORTS ROUTES', () => {
       it('should get working events', async () => {
         const response = await app.inject({
           method: 'GET',
-          url: '/exports/working_event/history?startDate=2019-01-15&endDate=2019-01-17',
+          url: '/exports/working_event/history?startDate=2019-01-15&endDate=2019-01-20',
           headers: { 'x-access-token': adminClientToken },
         });
 
         expect(response.statusCode).toBe(200);
         expect(response.result).toBeDefined();
-        expect(response.result.split('\r\n').length).toBe(3);
+        const rows = response.result.split('\r\n');
+        expect(rows.length).toBe(4);
+        expect(rows[0]).toMatch('"Type";"Heure interne";"Service";"Début";"Fin";"Durée";"Répétition";"Équipe";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"');
+        expect(rows[1]).toMatch('"Intervention";;;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";;;;"Oui";;"LILI";"Lola";;"Non";"Non";;');
+        expect(rows[2]).toMatch('"Heure interne";;;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";;;;"Oui";;;;;"Non";"Non";;');
+        expect(rows[3]).toMatch('"Intervention";;;"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";;"Lola";"LILI";"Non";;"LILI";"Lola";;"Non";"Non";"Facturée & payée";');
       });
     });
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -41,9 +41,9 @@ describe('EXPORTS ROUTES', () => {
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(4);
         expect(rows[0]).toMatch('"Type";"Heure interne";"Service";"Début";"Fin";"Durée";"Répétition";"Équipe";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"');
-        expect(rows[1]).toMatch('"Intervention";;;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";;;;"Oui";;"LILI";"Lola";;"Non";"Non";;');
-        expect(rows[2]).toMatch('"Heure interne";;;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";;;;"Oui";;;;;"Non";"Non";;');
-        expect(rows[3]).toMatch('"Intervention";;;"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";;"Lola";"LILI";"Non";;"LILI";"Lola";;"Non";"Non";"Facturée & payée";');
+        expect(rows[1]).toMatch('"Intervention";;"Service 1";"17/01/2019 15:30";"17/01/2019 17:30";"2,00";"Tous les jours";"Etoile";;;;"Oui";;"LILI";"Lola";;"Non";"Non";;');
+        expect(rows[2]).toMatch('"Heure interne";"planning";;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;;;;"Non";"Non";;');
+        expect(rows[3]).toMatch('"Intervention";;"Service 1";"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;"LILI";"Lola";"test";"Non";"Oui";"Facturée & payée";"Initiative du de l\'intervenant"');
       });
     });
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -40,10 +40,10 @@ describe('EXPORTS ROUTES', () => {
         expect(response.result).toBeDefined();
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(4);
-        expect(rows[0]).toMatch('"Type";"Heure interne";"Service";"Début";"Fin";"Durée";"Répétition";"Équipe";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"');
-        expect(rows[1]).toMatch('"Intervention";;"Service 1";"17/01/2019 15:30";"17/01/2019 17:30";"2,00";"Tous les jours";"Etoile";;;;"Oui";;"LILI";"Lola";;"Non";"Non";;');
-        expect(rows[2]).toMatch('"Heure interne";"planning";;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;;;;"Non";"Non";;');
-        expect(rows[3]).toMatch('"Intervention";;"Service 1";"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;"LILI";"Lola";"test";"Non";"Oui";"Facturée & payée";"Initiative du de l\'intervenant"');
+        expect(rows[0]).toEqual('\ufeff"Type";"Heure interne";"Service";"Début";"Fin";"Durée";"Répétition";"Équipe";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"');
+        expect(rows[1]).toEqual('"Intervention";;"Service 1";"17/01/2019 15:30";"17/01/2019 17:30";"2,00";"Tous les jours";"Etoile";;;;"Oui";;"LILI";"Lola";;"Non";"Non";;');
+        expect(rows[2]).toEqual('"Heure interne";"planning";;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;;;;"Non";"Non";;');
+        expect(rows[3]).toEqual('"Intervention";;"Service 1";"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";"M.";"Lulu";"LALA";"Non";;"LILI";"Lola";"test";"Non";"Oui";"Facturée & payée";"Initiative du de l\'intervenant"');
       });
     });
 

--- a/tests/integration/seed/exportSeed.js
+++ b/tests/integration/seed/exportSeed.js
@@ -22,7 +22,12 @@ const {
   HOURLY,
   CUSTOMER_CONTRACT,
   PAID_LEAVE,
+  INVOICED_AND_PAID,
   DAILY,
+  PLANNING,
+  INTERNAL_HOUR,
+  INTERVENTION,
+  ABSENCE,
 } = require('../../../src/helpers/constants');
 
 const sector = {
@@ -46,6 +51,8 @@ const sectorHistory = {
   company: authCompany._id,
   startDate: '2018-12-10',
 };
+
+const internalHour = { _id: new ObjectID(), name: PLANNING, company: authCompany._id };
 
 const customer = {
   _id: new ObjectID(),
@@ -225,7 +232,7 @@ const eventList = [
     _id: new ObjectID(),
     company: authCompany._id,
     sector,
-    type: 'absence',
+    type: ABSENCE,
     absence: PAID_LEAVE,
     absenceNature: DAILY,
     startDate: '2019-01-19T14:00:18.653Z',
@@ -237,12 +244,14 @@ const eventList = [
     _id: new ObjectID(),
     company: authCompany._id,
     sector,
-    type: 'intervention',
+    type: INTERVENTION,
     status: 'contract_with_company',
     startDate: '2019-01-16T09:30:19.543Z',
     endDate: '2019-01-16T11:30:21.653Z',
     auxiliary,
     customer: customer._id,
+    IsCancelled: true,
+    cancel: { condition: INVOICED_AND_PAID },
     createdAt: '2019-01-15T11:33:14.343Z',
     subscription: customer.subscriptions[0]._id,
     address: {
@@ -257,13 +266,43 @@ const eventList = [
     _id: new ObjectID(),
     company: authCompany._id,
     sector,
-    type: 'intervention',
+    type: INTERVENTION,
     status: 'contract_with_company',
     startDate: '2019-01-17T14:30:19.543Z',
     endDate: '2019-01-17T16:30:19.543Z',
-    auxiliary,
     customer: customer._id,
     createdAt: '2019-01-16T14:30:19.543Z',
+    subscription: customer.subscriptions[0]._id,
+    address: {
+      fullAddress: '37 rue de ponthieu 75008 Paris',
+      zipCode: '75008',
+      city: 'Paris',
+      street: '37 rue de Ponthieu',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    sector,
+    type: INTERNAL_HOUR,
+    internalHour: internalHour._id,
+    status: 'contract_with_company',
+    startDate: '2019-01-17T14:30:19.543Z',
+    endDate: '2019-01-17T16:30:19.543Z',
+    createdAt: '2019-01-16T14:30:19.543Z',
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    sector,
+    type: INTERVENTION,
+    status: 'contract_with_company',
+    startDate: '2019-01-11T09:30:19.543Z',
+    endDate: '2019-01-11T11:30:21.653Z',
+    auxiliary,
+    customer: customer._id,
+    createdAt: '2019-01-09T11:33:14.343Z',
     subscription: customer.subscriptions[0]._id,
     address: {
       fullAddress: '37 rue de ponthieu 75008 Paris',


### PR DESCRIPTION
- [ ] J'ai verifié la fonctionnalite sur mobile - non pertinent
- [ ] Mon code est testé unitairement - non pertinent
- [ ] Mon code est testé avec des tests d'intégration - déjà testé

- Périmetre interface : interface admin

- Périmetre pages : page export

- Cas d'usage : exporter les evenements sur un an

**Par rapport à l'index:** 
L'aggregation utilise l'index `startDate_-1_endDate_-1_type_-1` meme si on en ajoute un specifique `startDate: -1`. 
J'ai essayé de l'ajouter et de forcer l'aggregation à l'utiliser (avec un `hint`) mais je n'ai pas réussi à faire fonctionner les tests. Comme je ne savais pas si c'etait genant d'utiliser cet index (il a une taille plus important mais qui reste negligeable a cote de la taille max pour le sort) j'ai préféré ouvrir ma pr comme ca pour l'instant. Dites moi ce que vous en pensez :)
