### PR TITLE
Com 1698

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -248,9 +248,9 @@ const uploadFile = async (req) => {
   }
 };
 
-const uploadImage = async (req) => {
+const uploadPicture = async (req) => {
   try {
-    await UsersHelper.uploadImage(req.params._id, req.payload);
+    await UsersHelper.uploadPicture(req.params._id, req.payload);
 
     return { message: translate[language].fileCreated };
   } catch (e) {
@@ -259,9 +259,9 @@ const uploadImage = async (req) => {
   }
 };
 
-const deleteImage = async (req) => {
+const deletePicture = async (req) => {
   try {
-    await UsersHelper.deleteImage(req.params._id, req.pre.publicId);
+    await UsersHelper.deletePicture(req.params._id, req.pre.publicId);
 
     return { message: translate[language].cardUpdated };
   } catch (e) {
@@ -306,8 +306,8 @@ module.exports = {
   checkResetPasswordToken,
   updateCertificates,
   uploadFile,
-  uploadImage,
-  deleteImage,
+  uploadPicture,
+  deletePicture,
   createDriveFolder,
   updatePassword,
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -259,6 +259,19 @@ const uploadImage = async (req) => {
   }
 };
 
+const deleteImage = async (req) => {
+  try {
+    await UsersHelper.deleteImage(req.params._id, req.pre.publicId);
+
+    return { message: translate[language].cardUpdated };
+  } catch (e) {
+    if (e.upload && e.code === 404) return { message: translate[language].userUpdated };
+
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
 const createDriveFolder = async (req) => {
   try {
     await UsersHelper.createDriveFolder(req.pre.user);
@@ -294,6 +307,7 @@ module.exports = {
   updateCertificates,
   uploadFile,
   uploadImage,
+  deleteImage,
   createDriveFolder,
   updatePassword,
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -252,7 +252,7 @@ const uploadPicture = async (req) => {
   try {
     await UsersHelper.uploadPicture(req.params._id, req.payload);
 
-    return { message: translate[language].fileCreated };
+    return { message: translate[language].userUpdated };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
@@ -263,7 +263,7 @@ const deletePicture = async (req) => {
   try {
     await UsersHelper.deletePicture(req.params._id, req.pre.publicId);
 
-    return { message: translate[language].cardUpdated };
+    return { message: translate[language].userUpdated };
   } catch (e) {
     if (e.upload && e.code === 404) return { message: translate[language].userUpdated };
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,6 +1,4 @@
-const flat = require('flat');
 const Boom = require('@hapi/boom');
-const moment = require('moment');
 const translate = require('../helpers/translate');
 const UsersHelper = require('../helpers/users');
 const {
@@ -11,8 +9,6 @@ const {
   getUser,
   userExists,
 } = require('../helpers/users');
-const User = require('../models/User');
-const cloudinary = require('../helpers/cloudinary');
 
 const { language } = translate;
 
@@ -254,23 +250,9 @@ const uploadFile = async (req) => {
 
 const uploadImage = async (req) => {
   try {
-    const pictureUploaded = await cloudinary.addImage({
-      file: req.payload.picture,
-      folder: 'images/users/profile_pictures',
-      public_id: `${req.payload.fileName}-${moment().format('YYYY_MM_DD_HH_mm_ss')}`,
-    });
-    const payload = {
-      picture: {
-        publicId: pictureUploaded.public_id,
-        link: pictureUploaded.secure_url,
-      },
-    };
-    const userUpdated = await User.findOneAndUpdate({ _id: req.params._id }, { $set: flat(payload) }, { new: true });
+    await UsersHelper.uploadImage(req.params._id, req.payload);
 
-    return {
-      message: translate[language].fileCreated,
-      data: { picture: payload.picture, userUpdated },
-    };
+    return { message: translate[language].fileCreated };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -25,8 +25,7 @@ exports.deleteCardAnswer = async params => Card.updateOne(
 );
 
 exports.uploadMedia = async (cardId, payload) => {
-  const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const mediaUploaded = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
+  const mediaUploaded = await GCloudStorageHelper.uploadProgramMedia(payload);
 
   await Card.updateOne(
     { _id: cardId },

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -26,7 +26,7 @@ exports.deleteCardAnswer = async params => Card.updateOne(
 
 exports.uploadMedia = async (cardId, payload) => {
   const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const mediaUploaded = await GCloudStorageHelper.uploadMedia({ fileName, file: payload.file });
+  const mediaUploaded = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
 
   await Card.updateOne(
     { _id: cardId },

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -38,7 +38,7 @@ exports.deleteMedia = async (cardId, publicId) => {
   if (!publicId) return;
 
   await Card.updateOne({ _id: cardId }, { $unset: { 'media.publicId': '', 'media.link': '' } });
-  await GCloudStorageHelper.deleteMedia(publicId);
+  await GCloudStorageHelper.deleteProgramMedia(publicId);
 };
 
 exports.removeCard = async (cardId) => {

--- a/src/helpers/gCloudStorage.js
+++ b/src/helpers/gCloudStorage.js
@@ -6,7 +6,9 @@ const { UPLOAD_DATE_FORMAT } = require('./constants');
 exports.formatFileName = fileName =>
   `media-${fileName.replace(/[^a-zA-Z0-9]/g, '')}-${moment().format(UPLOAD_DATE_FORMAT)}`;
 
-exports.uploadProgramMedia = async payload => uploadMedia(payload, process.env.GCS_BUCKET_NAME);
+exports.uploadProgramMedia = async payload => uploadMedia(payload, process.env.GCS_PROGRAM_BUCKET);
+
+exports.uploadUserMedia = async payload => uploadMedia(payload, process.env.GCS_USER_BUCKET);
 
 const uploadMedia = async (payload, bucketName) => new Promise((resolve, reject) => {
   const { fileName, file } = payload;

--- a/src/helpers/gCloudStorage.js
+++ b/src/helpers/gCloudStorage.js
@@ -6,10 +6,12 @@ const { UPLOAD_DATE_FORMAT } = require('./constants');
 exports.formatFileName = fileName =>
   `media-${fileName.replace(/[^a-zA-Z0-9]/g, '')}-${moment().format(UPLOAD_DATE_FORMAT)}`;
 
-exports.uploadMedia = async payload => new Promise((resolve, reject) => {
+exports.uploadProgramMedia = async payload => uploadMedia(payload, process.env.GCS_BUCKET_NAME);
+
+const uploadMedia = async (payload, bucketName) => new Promise((resolve, reject) => {
   const { fileName, file } = payload;
 
-  const bucket = getStorage().bucket(process.env.GCS_BUCKET_NAME);
+  const bucket = getStorage().bucket(bucketName);
   const stream = bucket.file(fileName)
     .createWriteStream({ metadata: { contentType: get(file, 'hapi.headers.content-type') } })
     .on('finish', () => {

--- a/src/helpers/gCloudStorage.js
+++ b/src/helpers/gCloudStorage.js
@@ -27,8 +27,12 @@ const uploadMedia = async (payload, bucketName) => new Promise((resolve, reject)
   file.pipe(stream);
 });
 
-exports.deleteMedia = async publicId => new Promise((resolve, reject) => {
-  getStorage().bucket(process.env.GCS_BUCKET_NAME).file(publicId).delete({}, (err, res) => {
+exports.deleteProgramMedia = async payload => deleteMedia(payload, process.env.GCS_PROGRAM_BUCKET);
+
+exports.deleteUserMedia = async payload => deleteMedia(payload, process.env.GCS_USER_BUCKET);
+
+const deleteMedia = async (publicId, bucketName) => new Promise((resolve, reject) => {
+  getStorage().bucket(bucketName).file(publicId).delete({}, (err, res) => {
     if (err) {
       // eslint-disable-next-line no-param-reassign
       err.upload = true;

--- a/src/helpers/gCloudStorage.js
+++ b/src/helpers/gCloudStorage.js
@@ -3,15 +3,16 @@ const moment = require('moment');
 const { getStorage } = require('../models/Google/Storage');
 const { UPLOAD_DATE_FORMAT } = require('./constants');
 
-exports.formatFileName = fileName =>
-  `media-${fileName.replace(/[^a-zA-Z0-9]/g, '')}-${moment().format(UPLOAD_DATE_FORMAT)}`;
-
 exports.uploadProgramMedia = async payload => uploadMedia(payload, process.env.GCS_PROGRAM_BUCKET);
 
 exports.uploadUserMedia = async payload => uploadMedia(payload, process.env.GCS_USER_BUCKET);
 
+const formatFileName = fileName =>
+  `media-${fileName.replace(/[^a-zA-Z0-9]/g, '')}-${moment().format(UPLOAD_DATE_FORMAT)}`;
+
 const uploadMedia = async (payload, bucketName) => new Promise((resolve, reject) => {
-  const { fileName, file } = payload;
+  const { file } = payload;
+  const fileName = formatFileName(payload.fileName);
 
   const bucket = getStorage().bucket(bucketName);
   const stream = bucket.file(fileName)

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -74,7 +74,7 @@ exports.updateProgram = async (programId, payload) => Program.updateOne({ _id: p
 
 exports.uploadImage = async (programId, payload) => {
   const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const imageUploaded = await GCloudStorageHelper.uploadMedia({ fileName, file: payload.file });
+  const imageUploaded = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
 
   await Program.updateOne({ _id: programId }, { $set: flat({ image: imageUploaded }) });
 };

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -73,8 +73,7 @@ exports.getProgramForUser = async (programId, credentials) => {
 exports.updateProgram = async (programId, payload) => Program.updateOne({ _id: programId }, { $set: payload });
 
 exports.uploadImage = async (programId, payload) => {
-  const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const imageUploaded = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
+  const imageUploaded = await GCloudStorageHelper.uploadProgramMedia(payload);
 
   await Program.updateOne({ _id: programId }, { $set: flat({ image: imageUploaded }) });
 };

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -83,5 +83,5 @@ exports.deleteImage = async (programId, publicId) => {
   if (!publicId) return;
 
   await Program.updateOne({ _id: programId }, { $unset: { 'image.publicId': '', 'image.link': '' } });
-  await GCloudStorageHelper.deleteMedia(publicId);
+  await GCloudStorageHelper.deleteProgramMedia(publicId);
 };

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -305,7 +305,7 @@ exports.removeHelper = async (user) => {
 
 exports.uploadImage = async (userId, payload) => {
   const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const picture = await GCloudStorageHelper.uploadUserMedia({ fileName, file: payload.file });
+  const picture = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
 
   await User.updateOne({ _id: userId }, { $set: flat({ picture }) });
 };

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -305,9 +305,16 @@ exports.removeHelper = async (user) => {
 
 exports.uploadImage = async (userId, payload) => {
   const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const picture = await GCloudStorageHelper.uploadProgramMedia({ fileName, file: payload.file });
+  const picture = await GCloudStorageHelper.uploadUserMedia({ fileName, file: payload.file });
 
   await User.updateOne({ _id: userId }, { $set: flat({ picture }) });
+};
+
+exports.deleteImage = async (userId, publicId) => {
+  if (!publicId) return;
+
+  await User.updateOne({ _id: userId }, { $unset: { 'picture.publicId': '', 'picture.link': '' } });
+  await GCloudStorageHelper.deleteUserMedia(publicId);
 };
 
 exports.createDriveFolder = async (user) => {

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -15,7 +15,6 @@ const Company = require('../models/Company');
 const { TOKEN_EXPIRE_TIME } = require('../models/User');
 const Contract = require('../models/Contract');
 const translate = require('./translate');
-const GdriveStorage = require('./gdriveStorage');
 const GCloudStorageHelper = require('./gCloudStorage');
 const AuthenticationHelper = require('./authentication');
 const { TRAINER, AUXILIARY_ROLES, HELPER, AUXILIARY_WITHOUT_COMPANY } = require('./constants');
@@ -166,7 +165,7 @@ exports.saveFile = async (userId, administrativeKey, fileInfo) => {
 };
 
 exports.createAndSaveFile = async (params, payload) => {
-  const uploadedFile = await GdriveStorage.addFile({
+  const uploadedFile = await GdriveStorageHelper.addFile({
     driveFolderId: params.driveId,
     name: payload.fileName || payload.type.hapi.filename,
     type: payload['Content-Type'],

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -303,14 +303,14 @@ exports.removeHelper = async (user) => {
   await User.findOneAndUpdate({ _id: user._id }, payload);
 };
 
-exports.uploadImage = async (userId, payload) => {
+exports.uploadPicture = async (userId, payload) => {
   const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
   const picture = await GCloudStorageHelper.uploadUserMedia({ fileName, file: payload.file });
 
   await User.updateOne({ _id: userId }, { $set: flat({ picture }) });
 };
 
-exports.deleteImage = async (userId, publicId) => {
+exports.deletePicture = async (userId, publicId) => {
   if (!publicId) return;
 
   await User.updateOne({ _id: userId }, { $unset: { 'picture.publicId': '', 'picture.link': '' } });

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -303,8 +303,7 @@ exports.removeHelper = async (user) => {
 };
 
 exports.uploadPicture = async (userId, payload) => {
-  const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
-  const picture = await GCloudStorageHelper.uploadUserMedia({ fileName, file: payload.file });
+  const picture = await GCloudStorageHelper.uploadUserMedia(payload);
 
   await User.updateOne({ _id: userId }, { $set: flat({ picture }) });
 };

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -16,6 +16,7 @@ const { TOKEN_EXPIRE_TIME } = require('../models/User');
 const Contract = require('../models/Contract');
 const translate = require('./translate');
 const GdriveStorage = require('./gdriveStorage');
+const GCloudStorageHelper = require('./gCloudStorage');
 const AuthenticationHelper = require('./authentication');
 const { TRAINER, AUXILIARY_ROLES, HELPER, AUXILIARY_WITHOUT_COMPANY } = require('./constants');
 const SectorHistoriesHelper = require('./sectorHistories');
@@ -300,6 +301,13 @@ exports.removeHelper = async (user) => {
   if (userRoleVendor && role._id.toHexString() === userRoleVendor.toHexString()) payload.$unset.company = '';
 
   await User.findOneAndUpdate({ _id: user._id }, payload);
+};
+
+exports.uploadImage = async (userId, payload) => {
+  const fileName = GCloudStorageHelper.formatFileName(payload.fileName);
+  const picture = await GCloudStorageHelper.uploadUserMedia({ fileName, file: payload.file });
+
+  await User.updateOne({ _id: userId }, { $set: flat({ picture }) });
 };
 
 exports.createDriveFolder = async (user) => {

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -211,3 +211,10 @@ exports.authorizeLearnersGet = async (req) => {
 
   return null;
 };
+
+exports.getImagePublicId = async (req) => {
+  const user = await User.findOne({ _id: req.params._id }, { picture: 1 }).lean();
+  if (!user) throw Boom.notFound();
+
+  return get(user, 'picture.publicId') || '';
+};

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -104,7 +104,7 @@ const checkCustomers = async (userCompany, payload) => {
 };
 
 const checkUpdateRestrictions = (payload) => {
-  const allowedUpdateKeys = ['firstname', 'lastname', 'phone', 'email'];
+  const allowedUpdateKeys = ['firstname', 'lastname', 'phone', 'email', 'link', 'publicId'];
   const payloadKeys = (Object.values(payload).map(value => Object.keys(value))).flat();
   if (payloadKeys.some(key => !allowedUpdateKeys.includes(key))) throw Boom.forbidden();
 };

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -212,7 +212,7 @@ exports.authorizeLearnersGet = async (req) => {
   return null;
 };
 
-exports.getImagePublicId = async (req) => {
+exports.getPicturePublicId = async (req) => {
   const user = await User.findOne({ _id: req.params._id }, { picture: 1 }).lean();
   if (!user) throw Boom.notFound();
 

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -104,7 +104,7 @@ const checkCustomers = async (userCompany, payload) => {
 };
 
 const checkUpdateRestrictions = (payload) => {
-  const allowedUpdateKeys = ['firstname', 'lastname', 'phone', 'email', 'link', 'publicId'];
+  const allowedUpdateKeys = ['firstname', 'lastname', 'phone', 'email'];
   const payloadKeys = (Object.values(payload).map(value => Object.keys(value))).flat();
   if (payloadKeys.some(key => !allowedUpdateKeys.includes(key))) throw Boom.forbidden();
 };

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -20,8 +20,8 @@ const {
   checkResetPasswordToken,
   updateCertificates,
   uploadFile,
-  uploadImage,
-  deleteImage,
+  uploadPicture,
+  deletePicture,
   createDriveFolder,
   updatePassword,
 } = require('../controllers/userController');
@@ -35,7 +35,7 @@ const {
   authorizeUserUpdateWithoutCompany,
   authorizeUserDeletion,
   authorizeLearnersGet,
-  getImagePublicId,
+  getPicturePublicId,
 } = require('./preHandlers/users');
 const { addressValidation, objectIdOrArray, phoneNumberValidation } = require('./validations/utils');
 const { formDataPayload } = require('./validations/utils');
@@ -459,7 +459,7 @@ exports.plugin = {
     server.route({
       method: 'POST',
       path: '/{_id}/upload',
-      handler: uploadImage,
+      handler: uploadPicture,
       options: {
         auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
         validate: {
@@ -476,13 +476,13 @@ exports.plugin = {
     server.route({
       method: 'DELETE',
       path: '/{_id}/upload',
-      handler: deleteImage,
+      handler: deletePicture,
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
-        pre: [{ method: getImagePublicId, assign: 'publicId' }],
+        pre: [{ method: getPicturePublicId, assign: 'publicId' }],
       },
     });
   },

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -481,7 +481,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
-        auth: { scope: ['programs:edit'] },
+        auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
         pre: [{ method: getPicturePublicId, assign: 'publicId' }],
       },
     });

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -456,7 +456,7 @@ exports.plugin = {
 
     server.route({
       method: 'POST',
-      path: '/{_id}/cloudinary/upload',
+      path: '/{_id}/upload',
       handler: uploadImage,
       options: {
         auth: { scope: ['users:edit', 'user:edit-{params._id}'] },
@@ -464,7 +464,7 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object({
             fileName: Joi.string().required(),
-            picture: Joi.any().required(),
+            file: Joi.any().required(),
           }),
         },
         payload: formDataPayload(),

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -21,6 +21,7 @@ const {
   updateCertificates,
   uploadFile,
   uploadImage,
+  deleteImage,
   createDriveFolder,
   updatePassword,
 } = require('../controllers/userController');
@@ -34,6 +35,7 @@ const {
   authorizeUserUpdateWithoutCompany,
   authorizeUserDeletion,
   authorizeLearnersGet,
+  getImagePublicId,
 } = require('./preHandlers/users');
 const { addressValidation, objectIdOrArray, phoneNumberValidation } = require('./validations/utils');
 const { formDataPayload } = require('./validations/utils');
@@ -468,6 +470,19 @@ exports.plugin = {
           }),
         },
         payload: formDataPayload(),
+      },
+    });
+
+    server.route({
+      method: 'DELETE',
+      path: '/{_id}/upload',
+      handler: deleteImage,
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+        },
+        auth: { scope: ['programs:edit'] },
+        pre: [{ method: getImagePublicId, assign: 'publicId' }],
       },
     });
   },

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -758,7 +758,7 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
   const docPayload = { fileName: 'title_text_media', file: 'true' };
   beforeEach(() => {
     form = generateFormData(docPayload);
-    uploadMediaStub = sinon.stub(GCloudStorageHelper, 'uploadMedia');
+    uploadMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
     momentFormat = sinon.stub(momentProto, 'format');
   });
   afterEach(() => {

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -866,6 +866,9 @@ describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
 
     it('should delete a card media', async () => {
       const card = cardsList[1];
+      const imageExistsBeforeUpdate = await Card
+        .countDocuments({ _id: card._id, 'media.publicId': { $exists: true } });
+
       const response = await app.inject({
         method: 'DELETE',
         url: `/cards/${card._id}/upload`,
@@ -875,8 +878,9 @@ describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
       expect(response.statusCode).toBe(200);
       sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'publicId');
 
-      const updatedCard = await Card.findOne({ _id: card._id });
-      expect(updatedCard.media.publicId).not.toBeDefined();
+      const isPictureDeleted = await Card.countDocuments({ _id: card._id, 'media.publicId': { $exists: false } });
+      expect(imageExistsBeforeUpdate).toBeTruthy();
+      expect(isPictureDeleted).toBeTruthy();
     });
   });
 

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -848,12 +848,12 @@ describe('CARDS ROUTES - POST /cards/:id/upload', () => {
 
 describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
   let authToken;
-  let deleteMediaStub;
+  let deleteProgramMediaStub;
   beforeEach(() => {
-    deleteMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
+    deleteProgramMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
   });
   afterEach(() => {
-    deleteMediaStub.restore();
+    deleteProgramMediaStub.restore();
   });
 
   describe('VENDOR_ADMIN', () => {
@@ -871,10 +871,10 @@ describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      sinon.assert.calledOnce(deleteMediaStub);
+      sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'publicId');
 
-      const cardUpdated = await Card.findOne({ _id: card._id });
-      expect(cardUpdated.media.publicId).not.toBeDefined();
+      const updatedCard = await Card.findOne({ _id: card._id });
+      expect(updatedCard.media.publicId).not.toBeDefined();
     });
   });
 

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -850,7 +850,7 @@ describe('CARDS ROUTES - DELETE /cards/:id/upload', () => {
   let authToken;
   let deleteMediaStub;
   beforeEach(() => {
-    deleteMediaStub = sinon.stub(GCloudStorageHelper, 'deleteMedia');
+    deleteMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
   });
   afterEach(() => {
     deleteMediaStub.restore();

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -675,6 +675,9 @@ describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
 
     it('should delete a program media', async () => {
       const program = programsList[0];
+      const imageExistsBeforeUpdate = await Program
+        .countDocuments({ _id: program._id, 'image.publicId': { $exists: true } });
+
       const response = await app.inject({
         method: 'DELETE',
         url: `/programs/${program._id}/upload`,
@@ -684,8 +687,9 @@ describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
       expect(response.statusCode).toBe(200);
       sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'au revoir');
 
-      const updatedProgram = await Program.findOne({ _id: program._id }).lean();
-      expect(updatedProgram.image.publicId).not.toBeDefined();
+      const isPictureDeleted = await Program.countDocuments({ _id: program._id, 'image.publicId': { $exists: false } });
+      expect(imageExistsBeforeUpdate).toBeTruthy();
+      expect(isPictureDeleted).toBeTruthy();
     });
   });
 

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -570,7 +570,7 @@ describe('POST /programs/:id/upload', () => {
   const docPayload = { fileName: 'program_image_test', file: 'true' };
   beforeEach(() => {
     form = generateFormData(docPayload);
-    uploadMedia = sinon.stub(GCloudStorageHelper, 'uploadMedia');
+    uploadMedia = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
   });
   afterEach(() => {
     uploadMedia.restore();

--- a/tests/integration/seed/programsSeed.js
+++ b/tests/integration/seed/programsSeed.js
@@ -57,6 +57,7 @@ const programsList = [
     description: 'Je suis un super programme',
     learningGoals: 'Tellement cool ce qu\'on va apprendre ensemble',
     subPrograms: [subProgramsList[0]._id],
+    image: { link: 'bonjour', publicId: 'au revoir' },
   },
   { _id: new ObjectID(), name: 'training program', subPrograms: [subProgramsList[2]._id] },
   { _id: new ObjectID(), name: 'non valid program', subPrograms: [subProgramsList[1]._id] },

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -125,10 +125,7 @@ const usersSeedList = [
     inactivityDate: null,
     contracts: [{ _id: contractId }],
     establishment: establishmentList[0]._id,
-    picture: {
-      publicId: 'a/public/id',
-      link: 'https://the.complete.com/link/to/the/picture/storage/location',
-    },
+    picture: { publicId: 'a/public/id', link: 'https://the.complete.com/link/to/the/picture/storage/location' },
   },
   {
     _id: new ObjectID(),

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1829,24 +1829,22 @@ describe('POST /users/:id/upload', () => {
       authToken = await getToken('vendor_admin');
     });
 
-    it('should add a user pp', async () => {
+    it('should add a user picture', async () => {
       const user = usersSeedList[0];
       const form = generateFormData({ fileName: 'user_image_test', file: 'yoyoyo' });
       uploadUserMediaStub.returns({ public_id: 'abcdefgh', secure_url: 'https://alenvi.io' });
       momentFormat.returns('20200625054512');
 
+      const payload = await GetStream(form);
       const response = await app.inject({
         method: 'POST',
         url: `/users/${user._id}/upload`,
-        payload: await GetStream(form),
+        payload,
         headers: { ...form.getHeaders(), 'x-access-token': authToken },
       });
 
       expect(response.statusCode).toBe(200);
-      sinon.assert.calledOnceWithExactly(
-        uploadUserMediaStub,
-        { fileName: 'media-userimagetest-20200625054512', file: 'yoyoyo' }
-      );
+      sinon.assert.calledOnceWithExactly(uploadUserMediaStub, { fileName: 'user_image_test', file: 'yoyoyo' });
     });
 
     const wrongParams = ['file', 'fileName'];

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1922,6 +1922,7 @@ describe('DELETE /users/:id/upload', () => {
   });
 
   describe('VENDOR ROLE', () => {
+    beforeEach(populateDB);
     beforeEach(async () => {
       authToken = await getToken('vendor_admin');
     });
@@ -1929,7 +1930,7 @@ describe('DELETE /users/:id/upload', () => {
     it('should delete picture', async () => {
       const user = usersSeedList[0];
       const pictureExistsBeforeUpdate = await User
-        .countDocuments({ _id: user._id, 'image.publicId': { $exists: true } });
+        .countDocuments({ _id: user._id, 'picture.publicId': { $exists: true } });
 
       const response = await app.inject({
         method: 'DELETE',
@@ -1958,6 +1959,7 @@ describe('DELETE /users/:id/upload', () => {
   });
 
   describe('Other roles', () => {
+    beforeEach(populateDB);
     it('should delete picture if it is me', async () => {
       const user = userList[11];
       authToken = await getTokenByCredentials(user.local);
@@ -2029,6 +2031,7 @@ describe('POST /users/:id/drivefolder', () => {
   });
 
   describe('Other roles', () => {
+    beforeEach(populateDB);
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1928,7 +1928,8 @@ describe('DELETE /users/:id/upload', () => {
 
     it('should delete picture', async () => {
       const user = usersSeedList[0];
-      const userBeforeUpdate = await User.findOne({ _id: user._id }, { picture: 1 }).lean();
+      const pictureExistsBeforeUpdate = await User
+        .countDocuments({ _id: user._id, 'image.publicId': { $exists: true } });
 
       const response = await app.inject({
         method: 'DELETE',
@@ -1939,9 +1940,9 @@ describe('DELETE /users/:id/upload', () => {
       expect(response.statusCode).toBe(200);
       sinon.assert.calledOnceWithExactly(deleteUserMediaStub, 'a/public/id');
 
-      const updatedUser = await User.findOne({ _id: user._id }, { picture: 1 }).lean();
-      expect(userBeforeUpdate.picture.publicId).toBeDefined();
-      expect(updatedUser.picture.publicId).not.toBeDefined();
+      const isPictureDeleted = await User.countDocuments({ _id: user._id, 'picture.publicId': { $exists: false } });
+      expect(pictureExistsBeforeUpdate).toBeTruthy();
+      expect(isPictureDeleted).toBeTruthy();
     });
 
     it('should return 404 if invalid user id', async () => {

--- a/tests/seed/userSeed.js
+++ b/tests/seed/userSeed.js
@@ -112,6 +112,7 @@ const userList = [
     refreshToken: uuidv4(),
     local: { email: 'norole.nocompany@alenvi.io', password: 'fdsf5P56D' },
     contact: { phone: '0798640728' },
+    picture: { link: 'qwertyuio', pictureId: 'poiuytrew' },
   },
 ];
 

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -135,16 +135,13 @@ describe('removeCard', () => {
 describe('uploadMedia', () => {
   let updateOneStub;
   let uploadMediaStub;
-  let formatFileName;
   beforeEach(() => {
     updateOneStub = sinon.stub(Card, 'updateOne');
     uploadMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
-    formatFileName = sinon.stub(GCloudStorageHelper, 'formatFileName');
   });
   afterEach(() => {
     updateOneStub.restore();
     uploadMediaStub.restore();
-    formatFileName.restore();
   });
 
   it('should upload image', async () => {
@@ -152,15 +149,13 @@ describe('uploadMedia', () => {
       publicId: 'jesuisunsupernomdefichier',
       link: 'https://storage.googleapis.com/BucketKFC/myMedia',
     });
-    formatFileName.returns('jesuisunsupernomdefichier');
 
     const cardId = new ObjectID();
     const payload = { file: new ArrayBuffer(32), fileName: 'illustration' };
 
     await CardHelper.uploadMedia(cardId, payload);
 
-    sinon.assert.calledOnceWithExactly(formatFileName, 'illustration');
-    sinon.assert.calledOnceWithExactly(uploadMediaStub, { fileName: 'jesuisunsupernomdefichier', file: payload.file });
+    sinon.assert.calledOnceWithExactly(uploadMediaStub, { file: new ArrayBuffer(32), fileName: 'illustration' });
     sinon.assert.calledWithExactly(
       updateOneStub,
       { _id: cardId },

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -138,7 +138,7 @@ describe('uploadMedia', () => {
   let formatFileName;
   beforeEach(() => {
     updateOneStub = sinon.stub(Card, 'updateOne');
-    uploadMediaStub = sinon.stub(GCloudStorageHelper, 'uploadMedia');
+    uploadMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
     formatFileName = sinon.stub(GCloudStorageHelper, 'formatFileName');
   });
   afterEach(() => {

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -178,7 +178,7 @@ describe('deleteMedia', () => {
   let deleteMedia;
   beforeEach(() => {
     updateOne = sinon.stub(Card, 'updateOne');
-    deleteMedia = sinon.stub(GCloudStorageHelper, 'deleteMedia');
+    deleteMedia = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
   });
   afterEach(() => {
     updateOne.restore();

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -263,7 +263,7 @@ describe('deleteImage', () => {
   let deleteMedia;
   beforeEach(() => {
     updateOne = sinon.stub(Program, 'updateOne');
-    deleteMedia = sinon.stub(GCloudStorageHelper, 'deleteMedia');
+    deleteMedia = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
   });
   afterEach(() => {
     updateOne.restore();

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -224,7 +224,7 @@ describe('uploadImage', () => {
   beforeEach(() => {
     updateOne = sinon.stub(Program, 'updateOne');
     formatFileName = sinon.stub(GCloudStorageHelper, 'formatFileName');
-    uploadMedia = sinon.stub(GCloudStorageHelper, 'uploadMedia');
+    uploadMedia = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
   });
   afterEach(() => {
     updateOne.restore();

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -219,16 +219,13 @@ describe('update', () => {
 
 describe('uploadImage', () => {
   let updateOne;
-  let formatFileName;
   let uploadMedia;
   beforeEach(() => {
     updateOne = sinon.stub(Program, 'updateOne');
-    formatFileName = sinon.stub(GCloudStorageHelper, 'formatFileName');
     uploadMedia = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
   });
   afterEach(() => {
     updateOne.restore();
-    formatFileName.restore();
     uploadMedia.restore();
   });
 
@@ -237,15 +234,13 @@ describe('uploadImage', () => {
       publicId: 'jesuisunsupernomdefichier',
       link: 'https://storage.googleapis.com/BucketKFC/myMedia',
     });
-    formatFileName.returns('jesuisunsupernomdefichier');
 
     const programId = new ObjectID();
     const payload = { file: new ArrayBuffer(32), fileName: 'illustration' };
 
     await ProgramHelper.uploadImage(programId, payload);
 
-    sinon.assert.calledOnceWithExactly(formatFileName, 'illustration');
-    sinon.assert.calledOnceWithExactly(uploadMedia, { fileName: 'jesuisunsupernomdefichier', file: payload.file });
+    sinon.assert.calledOnceWithExactly(uploadMedia, { file: new ArrayBuffer(32), fileName: 'illustration' });
     sinon.assert.calledWithExactly(
       updateOne,
       { _id: programId },

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1407,16 +1407,13 @@ describe('generatePasswordToken', () => {
 describe('uploadPicture', () => {
   let updateOneStub;
   let uploadUserMedia;
-  let formatFileName;
   beforeEach(() => {
     updateOneStub = sinon.stub(User, 'updateOne');
     uploadUserMedia = sinon.stub(GCloudStorageHelper, 'uploadUserMedia');
-    formatFileName = sinon.stub(GCloudStorageHelper, 'formatFileName');
   });
   afterEach(() => {
     updateOneStub.restore();
     uploadUserMedia.restore();
-    formatFileName.restore();
   });
 
   it('should upload image', async () => {
@@ -1424,15 +1421,13 @@ describe('uploadPicture', () => {
       publicId: 'jesuisunsupernomdefichier',
       link: 'https://storage.googleapis.com/BucketKFC/myMedia',
     });
-    formatFileName.returns('jesuisunsupernomdefichier');
 
     const userId = new ObjectID();
     const payload = { file: new ArrayBuffer(32), fileName: 'illustration' };
 
     await UsersHelper.uploadPicture(userId, payload);
 
-    sinon.assert.calledOnceWithExactly(formatFileName, 'illustration');
-    sinon.assert.calledOnceWithExactly(uploadUserMedia, { fileName: 'jesuisunsupernomdefichier', file: payload.file });
+    sinon.assert.calledOnceWithExactly(uploadUserMedia, { file: new ArrayBuffer(32), fileName: 'illustration' });
     sinon.assert.calledWithExactly(
       updateOneStub,
       { _id: userId },


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Toutes

- Périmetre roles : Tous

- Cas d'usage : ETQ utilisateurs, je peux charger ma photo de profil vers GCS

NB : changement dans le `.env`, il faut remplacer `GCS_BUCKET_NAME` par `GCS_PROGRAM_BUCKET` et `GCS_USER_BUCKET`
