### PR TITLE
Fix auxiliary sector update

### DIFF
--- a/src/helpers/sectorHistories.js
+++ b/src/helpers/sectorHistories.js
@@ -7,6 +7,10 @@ exports.updateHistoryOnSectorUpdate = async (auxiliaryId, sector, companyId) => 
   const lastSectorHistory = await SectorHistory
     .findOne({ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] })
     .lean();
+  if (!lastSectorHistory) {
+    return exports.createHistory({ _id: auxiliaryId, sector }, companyId, moment().startOf('day').toDate());
+  }
+
   if (lastSectorHistory.sector.toHexString() === sector) return;
 
   const contracts = await Contract


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Coach

- Cas d'usage : Quand un auxiliaire est crée cote vendeur, je ne peux pas lui affecter une equipe cote client
