### PR TITLE
COM-1298-public-infos add specific route for course's public infos

### DIFF
--- a/src/controllers/courseController.js
+++ b/src/controllers/courseController.js
@@ -1,4 +1,5 @@
 const Boom = require('@hapi/boom');
+const get = require('lodash/get');
 const CoursesHelper = require('../helpers/courses');
 const translate = require('../helpers/translate');
 
@@ -35,6 +36,20 @@ const create = async (req) => {
 const getById = async (req) => {
   try {
     const course = await CoursesHelper.getCourse(req.params._id);
+
+    return {
+      message: translate[language].courseFound,
+      data: { course },
+    };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+const getPublicInfosById = async (req) => {
+  try {
+    const course = await CoursesHelper.getCoursePublicInfos(req.params._id);
 
     return {
       message: translate[language].courseFound,
@@ -140,6 +155,7 @@ module.exports = {
   list,
   create,
   getById,
+  getPublicInfosById,
   update,
   addTrainee,
   removeTrainee,

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -16,7 +16,7 @@ const ZipHelper = require('./zip');
 const TwilioHelper = require('./twilio');
 const DocxHelper = require('./docx');
 const drive = require('../models/Google/Drive');
-const { INTRA, INTER_B2B } = require('../helpers/constants');
+const { INTRA, INTER_B2B } = require('./constants');
 
 exports.createCourse = payload => (new Course(payload)).save();
 
@@ -43,15 +43,21 @@ exports.list = async (query) => {
 };
 
 exports.getCourse = async courseId => Course.findOne({ _id: courseId })
-  .populate({ path: 'company', select: '_id name' })
-  .populate({ path: 'program', select: '_id name learningGoals' })
+  .populate({ path: 'company', select: 'name' })
+  .populate({ path: 'program', select: 'name learningGoals' })
   .populate('slots')
   .populate({
     path: 'trainees',
-    select: '_id identity.firstname identity.lastname local.email company contact ',
+    select: 'identity.firstname identity.lastname local.email company contact ',
     populate: { path: 'company', select: 'name' },
   })
-  .populate({ path: 'trainer', select: '_id identity.firstname identity.lastname' })
+  .populate({ path: 'trainer', select: 'identity.firstname identity.lastname' })
+  .lean();
+
+exports.getCoursePublicInfos = async courseId => Course.findOne({ _id: courseId })
+  .populate({ path: 'program', select: 'name learningGoals' })
+  .populate('slots')
+  .populate({ path: 'trainer', select: 'identity.firstname identity.lastname biography' })
   .lean();
 
 exports.updateCourse = async (courseId, payload) =>

--- a/src/repositories/CourseRepository.js
+++ b/src/repositories/CourseRepository.js
@@ -1,9 +1,9 @@
 const Course = require('../models/Course');
 
 exports.findCourseAndPopulate = (query, populateVirtual = false) => Course.find(query)
-  .populate({ path: 'company', select: '_id name' })
-  .populate({ path: 'program', select: '_id name' })
-  .populate({ path: 'slots', select: '_id startDate endDate' })
-  .populate({ path: 'trainer', select: '_id identity.firstname identity.lastname' })
+  .populate({ path: 'company', select: 'name' })
+  .populate({ path: 'program', select: 'name' })
+  .populate({ path: 'slots', select: 'startDate endDate' })
+  .populate({ path: 'trainer', select: 'identity.firstname identity.lastname' })
   .populate({ path: 'trainees', select: 'company', populate: { path: 'company', select: 'name' } })
   .lean({ virtuals: populateVirtual });

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -6,6 +6,7 @@ const {
   list,
   create,
   getById,
+  getPublicInfosById,
   update,
   addTrainee,
   removeTrainee,
@@ -57,9 +58,21 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId() }),
         },
-        auth: { mode: 'optional' },
+        auth: { scope: ['courses:read'] },
       },
       handler: getById,
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/{_id}/public-infos',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId() }),
+        },
+        auth: { mode: 'optional' },
+      },
+      handler: getPublicInfosById,
     });
 
     server.route({

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -95,24 +95,53 @@ describe('getCourse', () => {
     CourseMock.expects('findOne')
       .withExactArgs({ _id: course._id })
       .chain('populate')
-      .withExactArgs({ path: 'company', select: '_id name' })
+      .withExactArgs({ path: 'company', select: 'name' })
       .chain('populate')
-      .withExactArgs({ path: 'program', select: '_id name learningGoals' })
+      .withExactArgs({ path: 'program', select: 'name learningGoals' })
       .chain('populate')
       .withExactArgs('slots')
       .chain('populate')
       .withExactArgs({
         path: 'trainees',
-        select: '_id identity.firstname identity.lastname local.email company contact ',
+        select: 'identity.firstname identity.lastname local.email company contact ',
         populate: { path: 'company', select: 'name' },
       })
       .chain('populate')
-      .withExactArgs({ path: 'trainer', select: '_id identity.firstname identity.lastname' })
+      .withExactArgs({ path: 'trainer', select: 'identity.firstname identity.lastname' })
       .chain('lean')
       .once()
       .returns(course);
 
     const result = await CourseHelper.getCourse(course._id);
+    expect(result).toMatchObject(course);
+  });
+});
+
+describe('getCoursePublicInfos', () => {
+  let CourseMock;
+  beforeEach(() => {
+    CourseMock = sinon.mock(Course);
+  });
+  afterEach(() => {
+    CourseMock.restore();
+  });
+
+  it('should return courses', async () => {
+    const course = { _id: new ObjectID() };
+
+    CourseMock.expects('findOne')
+      .withExactArgs({ _id: course._id })
+      .chain('populate')
+      .withExactArgs({ path: 'program', select: 'name learningGoals' })
+      .chain('populate')
+      .withExactArgs('slots')
+      .chain('populate')
+      .withExactArgs({ path: 'trainer', select: 'identity.firstname identity.lastname biography' })
+      .chain('lean')
+      .once()
+      .returns(course);
+
+    const result = await CourseHelper.getCoursePublicInfos(course._id);
     expect(result).toMatchObject(course);
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : page info formation

- Périmetre roles : tous/ meme sans authentification

- Cas d'usage : nouvelle route pour fournir les infos publics d'une formation sur la page info formation. 
L'ancienne route devient protégée par courses:read. Dans le futur ticket (dont on a parlé en daily) pour proteger les formations intra (et inter sans stagiaire de la structure ?) des utilisateur.ices d'autre structures on pourra rajouter un prehandler a cette route.
