### PR TITLE
COM-1495 get last sector of auxiliary

### DIFF
--- a/src/repositories/StatRepository.js
+++ b/src/repositories/StatRepository.js
@@ -211,7 +211,7 @@ exports.getEventsGroupedByFundingsforAllCustomers = async (fundingsDate, eventsD
         sectors: { $push: '$customer.sector' },
       },
     },
-    { $addFields: { 'customer.sector': { $arrayElemAt: ['$sectors', -1] } } },
+    { $addFields: { 'customer.sector': { $arrayElemAt: ['$sectors', 0] } } },
     { $lookup: { from: 'sectors', as: 'customer.sector', foreignField: '_id', localField: 'customer.sector.sector' } },
     { $unwind: { path: '$customer.sector', preserveNullAndEmptyArrays: true } },
   ];

--- a/tests/integration/seed/statsSeed.js
+++ b/tests/integration/seed/statsSeed.js
@@ -106,6 +106,13 @@ const sectorHistoryList = [{
   sector: sectorList[0]._id,
   company: authCompany._id,
   startDate: '2019-05-12T23:00:00.000+00:00',
+  endDate: '2020-02-12T22:59:00.000+00:00',
+},
+{
+  auxiliary: userList[1]._id,
+  sector: sectorList[1]._id,
+  company: authCompany._id,
+  startDate: '2020-02-12T23:00:00.000+00:00',
 }];
 
 const serviceList = [{

--- a/tests/integration/stat.test.js
+++ b/tests/integration/stat.test.js
@@ -143,7 +143,7 @@ describe('GET /stats/all-customers-fundings-monitoring', () => {
       expect(res.statusCode).toBe(200);
       expect(res.result.data.allCustomersFundingsMonitoring).toEqual(expect.arrayContaining([
         expect.objectContaining({
-          sector: expect.objectContaining({ name: 'Vénus' }),
+          sector: expect.objectContaining({ name: 'Neptune' }),
           customer: expect.objectContaining({ lastname: 'Giscard d\'Estaing' }),
           referent: expect.objectContaining({ firstname: 'Auxiliary', lastname: 'Black' }),
           currentMonthCareHours: 6,


### PR DESCRIPTION
- [ ] Mon code est testé unitairement -np
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : sur la page de suivi des plans d'aide c'est le dernier secteur de l'auxiliaire referent qui s'affiche
