### PR TITLE
COM-1101 - get all auxiliary roles on planning

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -157,15 +157,15 @@ module.exports = {
   // INTERFACES
   CLIENT: 'client',
   VENDOR: 'vendor',
-  // ROLE
-  // CLIENT
+  // ROLE CLIENT
   AUXILIARY: 'auxiliary',
   HELPER: 'helper',
   COACH: 'coach',
   PLANNING_REFERENT: 'planning_referent',
   AUXILIARY_WITHOUT_COMPANY: 'auxiliary_without_company',
   CLIENT_ADMIN: 'client_admin',
-  // VENDOR
+  get AUXILIARY_ROLES() { return [this.AUXILIARY, this.PLANNING_REFERENT, this.AUXILIARY_WITHOUT_COMPANY]; },
+  // ROLE VENDOR
   VENDOR_ADMIN: 'vendor_admin',
   TRAINING_ORGANISATION_MANAGER: 'training_organisation_manager',
   TRAINER: 'trainer',

--- a/src/helpers/dataExport.js
+++ b/src/helpers/dataExport.js
@@ -4,15 +4,13 @@ const has = require('lodash/has');
 const {
   CIVILITY_LIST,
   HELPER,
-  AUXILIARY,
-  PLANNING_REFERENT,
+  AUXILIARY_ROLES,
   COMPANY_CONTRACT,
   DAYS_INDEX,
   FUNDING_FREQUENCIES,
   FUNDING_NATURES,
   CONTRACT_STATUS_LIST,
   SERVICE_NATURES,
-  AUXILIARY_WITHOUT_COMPANY,
 } = require('./constants');
 const UtilsHelper = require('./utils');
 const Customer = require('../models/Customer');
@@ -165,7 +163,7 @@ const getDataForAuxiliariesExport = (aux, contractsLength, contract) => {
 
 exports.exportAuxiliaries = async (credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  const roles = await Role.find({ name: { $in: [AUXILIARY, PLANNING_REFERENT, AUXILIARY_WITHOUT_COMPANY] } }).lean();
+  const roles = await Role.find({ name: { $in: AUXILIARY_ROLES } }).lean();
   const roleIds = roles.map(role => role._id);
   const auxiliaries = await User
     .find({ 'role.client': { $in: roleIds }, company: companyId })

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -16,7 +16,7 @@ const Contract = require('../models/Contract');
 const translate = require('./translate');
 const GdriveStorage = require('./gdriveStorage');
 const AuthenticationHelper = require('./authentication');
-const { AUXILIARY, PLANNING_REFERENT, TRAINER, VENDOR } = require('./constants');
+const { AUXILIARY, PLANNING_REFERENT, TRAINER, VENDOR, AUXILIARY_ROLES } = require('./constants');
 const SectorHistoriesHelper = require('./sectorHistories');
 const EmailHelper = require('./email');
 
@@ -77,7 +77,7 @@ exports.getUsersList = async (query, credentials) => {
 };
 
 exports.getUsersListWithSectorHistories = async (query, credentials) => {
-  const params = await exports.formatQueryForUsersList({ ...query, role: [AUXILIARY, PLANNING_REFERENT] });
+  const params = await exports.formatQueryForUsersList({ ...query, role: AUXILIARY_ROLES });
 
   return User.find(params, {}, { autopopulate: false })
     .populate({ path: 'role.client', select: '-rights -__v -createdAt -updatedAt' })

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -536,8 +536,9 @@ describe('USERS ROUTES', () => {
 
       it('should get all auxiliary users', async () => {
         authToken = await getTokenByCredentials(usersSeedList[0].local);
-        const auxiliaryUsers = usersSeedList.filter(u =>
-          isExistingRole(u.role.client, 'auxiliary') || isExistingRole(u.role.client, 'planning_referent'));
+        const auxiliaryUsers = usersSeedList.filter(u => isExistingRole(u.role.client, 'auxiliary') ||
+          isExistingRole(u.role.client, 'planning_referent') ||
+          isExistingRole(u.role.client, 'auxiliary_without_company'));
 
         const res = await app.inject({
           method: 'GET',
@@ -550,7 +551,9 @@ describe('USERS ROUTES', () => {
         expect(res.result.data.users).toEqual(expect.arrayContaining([
           expect.objectContaining({
             role: expect.objectContaining({
-              client: expect.objectContaining({ name: expect.stringMatching(/auxiliary|planning_referent/) }),
+              client: expect.objectContaining({
+                name: expect.stringMatching(/auxiliary|planning_referent|auxiliary_without_company/),
+              }),
             }),
             sectorHistories: expect.any(Array),
           }),
@@ -580,7 +583,9 @@ describe('USERS ROUTES', () => {
         });
 
         expect(res.statusCode).toBe(200);
-        const roles = await Role.find({ name: { $in: ['auxiliary', 'planning_referent'] } }).lean();
+        const roles = await Role
+          .find({ name: { $in: ['auxiliary', 'planning_referent', 'auxiliary_without_company'] } })
+          .lean();
         const roleIds = roles.map(role => role._id);
         const usersCount = await User.countDocuments({ 'role.client': { $in: roleIds } });
         expect(res.result.data.users.length).toBe(usersCount);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -392,7 +392,10 @@ describe('getUsersListWithSectorHistories', () => {
       { ...credentials, role: { client: 'test' } }
     );
     expect(result).toEqual(users);
-    sinon.assert.calledWithExactly(formatQueryForUsersListStub, { ...query, role: ['auxiliary', 'planning_referent'] });
+    sinon.assert.calledWithExactly(
+      formatQueryForUsersListStub,
+      { ...query, role: ['auxiliary', 'planning_referent', 'auxiliary_without_company'] }
+    );
     UserMock.verify();
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Coach / auxiliaire

- Cas d'usage : Affichage des auxiliaire dont le role est `auxiliary_without_company` dans le planning
