### PR TITLE
COM-1249 change column order in historyExport/absence

### DIFF
--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -106,14 +106,14 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
 };
 
 const absenceExportHeader = [
+  'Auxiliaire - Prénom',
+  'Auxiliaire - Nom',
+  'Auxiliaire - Titre',
+  'Équipe',
   'Type',
   'Nature',
   'Début',
   'Fin',
-  'Équipe',
-  'Auxiliaire - Titre',
-  'Auxiliaire - Prénom',
-  'Auxiliaire - Nom',
   'Divers',
 ];
 
@@ -124,14 +124,14 @@ exports.exportAbsencesHistory = async (startDate, endDate, credentials) => {
   for (const event of events) {
     const datetimeFormat = event.absenceNature === HOURLY ? 'DD/MM/YYYY HH:mm' : 'DD/MM/YYYY';
     const cells = [
+      get(event, 'auxiliary.identity.firstname', ''),
+      get(event, 'auxiliary.identity.lastname', '').toUpperCase(),
+      CIVILITY_LIST[get(event, 'auxiliary.identity.title')] || '',
+      get(event, 'auxiliary.sector.name') || '',
       ABSENCE_TYPE_LIST[event.absence],
       ABSENCE_NATURE_LIST[event.absenceNature],
       moment(event.startDate).format(datetimeFormat),
       moment(event.endDate).format(datetimeFormat),
-      get(event, 'auxiliary.sector.name') || '',
-      CIVILITY_LIST[get(event, 'auxiliary.identity.title')] || '',
-      get(event, 'auxiliary.identity.firstname', ''),
-      get(event, 'auxiliary.identity.lastname', '').toUpperCase(),
       event.misc || '',
     ];
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -105,9 +105,9 @@ describe('EXPORTS ROUTES', () => {
         expect(response.result).toBeDefined();
         const rows = response.result.split('\r\n');
         expect(rows.length).toBe(3);
-        expect(rows[0]).toEqual('\ufeff"Type";"Nature";"Début";"Fin";"Équipe";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Divers"');
-        expect(rows[1]).toEqual('"Congé";"Journalière";"19/01/2019";"21/01/2019";"Etoile";"M.";"Lulu";"LALA";');
-        expect(rows[2]).toEqual('"Absence injustifiée";"Horaire";"19/01/2019 15:00";"19/01/2019 17:00";"Etoile";"M.";"Lulu";"LALA";"test absence"');
+        expect(rows[0]).toEqual('\ufeff"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Divers"');
+        expect(rows[1]).toEqual('"Lulu";"LALA";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";');
+        expect(rows[2]).toEqual('"Lulu";"LALA";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 15:00";"19/01/2019 17:00";"test absence"');
       });
     });
 

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -139,14 +139,14 @@ describe('exportWorkingEventsHistory', () => {
 
 describe('exportAbsencesHistory', () => {
   const header = [
+    'Auxiliaire - Prénom',
+    'Auxiliaire - Nom',
+    'Auxiliaire - Titre',
+    'Équipe',
     'Type',
     'Nature',
     'Début',
     'Fin',
-    'Équipe',
-    'Auxiliaire - Titre',
-    'Auxiliaire - Prénom',
-    'Auxiliaire - Nom',
     'Divers',
   ];
   const events = [
@@ -199,9 +199,8 @@ describe('exportAbsencesHistory', () => {
 
     expect(exportArray).toEqual([
       header,
-      ['Absence injustifiée', 'Horaire', '20/05/2019 08:00', '20/05/2019 10:00', 'Girafes - 75', '',
-        'Jean-Claude', 'VAN DAMME', ''],
-      ['Congé', 'Journalière', '20/05/2019', '20/05/2019', 'Etoiles - 75', '', 'Princess', 'CAROLYN', 'brbr'],
+      ['Jean-Claude', 'VAN DAMME', '', 'Girafes - 75', 'Absence injustifiée', 'Horaire', '20/05/2019 08:00', '20/05/2019 10:00', ''],
+      ['Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé', 'Journalière', '20/05/2019', '20/05/2019', 'brbr'],
     ]);
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : mettre nom/prénom en premier dans l'export des absences.
