### PR TITLE
Refacto create drive

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -2,7 +2,6 @@ const flat = require('flat');
 const Boom = require('@hapi/boom');
 const moment = require('moment');
 const translate = require('../helpers/translate');
-const GdriveStorageHelper = require('../helpers/gdriveStorage');
 const UsersHelper = require('../helpers/users');
 const {
   getUsersList,

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -280,40 +280,16 @@ const uploadImage = async (req) => {
 
 const createDriveFolder = async (req) => {
   try {
-    const user = await User.findById(req.params._id);
-    let updatedUser;
+    await UsersHelper.createDriveFolder(req.pre.user);
 
-    if (user.identity.firstname && user.identity.lastname) {
-      const parentFolderId = req.payload.parentFolderId || process.env.GOOGLE_DRIVE_AUXILIARIES_FOLDER_ID;
-      const folder = await GdriveStorageHelper.createFolder(user.identity, parentFolderId);
-
-      const folderPayload = {};
-      folderPayload.administrative = user.administrative || { driveFolder: {} };
-      folderPayload.administrative.driveFolder = {
-        driveId: folder.id,
-        link: folder.webViewLink,
-      };
-
-      updatedUser = await User.findOneAndUpdate(
-        { _id: user._id },
-        { $set: folderPayload },
-        { new: true, autopopulate: false }
-      );
-    }
-
-    return {
-      message: translate[language].userUpdated,
-      data: { updatedUser },
-    };
+    return { message: translate[language].userUpdated };
   } catch (e) {
     req.log('error', e);
     if (e.output && e.output.statusCode === 424) {
       return Boom.failedDependency(translate[language].googleDriveFolderCreationFailed);
     }
 
-    if (e.output && e.output.statusCode === 404) {
-      return Boom.notFound(translate[language].googleDriveFolderNotFound);
-    }
+    if (e.output && e.output.statusCode === 404) return Boom.notFound(translate[language].googleDriveFolderNotFound);
 
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
   }

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -448,14 +448,8 @@ exports.plugin = {
         auth: { scope: ['users:edit'] },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.object().keys({
-            parentFolderId: Joi.string().required(),
-          }),
         },
-        pre: [
-          { method: getUser, assign: 'user' },
-          { method: authorizeUserUpdate },
-        ],
+        pre: [{ method: getUser, assign: 'user' }],
       },
       handler: createDriveFolder,
     });

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1777,7 +1777,6 @@ describe('POST /users/:id/drivefolder', () => {
       expect(response.statusCode).toBe(200);
 
       const updatedUser = await User.findOne({ _id: usersSeedList[0]._id }, { 'administrative.driveFolder': 1 }).lean();
-      expect(updatedUser).toBeDefined();
       expect(updatedUser.administrative.driveFolder).toEqual({ driveId: '1234567890', link: 'http://test.com' });
       sinon.assert.calledWithExactly(createFolderStub, usersSeedList[0].identity, authCompany.auxiliariesFolderId);
     });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Admin / coach

- Cas d'usage : creation du dossier drive pour les auxiliaires
