### PR TITLE
Com 1216

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -132,7 +132,7 @@ exports.endContract = async (contractId, contractToEnd, credentials) => {
     .lean({ autopopulate: true, virtuals: true });
 
   await EventHelper.unassignInterventionsOnContractEnd(updatedContract, credentials);
-  await EventHelper.removeRepetitionOnContractEnd(updatedContract);
+  await EventHelper.removeRepetitionsOnContractEnd(updatedContract);
   await EventHelper.removeEventsExceptInterventionsOnContractEnd(updatedContract, credentials);
   await EventHelper.updateAbsencesOnContractEnd(updatedContract.user._id, updatedContract.endDate, credentials);
   await ReferentHistoryHelper.unassignReferentOnContractEnd(updatedContract);

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -132,6 +132,7 @@ exports.endContract = async (contractId, contractToEnd, credentials) => {
     .lean({ autopopulate: true, virtuals: true });
 
   await EventHelper.unassignInterventionsOnContractEnd(updatedContract, credentials);
+  await EventHelper.removeRepetitionOnContractEnd(updatedContract);
   await EventHelper.removeEventsExceptInterventionsOnContractEnd(updatedContract, credentials);
   await EventHelper.updateAbsencesOnContractEnd(updatedContract.user._id, updatedContract.endDate, credentials);
   await ReferentHistoryHelper.unassignReferentOnContractEnd(updatedContract);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -271,7 +271,7 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
   return exports.populateEventSubscription(updatedEvent);
 };
 
-exports.removeRepetitionOnContractEnd = async (contract) => {
+exports.removeRepetitionsOnContractEnd = async (contract) => {
   const { sector, _id: auxiliaryId } = contract.user;
 
   await Repetition.updateMany(

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -271,8 +271,7 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
   return exports.populateEventSubscription(updatedEvent);
 };
 
-exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
-  const companyId = get(credentials, 'company._id', null);
+exports.removeRepetitionOnContractEnd = async (contract) => {
   const { sector, _id: auxiliaryId } = contract.user;
 
   await Repetition.updateMany(
@@ -280,6 +279,11 @@ exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
     { $unset: { auxiliary: '' }, $set: { sector } }
   );
   await Repetition.deleteMany({ auxiliary: auxiliaryId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } });
+};
+
+exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
+  const companyId = get(credentials, 'company._id', null);
+  const { sector, _id: auxiliaryId } = contract.user;
 
   const customerSubscriptionsFromEvents = await EventRepository.getCustomerSubscriptions(contract, companyId);
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -273,6 +273,14 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
 
 exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
   const companyId = get(credentials, 'company._id', null);
+  const { sector, _id: auxiliaryId } = contract.user;
+
+  await Repetition.updateMany(
+    { auxiliary: auxiliaryId, type: INTERVENTION },
+    { $unset: { auxiliary: '' }, $set: { sector } }
+  );
+  await Repetition.deleteMany({ auxiliary: auxiliaryId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } });
+
   const customerSubscriptionsFromEvents = await EventRepository.getCustomerSubscriptions(contract, companyId);
 
   if (customerSubscriptionsFromEvents.length === 0) return;
@@ -284,7 +292,6 @@ exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
 
   const correspondingSubsIds = correspondingSubs.map(sub => sub.sub._id);
 
-  const { sector, _id: auxiliaryId } = contract.user;
   const unassignedInterventions = await EventRepository.getUnassignedInterventions(
     contract.endDate,
     auxiliaryId,
@@ -309,19 +316,10 @@ exports.unassignInterventionsOnContractEnd = async (contract, credentials) => {
     }
   }
 
-  promises.push(
-    Event.updateMany(
-      { _id: { $in: ids } },
-      { $set: { 'repetition.frequency': NEVER, sector }, $unset: { auxiliary: '' } }
-    ),
-    Repetition.updateMany(
-      { auxiliary: auxiliaryId, type: INTERVENTION },
-      { $unset: { auxiliary: '' }, $set: { sector } }
-    ),
-    Repetition.deleteMany({ auxiliary: auxiliaryId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } })
+  await Event.updateMany(
+    { _id: { $in: ids } },
+    { $set: { 'repetition.frequency': NEVER, sector }, $unset: { auxiliary: '' } }
   );
-
-  return Promise.all(promises);
 };
 
 exports.removeEventsExceptInterventionsOnContractEnd = async (contract, credentials) => {

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -516,13 +516,46 @@ describe('populateEvents', () => {
   });
 });
 
+describe('removeRepetitionsOnContractEnd', () => {
+  let updateManyRepetition;
+  let deleteManyRepetition;
+
+  const userId = new ObjectID();
+  const sectorId = new ObjectID();
+
+  beforeEach(() => {
+    updateManyRepetition = sinon.stub(Repetition, 'updateMany');
+    deleteManyRepetition = sinon.stub(Repetition, 'deleteMany');
+  });
+  afterEach(() => {
+    updateManyRepetition.restore();
+    deleteManyRepetition.restore();
+  });
+
+  it('should unassigned repetition intervention and remove other repetitions', async () => {
+    const contract = {
+      status: COMPANY_CONTRACT,
+      endDate: '2019-10-02T08:00:00.000Z',
+      user: { _id: userId, sector: sectorId },
+    };
+
+    await EventHelper.removeRepetitionsOnContractEnd(contract);
+    sinon.assert.calledWithExactly(
+      updateManyRepetition,
+      { auxiliary: userId, type: 'intervention' }, { $unset: { auxiliary: '' }, $set: { sector: sectorId } }
+    );
+    sinon.assert.calledWithExactly(
+      deleteManyRepetition,
+      { auxiliary: userId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } }
+    );
+  });
+});
+
 describe('unassignInterventionsOnContractEnd', () => {
   let getCustomerSubscriptions;
   let getUnassignedInterventions;
   let createEventHistoryOnUpdate;
   let updateManyEvent;
-  let updateManyRepetition;
-  let deleteManyRepetition;
 
   const customerId = new ObjectID();
   const userId = new ObjectID();
@@ -566,16 +599,12 @@ describe('unassignInterventionsOnContractEnd', () => {
     getUnassignedInterventions = sinon.stub(EventRepository, 'getUnassignedInterventions');
     createEventHistoryOnUpdate = sinon.stub(EventHistoriesHelper, 'createEventHistoryOnUpdate');
     updateManyEvent = sinon.stub(Event, 'updateMany');
-    updateManyRepetition = sinon.stub(Repetition, 'updateMany');
-    deleteManyRepetition = sinon.stub(Repetition, 'deleteMany');
   });
   afterEach(() => {
     getCustomerSubscriptions.restore();
     getUnassignedInterventions.restore();
     createEventHistoryOnUpdate.restore();
     updateManyEvent.restore();
-    updateManyRepetition.restore();
-    deleteManyRepetition.restore();
   });
 
   it('should unassign future events linked to company contract', async () => {
@@ -601,14 +630,6 @@ describe('unassignInterventionsOnContractEnd', () => {
       updateManyEvent,
       { _id: { $in: [interventions[0].events[0]._id, interventions[1].events[0]._id] } },
       { $set: { 'repetition.frequency': NEVER, sector: sectorId }, $unset: { auxiliary: '' } }
-    );
-    sinon.assert.calledWithExactly(
-      updateManyRepetition,
-      { auxiliary: userId, type: 'intervention' }, { $unset: { auxiliary: '' }, $set: { sector: sectorId } }
-    );
-    sinon.assert.calledWithExactly(
-      deleteManyRepetition,
-      { auxiliary: userId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } }
     );
   });
 
@@ -638,14 +659,6 @@ describe('unassignInterventionsOnContractEnd', () => {
       { _id: { $in: [interventions[1].events[0]._id] } },
       { $set: { 'repetition.frequency': NEVER, sector: sectorId }, $unset: { auxiliary: '' } }
     );
-    sinon.assert.calledWithExactly(
-      updateManyRepetition,
-      { auxiliary: userId, type: 'intervention' }, { $unset: { auxiliary: '' }, $set: { sector: sectorId } }
-    );
-    sinon.assert.calledWithExactly(
-      deleteManyRepetition,
-      { auxiliary: userId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } }
-    );
   });
 
   it('should create event history for non repeated event', async () => {
@@ -668,14 +681,6 @@ describe('unassignInterventionsOnContractEnd', () => {
       updateManyEvent,
       { _id: { $in: [interventions[0].events[0]._id] } },
       { $set: { 'repetition.frequency': NEVER, sector: sectorId }, $unset: { auxiliary: '' } }
-    );
-    sinon.assert.calledWithExactly(
-      updateManyRepetition,
-      { auxiliary: userId, type: 'intervention' }, { $unset: { auxiliary: '' }, $set: { sector: sectorId } }
-    );
-    sinon.assert.calledWithExactly(
-      deleteManyRepetition,
-      { auxiliary: userId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } }
     );
   });
 
@@ -703,14 +708,6 @@ describe('unassignInterventionsOnContractEnd', () => {
       updateManyEvent,
       { _id: { $in: [interventions[0].events[0]._id, interventions[1].events[0]._id] } },
       { $set: { 'repetition.frequency': NEVER, sector: sectorId }, $unset: { auxiliary: '' } }
-    );
-    sinon.assert.calledWithExactly(
-      updateManyRepetition,
-      { auxiliary: userId, type: 'intervention' }, { $unset: { auxiliary: '' }, $set: { sector: sectorId } }
-    );
-    sinon.assert.calledWithExactly(
-      deleteManyRepetition,
-      { auxiliary: userId, type: { $in: [UNAVAILABILITY, INTERNAL_HOUR] } }
     );
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : client

- Périmetre roles : admin/coach

- Cas d'usage : lorsque l'on met fin un contrat il faut que ca supprime les repetitions

--> cela regle le probleme pour les auxiliaires qui n'avait que des repetitions pas d'evenement.
--> Pour Reine, en regardant un peu le code de l'epoque j'ai l'impression qu'a l'epoque les repetitions n'etaient pas encore supprimées lors de la fin de contrat. 
