### PR TITLE
COM-1489 fix apa hours when funding has ended

### DIFF
--- a/src/repositories/StatRepository.js
+++ b/src/repositories/StatRepository.js
@@ -154,8 +154,8 @@ exports.getEventsGroupedByFundingsforAllCustomers = async (fundingsDate, eventsD
         'customer.fundings.nature': HOURLY,
         'customer.fundings.version.startDate': { $lte: fundingsDate.maxStartDate },
         $or: [
-          { 'customer.fundings.endDate': { $exists: false } },
-          { 'customer.fundings.endDate': { $exists: true, $gte: fundingsDate.minEndDate } },
+          { 'customer.fundings.version.endDate': { $exists: false } },
+          { 'customer.fundings.version.endDate': { $exists: true, $gte: fundingsDate.minEndDate } },
         ],
       },
     },

--- a/tests/integration/seed/statsSeed.js
+++ b/tests/integration/seed/statsSeed.js
@@ -138,6 +138,8 @@ const tppList = [{
   isApa: true,
 }];
 
+const subscriptionWithoutFundingId = new ObjectID();
+
 const customerList = [
   {
     _id: new ObjectID(),
@@ -221,6 +223,22 @@ const customerList = [
       },
       phone: '0612345678',
     },
+    fundings: [{
+      nature: HOURLY,
+      frequency: MONTHLY,
+      subscription: subscriptionWithoutFundingId,
+      thirdPartyPayer: tppId,
+      versions: [{
+        _id: new ObjectID(),
+        startDate: '2019-07-01T08:00:00.000+00:00',
+        endDate: '2019-07-01T10:00:00.000+00:00',
+        createdAt: moment().startOf('month').subtract(2, 'months').toDate(),
+        unitTTCRate: 20,
+        customerParticipationRate: 60,
+        careHours: 40,
+        careDays: [0, 1, 2, 3, 4, 5, 6, 7],
+      }],
+    }],
   },
 ];
 
@@ -294,7 +312,7 @@ const eventListForFollowUp = [
     type: 'intervention',
     customer: customerList[1]._id,
     sector: new ObjectID(),
-    subscription: subscriptionId,
+    subscription: subscriptionWithoutFundingId,
     auxiliary: userList[0]._id,
     startDate: '2019-07-01T10:00:00.000+00:00',
     endDate: '2019-07-01T11:00:00.000+00:00',
@@ -573,6 +591,26 @@ const eventListForFundingsMonitoring = [
     misc: 'test',
     startDate: cloneDeep(tuesdayOfPreviousMonth).hour('10').toDate(),
     endDate: cloneDeep(tuesdayOfPreviousMonth).hour('14').toDate(),
+    address: {
+      street: '37 rue de Ponthieu',
+      zipCode: '75008',
+      city: 'Paris',
+      fullAddress: '37 rue de Ponthieu 75008 Paris',
+      location: { type: 'Point', coordinates: [2.0987, 1.2345] },
+    },
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    type: 'intervention',
+    customer: customerList[1]._id,
+    sector: new ObjectID(),
+    subscription: subscriptionWithoutFundingId,
+    auxiliary: userList[0]._id,
+    isCancelled: false,
+    misc: 'test',
+    startDate: cloneDeep(tuesdayOfCurrentMonth).hour('12').toDate(),
+    endDate: cloneDeep(tuesdayOfCurrentMonth).hour('15').toDate(),
     address: {
       street: '37 rue de Ponthieu',
       zipCode: '75008',

--- a/tests/integration/seed/statsSeed.js
+++ b/tests/integration/seed/statsSeed.js
@@ -138,7 +138,7 @@ const tppList = [{
   isApa: true,
 }];
 
-const subscriptionWithoutFundingId = new ObjectID();
+const subscriptionWithEndedFundingId = new ObjectID();
 
 const customerList = [
   {
@@ -209,7 +209,7 @@ const customerList = [
     _id: new ObjectID(),
     company: authCompany._id,
     subscriptions: [{
-      _id: new ObjectID(),
+      _id: subscriptionWithEndedFundingId,
       service: serviceList[0]._id,
     }],
     identity: { lastname: 'test' },
@@ -226,7 +226,7 @@ const customerList = [
     fundings: [{
       nature: HOURLY,
       frequency: MONTHLY,
-      subscription: subscriptionWithoutFundingId,
+      subscription: subscriptionWithEndedFundingId,
       thirdPartyPayer: tppId,
       versions: [{
         _id: new ObjectID(),
@@ -312,7 +312,7 @@ const eventListForFollowUp = [
     type: 'intervention',
     customer: customerList[1]._id,
     sector: new ObjectID(),
-    subscription: subscriptionWithoutFundingId,
+    subscription: subscriptionWithEndedFundingId,
     auxiliary: userList[0]._id,
     startDate: '2019-07-01T10:00:00.000+00:00',
     endDate: '2019-07-01T11:00:00.000+00:00',
@@ -605,7 +605,7 @@ const eventListForFundingsMonitoring = [
     type: 'intervention',
     customer: customerList[1]._id,
     sector: new ObjectID(),
-    subscription: subscriptionWithoutFundingId,
+    subscription: subscriptionWithEndedFundingId,
     auxiliary: userList[0]._id,
     isCancelled: false,
     misc: 'test',

--- a/tests/integration/stat.test.js
+++ b/tests/integration/stat.test.js
@@ -1,4 +1,5 @@
 const expect = require('expect');
+const get = require('lodash/get');
 const app = require('../../server');
 const {
   customerList,
@@ -141,6 +142,7 @@ describe('GET /stats/all-customers-fundings-monitoring', () => {
         headers: { 'x-access-token': clientAdminToken },
       });
       expect(res.statusCode).toBe(200);
+
       expect(res.result.data.allCustomersFundingsMonitoring).toEqual(expect.arrayContaining([
         expect.objectContaining({
           sector: expect.objectContaining({ name: 'Neptune' }),
@@ -151,6 +153,9 @@ describe('GET /stats/all-customers-fundings-monitoring', () => {
           nextMonthCareHours: 0,
         }),
       ]));
+
+      expect(res.result.data.allCustomersFundingsMonitoring.some(el =>
+        get(el, 'customer.lastname') === 'test')).toBe(false);
     });
   });
 


### PR DESCRIPTION
- [ ] Mon code est testé unitairement -np
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : sur la page des suivi des plans d'aide, on n'affiche pas les beneficiaires qui n'ont plus de plans d'aide. 
