### PR TITLE
Com 1178 fix

### DIFF
--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -41,6 +41,7 @@ module.exports = {
     /* Role */
     rolesNotFound: 'Roles not found.',
     rolesFound: 'Roles found.',
+    unknownRole: 'Role does not exist',
     /* Email */
     emailSent: 'Email successfully sent.',
     /* Reset password token */
@@ -213,6 +214,8 @@ module.exports = {
     establishmentsFound: 'Establishments found.',
     establishmentRemoved: 'Establishment removed.',
     siretAlreadyExists: 'Siret already used by another establishment.',
+    /* Trainers */
+    trainerAlreadyExists: 'Trainer already exists',
     /* Programs */
     programsFound: 'Programs found.',
     programsNotFound: 'Programs not found.',
@@ -277,6 +280,7 @@ module.exports = {
     /* Role */
     rolesNotFound: 'Rôles non trouvés.',
     rolesFound: 'Rôles trouvés.',
+    unknownRole: 'Le rôle n\'existe pas',
     /* Email */
     emailSent: 'Email envoyé avec succès.',
     /* Reset password token */
@@ -447,13 +451,15 @@ module.exports = {
     establishmentsFound: 'Établissements trouvés.',
     establishmentRemoved: 'Établissement supprimé.',
     siretAlreadyExists: 'Siret déjà utilisé par un autre établissement.',
+    /* Trainers */
+    trainerAlreadyExists: 'Formateur déjà existant',
     /* Programs */
     programsFound: 'Liste des programmes trouvés.',
     programsNotFound: 'Liste des programmes non trouvés.',
     programCreated: 'Programme créé.',
     programFound: 'Programme trouvé.',
     programUpdated: 'Programme mis à jour.',
-    /* Formations */
+    /* Courses */
     coursesFound: 'Liste des formations trouvée.',
     coursesNotFound: 'Liste des formations non trouvée.',
     courseCreated: 'Formation créée.',
@@ -463,8 +469,7 @@ module.exports = {
     courseTraineeRemoved: 'Stagiaire supprimé de la formation.',
     courseTraineeAlreadyExists: 'Stagiaire déjà ajouté à la formation.',
     courseTraineeNotFromCourseCompany: 'Ce stagiaire n\'est pas relié à la structure de la formation',
-
-    /* Créneaux de formation */
+    /* Course slots */
     courseSlotCreated: 'Créneau de formation créé.',
     courseSlotUpdated: 'Créneau de formation mis à jour.',
     courseSlotDeleted: 'Créneau de formation supprimé.',

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -167,7 +167,7 @@ exports.createUser = async (userPayload, credentials) => {
   if (role.interface === VENDOR) {
     const userInDB = await User.findOne({ 'local.email': payload.local.email }).lean();
 
-    if (userInDB && userInDB.role.vendor) throw Boom.badRequest();
+    if (userInDB && userInDB.role.vendor) throw Boom.conflict('Trainer already exists');
     if (userInDB) {
       return User.findOneAndUpdate({ _id: userInDB._id }, { 'role.vendor': role._id }, { new: true })
         .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -153,7 +153,7 @@ exports.createUser = async (userPayload, credentials) => {
   const companyId = payload.company || get(credentials, 'company._id', null);
 
   const role = await Role.findById(roleId, { name: 1, interface: 1 }).lean();
-  if (!role) throw Boom.badRequest('Role does not exist');
+  if (!role) throw Boom.badRequest(translate[language].unknownRole);
 
   payload.role = { [role.interface]: role._id };
 
@@ -167,7 +167,7 @@ exports.createUser = async (userPayload, credentials) => {
   if (role.interface === VENDOR) {
     const userInDB = await User.findOne({ 'local.email': payload.local.email }).lean();
 
-    if (userInDB && userInDB.role.vendor) throw Boom.conflict('Trainer already exists');
+    if (userInDB && userInDB.role.vendor) throw Boom.conflict(translate[language].trainerAlreadyExists);
     if (userInDB) {
       return User.findOneAndUpdate({ _id: userInDB._id }, { 'role.vendor': role._id }, { new: true })
         .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
@@ -188,7 +188,7 @@ const formatUpdatePayload = async (updatedUser) => {
 
   if (updatedUser.role) {
     const role = await Role.findById(updatedUser.role, { name: 1, interface: 1 }).lean();
-    if (!role) throw Boom.badRequest('Role does not exist');
+    if (!role) throw Boom.badRequest(translate[language].unknownRole);
     payload.role = { [role.interface]: role._id.toHexString() };
   }
 

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -220,7 +220,7 @@ describe('USERS ROUTES', () => {
         expect(usersCountAfter).toEqual(usersCountBefore);
       });
 
-      it('should return an error if user already has vendor role', async () => {
+      it('should return an error 409 if trainer already has vendor role', async () => {
         const vendorAdminRole = await Role.findOne({ name: 'vendor_admin' }).lean();
         const trainerPayload = {
           identity: { firstname: 'Auxiliary2', lastname: 'Kirk' },
@@ -235,7 +235,8 @@ describe('USERS ROUTES', () => {
           payload: trainerPayload,
           headers: { 'x-access-token': authToken },
         });
-        expect(response.statusCode).toBe(400);
+
+        expect(response.statusCode).toBe(409);
       });
 
       it('should not create a trainer if missing status', async () => {

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -237,6 +237,7 @@ describe('USERS ROUTES', () => {
         });
 
         expect(response.statusCode).toBe(409);
+        expect(response.result.message).toBe('Formateur déjà existant');
       });
 
       it('should not create a trainer if missing status', async () => {

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -862,7 +862,7 @@ describe('createUser', () => {
     UserMock.verify();
   });
 
-  it('should return an error if user already has vendor role', async () => {
+  it('should return an error 409 if user already has vendor role', async () => {
     try {
       const payload = {
         identity: { lastname: 'Admin', firstname: 'Toto' },
@@ -889,7 +889,7 @@ describe('createUser', () => {
 
       await UsersHelper.createUser(payload, credentials);
     } catch (e) {
-      expect(e).toMatchObject(Boom.badRequest());
+      expect(e).toMatchObject(Boom.conflict('Formateur déjà existant'));
       RoleMock.verify();
       TaskMock.verify();
       UserMock.verify();
@@ -914,7 +914,7 @@ describe('createUser', () => {
 
       await UsersHelper.createUser(payload, credentials);
     } catch (e) {
-      expect(e).toEqual(Boom.badRequest('Role does not exist'));
+      expect(e).toEqual(Boom.badRequest('Le rôle n\'existe pas'));
     } finally {
       RoleMock.verify();
       UserMock.verify();
@@ -1025,7 +1025,7 @@ describe('updateUser', () => {
     try {
       await UsersHelper.updateUser(userId, payload, credentials);
     } catch (e) {
-      expect(e).toEqual(Boom.badRequest('Role does not exist'));
+      expect(e).toEqual(Boom.badRequest('Le rôle n\'existe pas'));
     } finally {
       RoleMock.verify();
       sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : Dans la modale de creation de formateur, un conflit avec un formateur déjà présent renvoie un notify spécifique. Depuis le back, on renvoie une 409 (anciennement 400)

rien a changer dans le front, la 409 était en fait attendu