### PR TITLE
COM-1134 add populate slot to course fetch

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -18,12 +18,16 @@ const { AUXILIARY } = require('./constants');
 
 exports.createCourse = payload => (new Course(payload)).save();
 
+<<<<<<< HEAD
 exports.list = async query => Course.find(query)
   .populate('companies')
   .populate('program')
   .populate('slots')
   .populate('trainer')
   .lean();
+=======
+exports.list = async query => Course.find(query).populate('slots').lean();
+>>>>>>> COM-1134 add populate slot to course fetch
 
 exports.getCourse = async courseId => Course.findOne({ _id: courseId })
   .populate('companies')

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -55,6 +55,7 @@ describe('list', () => {
     CourseMock.expects('find')
       .withExactArgs({ type: 'toto' })
       .chain('populate')
+<<<<<<< HEAD
       .withExactArgs('companies')
       .chain('populate')
       .withExactArgs('program')
@@ -62,6 +63,9 @@ describe('list', () => {
       .withExactArgs('slots')
       .chain('populate')
       .withExactArgs('trainer')
+=======
+      .withExactArgs('slots')
+>>>>>>> COM-1134 add populate slot to course fetch
       .chain('lean')
       .once()
       .returns(coursesList);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : un appel sur la liste des 'courses' renvoi les 'slots' associé
