### PR TITLE
COM-1320 - organise repetitions

### DIFF
--- a/src/controllers/scriptController.js
+++ b/src/controllers/scriptController.js
@@ -18,7 +18,7 @@ const eventRepetitionsScript = async (req) => {
   try {
     const job = await eventRepetitions.method(req);
 
-    return { message: `Event repetitions: ${job.results.length} évènements créés.`, data: job };
+    return { message: `Event repetitions: ${job ? job.results.length : 0} évènements créés.`, data: job };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -194,7 +194,7 @@ exports.deleteRepetition = async (event, credentials) => {
   return event;
 };
 
-exports.createFutureEventBasedOnRepetition = async (repetition, date) => {
+exports.formatEventBasedOnRepetition = async (repetition, date) => {
   const { frequency, parentId, startDate, endDate } = repetition;
   const startDateObj = moment(startDate).toObject();
   const endDateObj = moment(endDate).toObject();

--- a/src/jobs/eventRepetitions.js
+++ b/src/jobs/eventRepetitions.js
@@ -1,63 +1,87 @@
+/* eslint-disable no-loop-func */
 const moment = require('moment');
 const pick = require('lodash/pick');
 const get = require('lodash/get');
 const Repetition = require('../models/Repetition');
 const Company = require('../models/Company');
 const Event = require('../models/Event');
-const { EVERY_WEEK, EVERY_DAY, EVERY_WEEK_DAY, EVERY_TWO_WEEKS } = require('../helpers/constants');
+const {
+  EVERY_WEEK,
+  EVERY_DAY,
+  EVERY_WEEK_DAY,
+  EVERY_TWO_WEEKS,
+  INTERNAL_HOUR,
+  UNAVAILABILITY,
+  INTERVENTION,
+} = require('../helpers/constants');
 const EventsRepetitionHelper = require('../helpers/eventsRepetition');
 const EmailHelper = require('../helpers/email');
+
+const createEventBasedOnRepetition = async (repetition, date) => {
+  const { startDate, frequency } = repetition;
+  const newEventStartDate = moment(date).add(90, 'd')
+    .set(pick(moment(startDate).toObject(), ['hours', 'minutes', 'seconds', 'milliseconds']));
+  let futureEvent;
+  switch (frequency) {
+    case EVERY_TWO_WEEKS:
+      if (moment(startDate).day() === moment(newEventStartDate).day()
+          && (newEventStartDate.diff(moment(startDate), 'week') % 2 === 0)) {
+        futureEvent = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, date);
+      }
+      break;
+    case EVERY_WEEK:
+      if (moment(startDate).day() === newEventStartDate.day()) {
+        futureEvent = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, date);
+      }
+      break;
+    case EVERY_DAY:
+      futureEvent = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, date);
+      break;
+    case EVERY_WEEK_DAY:
+      if (newEventStartDate.day() !== 0 && newEventStartDate.day() !== 6) {
+        futureEvent = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, date);
+      }
+      break;
+  }
+
+  if (!futureEvent) return null;
+  return Event.create(futureEvent);
+};
 
 const eventRepetitions = {
   async method(server) {
     const date = get(server, 'query.date') || new Date();
     const errors = [];
     const companies = await Company.find({}).lean();
+    const newSavedEvents = [];
+
     for (const company of companies) {
       const repetitions = await Repetition
-        .find({ company: company._id, startDate: { $lt: moment(date).startOf('d').toDate() } }).lean();
-      if (!repetitions.length) return server.log(['cron', 'jobs'], 'Event repetitions: No repetitions found.');
+        .find({ company: company._id, startDate: { $lt: moment(date).startOf('d').toDate() } })
+        .lean();
+      if (!repetitions.length) {
+        server.log(['cron', 'jobs'], 'Event repetitions: No repetitions found.');
+        continue;
+      }
 
-      const newSavedEvents = [];
-      for (const repetition of repetitions) {
-        const { startDate, frequency } = repetition;
-        const newEventStartDate = moment(date).add(90, 'd')
-          .set(pick(moment(startDate).toObject(), ['hours', 'minutes', 'seconds', 'milliseconds']));
-        let futureEvent;
+      const orderedRepetitions = [ // order matters
+        ...repetitions.filter(rep => rep.type === UNAVAILABILITY),
+        ...repetitions.filter(rep => rep.type === INTERNAL_HOUR),
+        ...repetitions.filter(rep => rep.type === INTERVENTION),
+      ];
+
+      for (const repetition of orderedRepetitions) {
         try {
-          switch (frequency) {
-            case EVERY_TWO_WEEKS:
-              if (moment(startDate).day() === moment(newEventStartDate).day()
-                && (newEventStartDate.diff(moment(startDate), 'week') % 2 === 0)) {
-                futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, date);
-              }
-              break;
-            case EVERY_WEEK:
-              if (moment(startDate).day() === newEventStartDate.day()) {
-                futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, date);
-              }
-              break;
-            case EVERY_DAY:
-              futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, date);
-              break;
-            case EVERY_WEEK_DAY:
-              if (newEventStartDate.day() !== 0 && newEventStartDate.day() !== 6) {
-                futureEvent = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, date);
-              }
-              break;
-          }
-          if (futureEvent) {
-            const createdEvent = await Event.create(futureEvent);
-            newSavedEvents.push(createdEvent);
-          }
+          const futureEvent = await createEventBasedOnRepetition(repetition, date);
+          if (futureEvent) newSavedEvents.push(futureEvent);
         } catch (e) {
           server.log(['error', 'cron', 'jobs'], e);
           errors.push(repetition._id);
         }
       }
-
-      return { results: newSavedEvents, errors };
     }
+
+    return { results: newSavedEvents, errors };
   },
   async onComplete(server, { results, errors }) {
     try {

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -593,7 +593,7 @@ describe('deleteRepetition', () => {
   });
 });
 
-describe('createFutureEventBasedOnRepetition', () => {
+describe('formatEventBasedOnRepetition', () => {
   let hasConflicts;
   let UserMock;
   beforeEach(() => {
@@ -629,7 +629,7 @@ describe('createFutureEventBasedOnRepetition', () => {
     hasConflicts.returns(false);
     UserMock.expects('findOne').never();
 
-    const event = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, new Date());
+    const event = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, new Date());
 
     expect(event.toObject()).toEqual(expect.objectContaining({
       ...omit(repetition, ['frequency', 'parentId', 'startDate', 'endDate']),
@@ -658,7 +658,7 @@ describe('createFutureEventBasedOnRepetition', () => {
     hasConflicts.returns(true);
     UserMock.expects('findOne').never();
 
-    const event = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, new Date());
+    const event = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, new Date());
 
     expect(event).toBeNull();
     UserMock.verify();
@@ -696,7 +696,7 @@ describe('createFutureEventBasedOnRepetition', () => {
       .once()
       .returns({ _id: repetition.auxiliary, sector: sectorId });
 
-    const event = await EventsRepetitionHelper.createFutureEventBasedOnRepetition(repetition, '2020-03-11T00:00:00');
+    const event = await EventsRepetitionHelper.formatEventBasedOnRepetition(repetition, '2020-03-11T00:00:00');
 
 
     expect(event.toObject()).toEqual(expect.objectContaining({

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -15,7 +15,7 @@ describe('method', () => {
   let EventMock;
   let RepetitionMock;
   let CompanyMock;
-  let CreateFutureEventBasedOnRepetitionStub;
+  let formatEventBasedOnRepetitionStub;
   let EmailHelperStub;
   let date;
   const fakeDate = moment('2019-09-20').startOf('d').toDate();
@@ -23,7 +23,7 @@ describe('method', () => {
     RepetitionMock = sinon.mock(Repetition);
     CompanyMock = sinon.mock(Company);
     EventMock = sinon.mock(Event);
-    CreateFutureEventBasedOnRepetitionStub = sinon.stub(EventsRepetitionHelper, 'createFutureEventBasedOnRepetition');
+    formatEventBasedOnRepetitionStub = sinon.stub(EventsRepetitionHelper, 'formatEventBasedOnRepetition');
     EmailHelperStub = sinon.stub(EmailHelper, 'completeEventRepScriptEmail');
     date = sinon.useFakeTimers(fakeDate);
   });
@@ -31,7 +31,7 @@ describe('method', () => {
     EventMock.restore();
     RepetitionMock.restore();
     CompanyMock.restore();
-    CreateFutureEventBasedOnRepetitionStub.restore();
+    formatEventBasedOnRepetitionStub.restore();
     EmailHelperStub.restore();
     date.restore();
   });
@@ -87,7 +87,7 @@ describe('method', () => {
           parentId: '5d84f869b7e67963c65236a9',
         },
       });
-      CreateFutureEventBasedOnRepetitionStub.returns(futureEvent);
+      formatEventBasedOnRepetitionStub.returns(futureEvent);
       EventMock.expects('create')
         .withArgs(futureEvent)
         .once()
@@ -96,7 +96,7 @@ describe('method', () => {
       const result = await eventRepetitions.method(server);
 
       expect(result).toMatchObject({ results: [futureEvent], errors: [] });
-      sinon.assert.calledWith(CreateFutureEventBasedOnRepetitionStub, repetition[0], new Date());
+      sinon.assert.calledWith(formatEventBasedOnRepetitionStub, repetition[0], new Date());
       RepetitionMock.verify();
       EventMock.verify();
       CompanyMock.verify();
@@ -135,7 +135,7 @@ describe('method', () => {
       .once()
       .returns(repetition);
 
-    CreateFutureEventBasedOnRepetitionStub.returns(Promise.reject(error));
+    formatEventBasedOnRepetitionStub.returns(Promise.reject(error));
 
     const result = await eventRepetitions.method(server);
 

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -19,6 +19,8 @@ describe('method', () => {
   let EmailHelperStub;
   let date;
   const fakeDate = moment('2019-09-20').startOf('d').toDate();
+  const server = { log: (tags, text) => `${tags}, ${text}` };
+  let serverLogStub;
   beforeEach(() => {
     RepetitionMock = sinon.mock(Repetition);
     CompanyMock = sinon.mock(Company);
@@ -26,6 +28,7 @@ describe('method', () => {
     formatEventBasedOnRepetitionStub = sinon.stub(EventsRepetitionHelper, 'formatEventBasedOnRepetition');
     EmailHelperStub = sinon.stub(EmailHelper, 'completeEventRepScriptEmail');
     date = sinon.useFakeTimers(fakeDate);
+    serverLogStub = sinon.stub(server, 'log');
   });
   afterEach(() => {
     EventMock.restore();
@@ -34,6 +37,7 @@ describe('method', () => {
     formatEventBasedOnRepetitionStub.restore();
     EmailHelperStub.restore();
     date.restore();
+    serverLogStub.restore();
   });
 
   const frequencies = [
@@ -58,11 +62,10 @@ describe('method', () => {
     }];
 
     it(`should create a J+90 event for ${freq.type} repetition object`, async () => {
-      const server = 'server';
       const companyId = new ObjectID();
 
       CompanyMock.expects('find')
-        .withExactArgs({})
+        .withExactArgs({ 'subscriptions.erp': true })
         .chain('lean')
         .once()
         .returns([{ _id: companyId }]);
@@ -104,8 +107,6 @@ describe('method', () => {
   });
 
   it('should log repetitions ids which failed to create J+90 event', async () => {
-    const server = { log: (tags, text) => `${tags}, ${text}` };
-    const serverLogStub = sinon.stub(server, 'log');
     const error = new Error('Test error.');
     const repetition = [{
       _id: '5d84f869b7e67963c6523704',
@@ -123,7 +124,7 @@ describe('method', () => {
 
     const companyId = new ObjectID();
     CompanyMock.expects('find')
-      .withExactArgs({})
+      .withExactArgs({ 'subscriptions.erp': true })
       .chain('lean')
       .once()
       .returns([{ _id: companyId }]);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration

- Périmetre interface : 

- Périmetre roles : 

- Cas d'usage : Ajouter un ordre dans la script des repetitions pour que les indispo et les heures internes soient creees avant les interventions
