### PR TITLE
COM-1132 populate courses

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -21,7 +21,6 @@ exports.list = async query => Course.find(query)
   .populate('companies')
   .populate('program')
   .populate('slots')
-  .populate('trainees')
   .populate('trainer')
   .lean();
 

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -17,7 +17,13 @@ const { AUXILIARY } = require('./constants');
 
 exports.createCourse = payload => (new Course(payload)).save();
 
-exports.list = async query => Course.find(query).lean();
+exports.list = async query => Course.find(query)
+  .populate('companies')
+  .populate('program')
+  .populate('slots')
+  .populate('trainees')
+  .populate('trainer')
+  .lean();
 
 exports.getCourse = async courseId => Course.findOne({ _id: courseId })
   .populate('companies')

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -60,8 +60,6 @@ describe('list', () => {
       .chain('populate')
       .withExactArgs('slots')
       .chain('populate')
-      .withExactArgs('trainees')
-      .chain('populate')
       .withExactArgs('trainer')
       .chain('lean')
       .once()

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -53,6 +53,16 @@ describe('list', () => {
 
     CourseMock.expects('find')
       .withExactArgs({ type: 'toto' })
+      .chain('populate')
+      .withExactArgs('companies')
+      .chain('populate')
+      .withExactArgs('program')
+      .chain('populate')
+      .withExactArgs('slots')
+      .chain('populate')
+      .withExactArgs('trainees')
+      .chain('populate')
+      .withExactArgs('trainer')
       .chain('lean')
       .once()
       .returns(coursesList);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : Les cartes d'une formation possedent les infos suivantes: 
    - programme
    - entreprise
    - formateur
    - Nombre de stagiaire
    - Nombre de jours de formations