### PR TITLE
COM-1202 add courses:edit with restriction to coach/admin

### DIFF
--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -16,7 +16,7 @@ const {
 } = require('../controllers/courseController');
 const { MESSAGE_TYPE } = require('../models/CourseSmsHistory');
 const { phoneNumberValidation } = require('./validations/utils');
-const { getCourseTrainee, authorizeCourseGetOrUpdate, authorizeGetCourseList } = require('./preHandlers/courses');
+const { getCourseTrainee, authorizeCourseEdit, authorizeGetCourseList } = require('./preHandlers/courses');
 const { INTRA } = require('../helpers/constants');
 
 exports.plugin = {
@@ -57,7 +57,6 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId() }),
         },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
         auth: { mode: 'optional' },
       },
       handler: getById,
@@ -79,7 +78,7 @@ exports.plugin = {
             }).min(1),
           }),
         },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
         auth: { scope: ['courses:edit'] },
       },
       handler: update,
@@ -97,7 +96,7 @@ exports.plugin = {
             type: Joi.string().required().valid(...MESSAGE_TYPE),
           }).required(),
         },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
       },
       handler: sendSMS,
     });
@@ -110,7 +109,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId() }),
         },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
       },
       handler: getSMSHistory,
     });
@@ -130,7 +129,7 @@ exports.plugin = {
             company: Joi.objectId().required(),
           }),
         },
-        pre: [{ method: getCourseTrainee, assign: 'trainee' }, { method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: getCourseTrainee, assign: 'trainee' }, { method: authorizeCourseEdit }],
         auth: { scope: ['courses:edit'] },
       },
       handler: addTrainee,
@@ -141,7 +140,7 @@ exports.plugin = {
       path: '/{_id}/trainees/{traineeId}',
       options: {
         auth: { scope: ['courses:edit'] },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
       },
       handler: removeTrainee,
     });
@@ -151,7 +150,7 @@ exports.plugin = {
       path: '/{_id}/attendance-sheets',
       options: {
         auth: { scope: ['courses:edit'] },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
       },
       handler: downloadAttendanceSheets,
     });
@@ -161,7 +160,7 @@ exports.plugin = {
       path: '/{_id}/completion-certificates',
       options: {
         auth: { scope: ['courses:edit'] },
-        pre: [{ method: authorizeCourseGetOrUpdate }],
+        pre: [{ method: authorizeCourseEdit }],
       },
       handler: downloadCompletionCertificates,
     });

--- a/src/routes/preHandlers/courseSlot.js
+++ b/src/routes/preHandlers/courseSlot.js
@@ -3,7 +3,8 @@ const get = require('lodash/get');
 const CourseSlot = require('../../models/CourseSlot');
 const Course = require('../../models/Course');
 const translate = require('../../helpers/translate');
-const { TRAINER } = require('../../helpers/constants');
+const { TRAINER, VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER, CLIENT_ADMIN, COACH } =
+  require('../../helpers/constants');
 
 const { language } = translate;
 
@@ -21,9 +22,23 @@ exports.getCourseSlot = async (req) => {
 
 const checkAuthorization = async (courseId, credentials) => {
   const course = await Course.findById(courseId).lean();
+  if (!course) throw Boom.notFound();
 
-  const userRole = get(credentials, 'role.vendor.name');
-  if (userRole === TRAINER && course.trainer.toHexString() !== credentials._id) throw Boom.forbidden();
+  const courseTrainerId = course.trainer ? course.trainer.toHexString() : undefined;
+  const courseCompanyId = course.company ? course.company.toHexString() : undefined;
+
+  const userVendorRole = get(credentials, 'role.vendor.name');
+  const userClientRole = get(credentials, 'role.client.name');
+  const userCompanyId = credentials.company ? credentials.company._id.toHexString() : undefined;
+  const userId = get(credentials, '_id');
+
+  const isAdminVendor = userVendorRole === VENDOR_ADMIN;
+  const isTOM = userVendorRole === TRAINING_ORGANISATION_MANAGER;
+  const isTrainerAndAuthorized = userVendorRole === TRAINER && userId === courseTrainerId;
+  const isClientAndAuthorized = (userClientRole === CLIENT_ADMIN || userClientRole === COACH)
+    && userCompanyId === courseCompanyId;
+
+  if (!isAdminVendor && !isTOM && !isTrainerAndAuthorized && !isClientAndAuthorized) throw Boom.forbidden();
 };
 
 exports.authorizeCreate = async (req) => {

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -15,11 +15,11 @@ const translate = require('../../helpers/translate');
 
 const { language } = translate;
 
-const checkAuthorization = async (courseTrainerId, courseCompanyId, credentials) => {
+exports.checkAuthorization = (courseTrainerId, courseCompanyId, credentials) => {
   const userVendorRole = get(credentials, 'role.vendor.name');
   const userClientRole = get(credentials, 'role.client.name');
-  const userCompanyId = credentials.company ? credentials.company._id.toHexString() : undefined;
-  const userId = credentials._id;
+  const userCompanyId = credentials.company ? credentials.company._id.toHexString() : null;
+  const userId = get(credentials, '_id');
 
   const isAdminVendor = userVendorRole === VENDOR_ADMIN;
   const isTOM = userVendorRole === TRAINING_ORGANISATION_MANAGER;
@@ -36,9 +36,9 @@ exports.authorizeCourseEdit = async (req) => {
     const course = await Course.findOne({ _id: req.params._id }).lean();
     if (!course) throw Boom.notFound();
 
-    const courseTrainerId = course.trainer ? course.trainer.toHexString() : undefined;
-    const courseCompanyId = course.company ? course.company.toHexString() : undefined;
-    await checkAuthorization(courseTrainerId, courseCompanyId, credentials);
+    const courseTrainerId = course.trainer ? course.trainer.toHexString() : null;
+    const courseCompanyId = course.company ? course.company.toHexString() : null;
+    this.checkAuthorization(courseTrainerId, courseCompanyId, credentials);
 
     return null;
   } catch (e) {
@@ -52,7 +52,7 @@ exports.authorizeGetCourseList = async (req) => {
 
   const courseTrainerId = get(req, 'query.trainer');
   const courseCompanyId = get(req, 'query.company');
-  await checkAuthorization(courseTrainerId, courseCompanyId, credentials);
+  this.checkAuthorization(courseTrainerId, courseCompanyId, credentials);
 
   return null;
 };

--- a/tests/integration/courseSlots.test.js
+++ b/tests/integration/courseSlots.test.js
@@ -126,12 +126,46 @@ describe('COURSE SLOTS ROUTES - POST /courseslots', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should return 200 as user is client admin from course company', async () => {
+      const payload = {
+        startDate: '2020-03-04T09:00:00',
+        endDate: '2020-03-04T11:00:00',
+        courseId: coursesList[0]._id,
+      };
+      token = await getToken('client_admin');
+      const response = await app.inject({
+        method: 'POST',
+        url: '/courseslots',
+        headers: { 'x-access-token': token },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 200 as user is coach from course company', async () => {
+      const payload = {
+        startDate: '2020-03-04T09:00:00',
+        endDate: '2020-03-04T11:00:00',
+        courseId: coursesList[0]._id,
+      };
+      token = await getToken('coach');
+      const response = await app.inject({
+        method: 'POST',
+        url: '/courseslots',
+        headers: { 'x-access-token': token },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         const payload = {
           startDate: '2020-03-04T09:00:00',
           endDate: '2020-03-04T11:00:00',
-          courseId: coursesList[0]._id,
+          courseId: coursesList[1]._id,
         };
         token = await getToken(role.name);
         const response = await app.inject({
@@ -232,13 +266,26 @@ describe('COURSE SLOTS ROUTES - PUT /courseslots/{_id}', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should return 200 as user is client admin from course company', async () => {
+      token = await getToken('client_admin');
+      const payload = { startDate: '2020-03-04T09:00:00', endDate: '2020-03-04T11:00:00' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/courseslots/${courseSlotsList[0]._id}`,
+        headers: { 'x-access-token': token },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         const payload = { startDate: '2020-03-04T09:00:00', endDate: '2020-03-04T11:00:00' };
         token = await getToken(role.name);
         const response = await app.inject({
           method: 'PUT',
-          url: `/courseslots/${courseSlotsList[0]._id}`,
+          url: `/courseslots/${courseSlotsList[3]._id}`,
           headers: { 'x-access-token': token },
           payload,
         });
@@ -301,12 +348,23 @@ describe('COURSES ROUTES - DELETE /courses/{_id}', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should return 200 as user is client admin from course company', async () => {
+      token = await getToken('client_admin');
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/courseslots/${courseSlotsList[0]._id}`,
+        headers: { 'x-access-token': token },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         token = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
-          url: `/courseslots/${courseSlotsList[0]._id}`,
+          url: `/courseslots/${courseSlotsList[3]._id}`,
           headers: { 'x-access-token': token },
         });
 

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -202,30 +202,6 @@ describe('COURSES ROUTES - GET /courses/{_id}', () => {
     expect(response.statusCode).toBe(200);
     expect(response.result.data.course._id).toEqual(courseIdFromAuthCompany);
   });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 200 },
-      { name: 'auxiliary', expectedCode: 200 },
-      { name: 'auxiliary_without_company', expectedCode: 200 },
-      { name: 'coach', expectedCode: 200 },
-      { name: 'client_admin', expectedCode: 200 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 200 },
-    ];
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const response = await app.inject({
-          method: 'GET',
-          url: `/courses/${courseIdFromOtherCompany.toHexString()}`,
-          headers: { 'x-access-token': authToken },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
 });
 
 describe('COURSES ROUTES - PUT /courses/{_id}', () => {

--- a/tests/integration/seed/courseSlotsSeed.js
+++ b/tests/integration/seed/courseSlotsSeed.js
@@ -58,6 +58,12 @@ const courseSlotsList = [
     endDate: '2020-03-10T12:00:00',
     courseId: coursesList[1]._id,
   },
+  {
+    _id: new ObjectID(),
+    startDate: '2020-04-10T09:00:00',
+    endDate: '2020-04-10T12:00:00',
+    courseId: coursesList[1]._id,
+  },
 ];
 
 const populateDB = async () => {

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -29,7 +29,7 @@ const trainee = {
   inactivityDate: null,
 };
 
-const trainer = {
+const courseTrainer = {
   _id: new ObjectID(),
   identity: { firstname: 'trainer', lastname: 'trainer' },
   refreshToken: uuidv4(),
@@ -49,7 +49,7 @@ const coursesList = [
     name: 'first session',
     program: programsList[0]._id,
     company: authCompany._id,
-    trainer: trainer._id,
+    trainer: courseTrainer._id,
     type: 'intra',
   },
   {
@@ -65,7 +65,7 @@ const coursesList = [
     name: 'second session',
     program: programsList[0]._id,
     company: authCompany._id,
-    trainer: trainer._id,
+    trainer: courseTrainer._id,
     type: 'intra',
     trainees: [trainee._id],
   },
@@ -114,7 +114,7 @@ const populateDB = async () => {
   await Program.insertMany(programsList);
   await Course.insertMany(coursesList);
   await CourseSlot.insertMany(slots);
-  await User.create([auxiliary, trainee, trainer]);
+  await User.create([auxiliary, trainee, courseTrainer]);
   await CourseSmsHistory.create(courseSmsHistory);
 };
 
@@ -125,5 +125,5 @@ module.exports = {
   auxiliary,
   trainee,
   courseSmsHistory,
-  trainer,
+  courseTrainer,
 };

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -71,6 +71,15 @@ const coursesList = [
   },
   {
     _id: new ObjectID(),
+    name: 'second team formation',
+    program: programsList[0]._id,
+    company: otherCompany._id,
+    trainer: new ObjectID(),
+    type: 'intra',
+    trainees: [trainee._id],
+  },
+  {
+    _id: new ObjectID(),
     name: 'inter b2b session',
     program: programsList[0]._id,
     type: 'inter_b2b',
@@ -90,6 +99,7 @@ const slots = [
   { startDate: '2020-03-20T14:00:00', endDate: '2020-03-20T18:00:00', courseId: coursesList[0] },
   { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00', courseId: coursesList[1] },
   { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00', courseId: coursesList[2] },
+  { startDate: '2020-03-20T09:00:00', endDate: '2020-03-20T11:00:00', courseId: coursesList[3] },
 ];
 
 const populateDB = async () => {

--- a/tests/seed/roleSeed.js
+++ b/tests/seed/roleSeed.js
@@ -149,6 +149,7 @@ const clientAdminRights = [
   'establishments:read',
   'sms:send',
   'courses:read',
+  'courses:edit',
 ];
 const coachRights = [
   'config:read',
@@ -172,6 +173,7 @@ const coachRights = [
   'establishments:read',
   'sms:send',
   'courses:read',
+  'courses:edit',
 ];
 const auxiliaryRights = [
   'config:read',


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : coach / client_admin

- Cas d'usage : en tant que coach/admin, je peux lire et editer les infos d'une formations de ma structure

> note : pour les test d'integration courses.test.js : 
     - j'ai fait un essai (dans la boucle des 'other roles') pour preciser qu'on essaie avec une structure differentes de celle de l'utilisateur.ice. Je suis pas très satisfait de se que j'ai fait ( rajouter la 'situation') dites moi si vous en pensez 
     - je teste une fois avec les deux roles, puis ensuite que avec clien_admin, ça vous parait bien ?
