### PR TITLE
COM-1274 select only events within contract in draftPay

### DIFF
--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -274,9 +274,10 @@ exports.getPayFromAbsences = (absences, contract, query) => {
   let hours = 0;
   for (const absence of absences) {
     if (absence.absenceNature === DAILY) {
-      const start = moment.max(moment(absence.startDate).startOf('d'), moment(query.startDate));
-      const end = moment.min(moment(absence.endDate), moment(query.endDate));
+      const start = moment.max(moment(absence.startDate).startOf('d'), moment(query.startDate), moment(contract.startDate));
+      const end = moment.min(moment(absence.endDate), moment(query.endDate), moment(contract.endDate));
       const range = Array.from(moment().range(start, end).by('days'));
+
       for (const day of range) {
         if (day.startOf('d').isBusinessDay()) { // startOf('day') is necessery to check fr holidays in business day
           const version = contract.versions.length === 1 ? contract.versions[0] : UtilsHelper.getMatchingVersion(day, contract, 'startDate');
@@ -304,8 +305,27 @@ exports.getContract = (contracts, endDate) => contracts.find((cont) => {
 
 exports.computeBalance = async (auxiliary, contract, eventsToPay, company, query, distanceMatrix, surcharges) => {
   const contractInfo = exports.getContractMonthInfo(contract, query);
-  const hours = await exports.getPayFromEvents(eventsToPay.events, auxiliary, distanceMatrix, surcharges, query);
-  const absencesHours = exports.getPayFromAbsences(eventsToPay.absences, contract, query);
+
+  const contractEvents = eventsToPay.events.filter((eventsPerDay) => {
+    if (!eventsPerDay.length) return false;
+    const firstEvent = eventsPerDay[0];
+    const isEventBeforeContractEnd = !contract.endDate || moment(contract.endDate).isSameOrAfter(firstEvent.start);
+    const isEventAfterContractStart = moment(contract.startDate).isSameOrBefore(firstEvent.startDate);
+
+    return isEventBeforeContractEnd && isEventAfterContractStart;
+  });
+  const hours = await exports.getPayFromEvents(contractEvents, auxiliary, distanceMatrix, surcharges, query);
+
+  const contractAbsences = eventsToPay.absences.filter((absence) => {
+    const isAbsenceEndsInContractRange = (!contract.endDate && moment(absence.endDate).isAfter(contract.startDate)) ||
+      moment(absence.endDate).isBetween(contract.startDate, contract.endDate, 'days', '[]');
+    const isContractStartsInAbsenceRange = moment(contract.startDate)
+      .isBetween(absence.startDate, absence.endDate, 'days', '[]');
+
+    return isAbsenceEndsInContractRange || isContractStartsInAbsenceRange;
+  });
+  const absencesHours = exports.getPayFromAbsences(contractAbsences, contract, query);
+
   const hoursToWork = Math.max(contractInfo.contractHours - contractInfo.holidaysHours - absencesHours, 0);
   const hoursBalance = hours.workedHours - hoursToWork;
 

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -309,8 +309,8 @@ exports.computeBalance = async (auxiliary, contract, eventsToPay, company, query
   const contractEvents = eventsToPay.events.filter((eventsPerDay) => {
     if (!eventsPerDay.length) return false;
     const firstEvent = eventsPerDay[0];
-    const isEventBeforeContractEnd = !contract.endDate || moment(contract.endDate).isSameOrAfter(firstEvent.start);
-    const isEventAfterContractStart = moment(contract.startDate).isSameOrBefore(firstEvent.startDate);
+    const isEventBeforeContractEnd = !contract.endDate || moment(firstEvent.startDate).isBefore(contract.endDate);
+    const isEventAfterContractStart = moment(firstEvent.startDate).isAfter(contract.startDate);
 
     return isEventBeforeContractEnd && isEventAfterContractStart;
   });

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -315,12 +315,11 @@ const filterEvents = (eventsToPay, contract) => eventsToPay.events.filter((event
 
 
 const filterAbsences = (eventsToPay, contract) => eventsToPay.absences.filter((absence) => {
-  const isAbsenceEndInContractRange = (!contract.endDate && moment(absence.endDate).isAfter(contract.startDate)) ||
-    moment(absence.endDate).isBetween(contract.startDate, contract.endDate, 'days', '[]');
-  const isContractStartInAbsenceRange = moment(contract.startDate)
-    .isBetween(absence.startDate, absence.endDate, 'days', '[]');
+  const isAbsenceStartBeforeContractEnd = !contract.endDate
+    || moment(absence.startDate).isBefore(contract.endDate);
+  const isAbsenceEndAfterContractStart = moment(absence.endDate).isAfter(contract.startDate);
 
-  return isAbsenceEndInContractRange || isContractStartInAbsenceRange;
+  return isAbsenceStartBeforeContractEnd && isAbsenceEndAfterContractStart;
 });
 
 exports.computeBalance = async (auxiliary, contract, eventsToPay, company, query, distanceMatrix, surcharges) => {

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1231,7 +1231,7 @@ describe('getPayFromAbsences', () => {
       ];
       const contract = {
         startDate: '2019-02-18T07:00:00',
-        endDate: '2019-07-18T22:00:00', 
+        endDate: '2019-07-18T22:00:00',
         versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
       };
 
@@ -1244,13 +1244,13 @@ describe('getPayFromAbsences', () => {
     });
   });
 
-  describe('contract begin or end during this month', () => {
+  describe('contract begins or ends during this month', () => {
     it('contract begins in middle of absence', () => {
       const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
       const absences = [
         { absenceNature: 'daily', startDate: '2019-05-02T07:00:00', endDate: '2019-05-06T22:00:00' },
       ];
-      const contract = { startDate: '2019-05-03T07:00:00', endDate: '2019-07-18T22:00:00', versions: [{ weeklyHours: 12 }] };
+      const contract = { startDate: '2019-05-03T07:00:00', versions: [{ weeklyHours: 12 }] };
 
       const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
 
@@ -1273,7 +1273,7 @@ describe('getPayFromAbsences', () => {
       sinon.assert.notCalled(getMatchingVersion);
     });
 
-    it('contract ends during an entire month af absence', () => {
+    it('contract ends during an entire month of absence', () => {
       const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
       const absences = [
         { absenceNature: 'daily', startDate: '2019-03-02T10:00:00', endDate: '2019-06-18T12:00:00' },


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : refacto du calcul des evenements, on attribut au contrat en cours a la fin du mois uniquement les évènements qui lui correspondent
