### PR TITLE
COM-736 - remove payments right to coach

### DIFF
--- a/src/data/rights.js
+++ b/src/data/rights.js
@@ -34,7 +34,7 @@ const rights = [
   { permission: 'pay:edit', rolesConcerned: [CLIENT_ADMIN], subscription: ERP, description: 'Edition de la paie' },
   { permission: 'pay:read', rolesConcerned: [CLIENT_ADMIN, COACH, AUXILIARY, PLANNING_REFERENT], subscription: ERP, description: 'Consulter les données de paie' },
   { permission: 'paydocuments:edit', rolesConcerned: [CLIENT_ADMIN, COACH], subscription: ERP, description: 'Editer les documents de paie' },
-  { permission: 'payments:edit', rolesConcerned: [CLIENT_ADMIN, COACH], subscription: ERP, description: 'Editer un paiement' },
+  { permission: 'payments:edit', rolesConcerned: [CLIENT_ADMIN], subscription: ERP, description: 'Editer un paiement' },
   { permission: 'payments:list:create', rolesConcerned: [CLIENT_ADMIN], subscription: ERP, description: 'Creer une liste de paiement' },
   { permission: 'programs:edit', rolesConcerned: [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER], description: 'Editer les programmes' },
   { permission: 'programs:read', rolesConcerned: [VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER], description: 'Consulter les données des programmes' },

--- a/tests/integration/payments.test.js
+++ b/tests/integration/payments.test.js
@@ -142,7 +142,7 @@ describe('PAYMENTS ROUTES - POST /payments', () => {
       { name: 'helper', expectedCode: 403, erp: true },
       { name: 'auxiliary', expectedCode: 403, erp: true },
       { name: 'auxiliary_without_company', expectedCode: 403, erp: true },
-      { name: 'coach', expectedCode: 200, erp: true },
+      { name: 'coach', expectedCode: 403, erp: true },
       { name: 'client_admin', expectedCode: 403, erp: false },
     ];
 
@@ -430,7 +430,7 @@ describe('PAYMENTS ROUTES - PUT /payments/_id', () => {
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },
       { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 200 },
+      { name: 'coach', expectedCode: 403 },
     ];
 
     roles.forEach((role) => {

--- a/tests/unit/helpers/authentication.test.js
+++ b/tests/unit/helpers/authentication.test.js
@@ -233,7 +233,7 @@ describe('validate', () => {
     });
   });
 
-  it('should authenticate trainer', async () => {
+  it('should authenticate a user with coach and trainer role', async () => {
     const userId = new ObjectID();
     const sectorId = new ObjectID();
     const user = {
@@ -291,7 +291,6 @@ describe('validate', () => {
           'exports:read',
           'pay:read',
           'paydocuments:edit',
-          'payments:edit',
           'roles:read',
           'sms:send',
           'taxcertificates:edit',


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Coach

- Cas d'usage : retirer aux coachs la possibilité de créer et modifier des paiements
