### PR TITLE
Com 1276 fix

### DIFF
--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -39,7 +39,6 @@ exports.checkContracts = async (event, user) => {
     return ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate);
   }
 
-  // If the auxiliary is only under customer contract, create internal hours is not allowed
   if (event.type === INTERNAL_HOUR) {
     return ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate);
   }

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -103,8 +103,6 @@ exports.getLearnerList = async credentials =>
 
 exports.getUser = async (userId, credentials) => {
   const user = await User.findOne({ _id: userId })
-    .populate({ path: 'customers', select: 'contracts' })
-    .populate({ path: 'contracts', select: '-__v -createdAt -updatedAt' })
     .populate({
       path: 'sector',
       select: '_id sector',

--- a/src/routes/contracts.js
+++ b/src/routes/contracts.js
@@ -30,7 +30,7 @@ exports.plugin = {
       method: 'GET',
       path: '/',
       options: {
-        auth: { scope: ['contracts:edit', 'user:read-{query.user}', 'customer-{query.customer}'] },
+        auth: { scope: ['contracts:edit', 'user:read-{query.user}'] },
         validate: {
           query: Joi.object().keys({
             user: Joi.objectId(),

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -10,7 +10,7 @@ const Event = require('../../../src/models/Event');
 const { rolesList, getUser } = require('./authenticationSeed');
 const { populateDBForAuthentication, authCompany, otherCompany } = require('./authenticationSeed');
 
-const contractCustomer = {
+const customer = {
   _id: new ObjectID(),
   company: authCompany._id,
   identity: { title: 'mr', firstname: 'Romain', lastname: 'Bardet' },
@@ -401,9 +401,9 @@ const contractEvents = [
     startDate: '2019-01-16T09:30:19.543Z',
     endDate: '2019-01-16T11:30:21.653Z',
     auxiliary: contractUsers[0]._id,
-    customer: contractCustomer._id,
+    customer: customer._id,
     createdAt: '2019-01-15T11:33:14.343Z',
-    subscription: contractCustomer.subscriptions[0]._id,
+    subscription: customer.subscriptions[0]._id,
     address: {
       fullAddress: '37 rue de ponthieu 75008 Paris',
       zipCode: '75008',
@@ -420,9 +420,9 @@ const contractEvents = [
     startDate: '2019-01-17T14:30:19.543Z',
     endDate: '2019-01-17T16:30:19.543Z',
     auxiliary: contractUsers[0]._id,
-    customer: contractCustomer._id,
+    customer: customer._id,
     createdAt: '2019-01-16T14:30:19.543Z',
-    subscription: contractCustomer.subscriptions[0]._id,
+    subscription: customer.subscriptions[0]._id,
     address: {
       fullAddress: '37 rue de ponthieu 75008 Paris',
       zipCode: '75008',
@@ -444,7 +444,7 @@ const populateDB = async () => {
   await populateDBForAuthentication();
   await User.insertMany([...contractUsers, otherContractUser, userFromOtherCompany]);
   await new Sector(sector).save();
-  await new Customer(contractCustomer).save();
+  await new Customer(customer).save();
   await Contract.insertMany([...contractsList, otherContract]);
   await Event.insertMany(contractEvents);
   await SectorHistory.insertMany(sectorHistories);
@@ -454,7 +454,7 @@ module.exports = {
   contractsList,
   populateDB,
   contractUsers,
-  contractCustomer,
+  customer,
   contractEvents,
   otherContract,
   otherContractUser,

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -444,10 +444,6 @@ describe('getUser', () => {
     userMock.expects('findOne')
       .withExactArgs({ _id: userId })
       .chain('populate')
-      .withExactArgs({ path: 'customers', select: 'contracts' })
-      .chain('populate')
-      .withExactArgs({ path: 'contracts', select: '-__v -createdAt -updatedAt' })
-      .chain('populate')
       .withExactArgs({
         path: 'sector',
         select: '_id sector',
@@ -470,10 +466,6 @@ describe('getUser', () => {
       const credentials = { company: { _id: new ObjectID() }, role: { vendor: { _id: new ObjectID() } } };
       userMock.expects('findOne')
         .withExactArgs({ _id: userId })
-        .chain('populate')
-        .withExactArgs({ path: 'customers', select: 'contracts' })
-        .chain('populate')
-        .withExactArgs({ path: 'contracts', select: '-__v -createdAt -updatedAt' })
         .chain('populate')
         .withExactArgs({
           path: 'sector',


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Cas d'usage : 
contractSeed: le customer s'appelle customerContract
Il y a un commentaire a la ligne 42 de eventsValidation a supprimer
suppression du populate contracts dans helpers/users
il y a un test unitaire ‘it should create a new customer contract’
Suppression du droit customer-{_id} dans la route get contracts.