### PR TITLE
COM-1665: externalize getprogress in back

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -53,6 +53,8 @@ exports.list = async (query) => {
 };
 
 exports.getCourseProgress = (steps) => {
+  if (steps === null) return 0;
+
   const progressSum = steps.map(step => step.progress).reduce((acc, value) => acc + value, 0);
   return steps.length ? (progressSum / steps.length) : 0;
 };

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -53,10 +53,9 @@ exports.list = async (query) => {
 };
 
 exports.getCourseProgress = (steps) => {
-  if (steps === null) return 0;
+  if (!steps || !steps.length) return 0;
 
-  const progressSum = steps.map(step => step.progress).reduce((acc, value) => acc + value, 0);
-  return steps.length ? (progressSum / steps.length) : 0;
+  return steps.map(step => step.progress).reduce((acc, value) => acc + value, 0) / steps.length;
 };
 
 exports.formatCourseWithProgress = (course) => {
@@ -65,10 +64,7 @@ exports.formatCourseWithProgress = (course) => {
 
   return {
     ...course,
-    subProgram: {
-      ...course.subProgram,
-      steps,
-    },
+    subProgram: { ...course.subProgram, steps },
     progress: exports.getCourseProgress(steps),
   };
 };

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -171,7 +171,7 @@ describe('getCourseProgress', () => {
   });
 
   it('should return 0 if no steps', async () => {
-    const steps = null;
+    const steps = [];
 
     const result = await CourseHelper.getCourseProgress(steps);
     expect(result).toBe(0);

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -169,6 +169,13 @@ describe('getCourseProgress', () => {
     const result = await CourseHelper.getCourseProgress(steps);
     expect(result).toBe(1);
   });
+
+  it('should return 0 if no steps', async () => {
+    const steps = null;
+
+    const result = await CourseHelper.getCourseProgress(steps);
+    expect(result).toBe(0);
+  });
 });
 
 describe('formatCourseWithProgress', () => {


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration (np)

- Périmetre interface : mobile

- Périmetre roles : tous

- Cas d'usage : externaliser dans le back le calcul de la progression pour une formation
