### PR TITLE
COM-1028 - update post route

### DIFF
--- a/src/controllers/companyController.js
+++ b/src/controllers/companyController.js
@@ -42,6 +42,10 @@ const create = async (req) => {
       data: { company: newCompany },
     };
   } catch (e) {
+    if (e.code === 11000) {
+      req.log(['error', 'db'], e);
+      return Boom.conflict(translate[language].companyExists);
+    }
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
   }

--- a/src/routes/companies.js
+++ b/src/routes/companies.js
@@ -148,20 +148,20 @@ exports.plugin = {
             rhConfig: Joi.object().keys({
               contractWithCompany: Joi.object().keys({
                 grossHourlyRate: Joi.number(),
-              }),
+              }).min(1),
               contractWithCustomer: Joi.object().keys({
                 grossHourlyRate: Joi.number(),
-              }),
+              }).min(1),
               feeAmount: Joi.number(),
               amountPerKm: Joi.number(),
               transportSubs: Joi.array().items({
                 department: Joi.string(),
                 price: Joi.number(),
-              }),
-            }).required(),
+              }).min(1),
+            }).min(1),
             customersConfig: Joi.object().keys({
               billingPeriod: Joi.string().valid(...COMPANY_BILLING_PERIODS).default(TWO_WEEKS),
-            }),
+            }).min(1),
           }),
         },
       },

--- a/tests/integration/companies.test.js
+++ b/tests/integration/companies.test.js
@@ -241,6 +241,22 @@ describe('COMPANIES ROUTES', () => {
         expect(companiesCount).toEqual(companiesBefore.length + 1);
       });
 
+      it('should not create a company if name provided already exists', async () => {
+        createFolderForCompany.returns({ id: '1234567890' });
+        createFolder.onCall(0).returns({ id: '0987654321' });
+        createFolder.onCall(1).returns({ id: 'qwerty' });
+        createFolder.onCall(2).returns({ id: 'asdfgh' });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/companies',
+          payload: { name: authCompany.name, tradeName: 'qwerty', type: 'association' },
+          headers: { 'x-access-token': authToken },
+        });
+
+        expect(response.statusCode).toBe(409);
+      });
+
       const missingParams = [
         { path: 'name' },
         { path: 'tradeName' },


### PR DESCRIPTION
- [ ] Mon code est testé unitairement - non pertinent
- [ ] Mon code est testé avec des tests d'intégration - non pertinent

- Périmetre interface : Vendeur / admin + responsable organisme formation

- Périmetre pages : repertoire structures

- Cas d'usage : Creation d'une structure

NB : on garde `tradeName` et `type` en obligatoire dans le model de l'organisation
