### PR TITLE
COM-1300 in attendance sheet add program name to course title

### DIFF
--- a/src/data/attendanceSheet.html
+++ b/src/data/attendanceSheet.html
@@ -105,8 +105,7 @@
       </div>
       <div class="course-info margin-bottom">
         <div style="width: 500px">
-          <div style="font-weight: bold">Nom de la formation : {{ course.name }}</div>
-          <div>Programme : {{ course.programName }}</div>
+          <div style="font-weight: bold">Nom de la formation : {{ course.programName }} - {{ course.name }}</div>
           <div>Dates : du {{ course.firstDate }} au {{ course.lastDate }}</div>
           <div>Durée : {{ course.duration }}</div>
           <div>Structure : {{ company }}</div>

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -139,7 +139,6 @@ exports.generateAttendanceSheets = async (courseId) => {
 };
 
 exports.formatCourseForDocx = course => ({
-  name: course.name,
   duration: exports.getCourseDuration(course.slots),
   learningGoals: get(course, 'program.learningGoals') || '',
   programName: get(course, 'program.name').toUpperCase() || '',

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -526,7 +526,6 @@ describe('formatCourseForDocx', () => {
         { startDate: '2020-04-12T09:00:00', endDate: '2020-04-12T11:30:00' },
         { startDate: '2020-04-21T09:00:00', endDate: '2020-04-21T11:30:00' },
       ],
-      name: 'Bonjour je suis une formation',
       program: { learningGoals: 'Apprendre', name: 'nom du programme' },
     };
     getCourseDuration.returns('7h');
@@ -534,7 +533,6 @@ describe('formatCourseForDocx', () => {
     const result = CourseHelper.formatCourseForDocx(course);
 
     expect(result).toEqual({
-      name: 'Bonjour je suis une formation',
       duration: '7h',
       learningGoals: course.program.learningGoals,
       startDate: '20/03/2020',
@@ -591,7 +589,7 @@ describe('generateCompletionCertificate', () => {
       ],
       name: 'Bonjour je suis une formation',
     };
-    const formattedCourse = { courseName: 'Bonjour je suis une formation', courseDuration: '8h' };
+    const formattedCourse = { program: { learningGoals: 'Apprendre', name: 'nom du programme' }, courseDuration: '8h' };
     CourseMock.expects('findOne')
       .withExactArgs({ _id: courseId })
       .chain('populate')


### PR DESCRIPTION
- [ ] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendeur

- Périmetre roles : admin

- Cas d'usage : - pour l'attestation de fin de stage, mofication du template (gdrive) pour enlever le course.name et ne garder que course.programName.
- pour les feuilles de présence, ajout du nom du programme au titre de la formation
