### PR TITLE
Fix authenticate

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -24,7 +24,7 @@ const { language } = translate;
 
 exports.authenticate = async (payload) => {
   const user = await User.findOne({ 'local.email': payload.email.toLowerCase() }).lean({ autopopulate: true });
-  const correctPassword = get(user, 'local.password');
+  const correctPassword = get(user, 'local.password') || '';
   const isCorrect = await bcrypt.compare(payload.password, correctPassword);
   if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
 

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -24,10 +24,9 @@ const { language } = translate;
 
 exports.authenticate = async (payload) => {
   const user = await User.findOne({ 'local.email': payload.email.toLowerCase() }).lean({ autopopulate: true });
-  if (!user || !user.refreshToken) throw Boom.unauthorized();
-
-  const correctPassword = await bcrypt.compare(payload.password, user.local.password);
-  if (!correctPassword) throw Boom.unauthorized();
+  const correctPassword = get(user, 'local.password');
+  const isCorrect = await bcrypt.compare(payload.password, correctPassword);
+  if (!user || !user.refreshToken || !correctPassword || !isCorrect) throw Boom.unauthorized();
 
   const tokenPayload = { _id: user._id.toHexString() };
   const token = AuthenticationHelper.encode(tokenPayload, TOKEN_EXPIRE_TIME);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -55,7 +55,7 @@ describe('authenticate', () => {
       expect(e.output.statusCode).toEqual(401);
     } finally {
       UserMock.verify();
-      sinon.assert.notCalled(compare);
+      sinon.assert.calledOnceWithExactly(compare, '123456!eR', '');
       sinon.assert.notCalled(encode);
     }
   });
@@ -74,7 +74,7 @@ describe('authenticate', () => {
       expect(e.output.statusCode).toEqual(401);
     } finally {
       UserMock.verify();
-      sinon.assert.notCalled(compare);
+      sinon.assert.calledOnceWithExactly(compare, '123456!eR', '');
       sinon.assert.notCalled(encode);
     }
   });


### PR DESCRIPTION
- [ ] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : -

- Périmetre roles : -

- Cas d'usage : Fix a l'authentification
-- Ne renvoyer l'erreur a la fin, apres toutes les verifications pour ne pas donner d'information au hacker
-- Si pas de mot de passe enregistrer, envoyer une string vide a bcrypt pour ne pas avoir une erreur
