### PR TITLE
Com 1691 - refacto qcm/qcu/questionAnswers

### DIFF
--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -13,15 +13,15 @@ exports.updateCard = async (cardId, payload) => Card.updateOne(
   { $set: flat(payload, { safe: true }) }
 );
 
-exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { qAnswers: { text: '' } } });
+exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { qcAnswers: { text: '' } } });
 
 exports.updateCardAnswer = async (params, payload) => Card.updateOne(
-  { _id: params._id, 'qAnswers._id': params.answerId },
-  { $set: { 'qAnswers.$.text': payload.text } }
+  { _id: params._id, 'qcAnswers._id': params.answerId },
+  { $set: { 'qcAnswers.$.text': payload.text } }
 );
 
 exports.deleteCardAnswer = async params => Card.updateOne(
-  { _id: params._id }, { $pull: { qAnswers: { _id: params.answerId } } }
+  { _id: params._id }, { $pull: { qcAnswers: { _id: params.answerId } } }
 );
 
 exports.uploadMedia = async (cardId, payload) => {

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -13,15 +13,15 @@ exports.updateCard = async (cardId, payload) => Card.updateOne(
   { $set: flat(payload, { safe: true }) }
 );
 
-exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { questionAnswers: { text: '' } } });
+exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { qAnswers: { text: '' } } });
 
 exports.updateCardAnswer = async (params, payload) => Card.updateOne(
-  { _id: params._id, 'questionAnswers._id': params.answerId },
-  { $set: { 'questionAnswers.$.text': payload.text } }
+  { _id: params._id, 'qAnswers._id': params.answerId },
+  { $set: { 'qAnswers.$.text': payload.text } }
 );
 
 exports.deleteCardAnswer = async params => Card.updateOne(
-  { _id: params._id }, { $pull: { questionAnswers: { _id: params.answerId } } }
+  { _id: params._id }, { $pull: { qAnswers: { _id: params.answerId } } }
 );
 
 exports.uploadMedia = async (cardId, payload) => {

--- a/src/models/Card.js
+++ b/src/models/Card.js
@@ -53,7 +53,7 @@ const CardSchema = mongoose.Schema({
     type: [String],
     default: undefined,
   },
-  qAnswers: {
+  qcAnswers: {
     type: [mongoose.Schema({ text: { type: String }, correct: { type: Boolean } }, { id: false })],
     default: undefined,
   },
@@ -80,17 +80,17 @@ function save(next) {
         this.falsyGapAnswers = [];
         break;
       case SINGLE_CHOICE_QUESTION:
-        this.qAnswers = [{ text: '' }];
+        this.qcAnswers = [{ text: '' }];
         break;
       case QUESTION_ANSWER:
-        this.qAnswers = [{ text: '' }, { text: '' }];
+        this.qcAnswers = [{ text: '' }, { text: '' }];
         this.isQuestionAnswerMultipleChoiced = false;
         break;
       case ORDER_THE_SEQUENCE:
         this.orderedAnswers = [];
         break;
       case MULTIPLE_CHOICE_QUESTION:
-        this.qAnswers = [{ text: '', correct: false }, { text: '', correct: false }];
+        this.qcAnswers = [{ text: '', correct: false }, { text: '', correct: false }];
         break;
       case SURVEY:
         this.label = {};

--- a/src/models/Card.js
+++ b/src/models/Card.js
@@ -80,17 +80,17 @@ function save(next) {
         this.falsyGapAnswers = [];
         break;
       case SINGLE_CHOICE_QUESTION:
-        this.qcuFalsyAnswers = [];
+        this.qAnswers = [{ text: '' }];
         break;
       case QUESTION_ANSWER:
-        this.questionAnswers = [{ text: '' }, { text: '' }];
+        this.qAnswers = [{ text: '' }, { text: '' }];
         this.isQuestionAnswerMultipleChoiced = false;
         break;
       case ORDER_THE_SEQUENCE:
         this.orderedAnswers = [];
         break;
       case MULTIPLE_CHOICE_QUESTION:
-        this.qcmAnswers = [];
+        this.qAnswers = [{ text: '', correct: false }, { text: '', correct: false }];
         break;
       case SURVEY:
         this.label = {};

--- a/src/models/Card.js
+++ b/src/models/Card.js
@@ -53,19 +53,11 @@ const CardSchema = mongoose.Schema({
     type: [String],
     default: undefined,
   },
-  qcuFalsyAnswers: {
-    type: [String],
-    default: undefined,
-  },
-  questionAnswers: {
-    type: [mongoose.Schema({ text: { type: String } }, { id: false })],
+  qAnswers: {
+    type: [mongoose.Schema({ text: { type: String }, correct: { type: Boolean } }, { id: false })],
     default: undefined,
   },
   isQuestionAnswerMultipleChoiced: { type: Boolean },
-  qcmAnswers: {
-    type: [mongoose.Schema({ label: { type: String }, correct: { type: Boolean } }, { _id: false, id: false })],
-    default: undefined,
-  },
   explanation: { type: String },
   orderedAnswers: {
     type: [String],

--- a/src/models/validations/cardValidation.js
+++ b/src/models/validations/cardValidation.js
@@ -69,7 +69,7 @@ exports.cardValidationByTemplate = (template) => {
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
         qcuGoodAnswer: Joi.string().required().max(QC_ANSWER_MAX_LENGTH),
-        qAnswers: Joi.array().items(Joi.object({
+        qcAnswers: Joi.array().items(Joi.object({
           text: Joi.string().max(QC_ANSWER_MAX_LENGTH).required(),
         })).min(1).max(SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT),
         explanation: Joi.string().required(),
@@ -83,7 +83,7 @@ exports.cardValidationByTemplate = (template) => {
     case MULTIPLE_CHOICE_QUESTION:
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
-        qAnswers: Joi.array()
+        qcAnswers: Joi.array()
           .items(Joi.object({
             text: Joi.string().required().max(QC_ANSWER_MAX_LENGTH),
             correct: Joi.boolean().required(),
@@ -114,7 +114,7 @@ exports.cardValidationByTemplate = (template) => {
     case QUESTION_ANSWER:
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
-        qAnswers: Joi.array().items(Joi.object({
+        qcAnswers: Joi.array().items(Joi.object({
           text: Joi.string().required(),
         })).min(2).max(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
       });

--- a/src/models/validations/cardValidation.js
+++ b/src/models/validations/cardValidation.js
@@ -69,9 +69,9 @@ exports.cardValidationByTemplate = (template) => {
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
         qcuGoodAnswer: Joi.string().required().max(QC_ANSWER_MAX_LENGTH),
-        qcuFalsyAnswers: Joi.array().items(
-          Joi.string().max(QC_ANSWER_MAX_LENGTH)
-        ).min(1).max(SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT),
+        qAnswers: Joi.array().items(Joi.object({
+          text: Joi.string().max(QC_ANSWER_MAX_LENGTH).required(),
+        })).min(1).max(SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT),
         explanation: Joi.string().required(),
       });
     case ORDER_THE_SEQUENCE:
@@ -83,9 +83,9 @@ exports.cardValidationByTemplate = (template) => {
     case MULTIPLE_CHOICE_QUESTION:
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
-        qcmAnswers: Joi.array()
+        qAnswers: Joi.array()
           .items(Joi.object({
-            label: Joi.string().required().max(QC_ANSWER_MAX_LENGTH),
+            text: Joi.string().required().max(QC_ANSWER_MAX_LENGTH),
             correct: Joi.boolean().required(),
           }))
           .has(Joi.object({ correct: true }))
@@ -114,9 +114,9 @@ exports.cardValidationByTemplate = (template) => {
     case QUESTION_ANSWER:
       return Joi.object().keys({
         question: Joi.string().required().max(QUESTION_MAX_LENGTH),
-        questionAnswers: Joi.array().items({
+        qAnswers: Joi.array().items(Joi.object({
           text: Joi.string().required(),
-        }).min(2).max(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
+        })).min(2).max(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
       });
     default:
       return Joi.object().keys();

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -21,15 +21,12 @@ const {
   getCardMediaPublicId,
 } = require('./preHandlers/cards');
 const {
-  SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT,
   FILL_THE_GAPS_MAX_ANSWERS_COUNT,
-  MULTIPLE_CHOICE_QUESTION_MAX_ANSWERS_COUNT,
   ORDER_THE_SEQUENCE_MAX_ANSWERS_COUNT,
   SURVEY_LABEL_MAX_LENGTH,
   QC_ANSWER_MAX_LENGTH,
   QUESTION_MAX_LENGTH,
   GAP_ANSWER_MAX_LENGTH,
-  QUESTION_ANSWER_MAX_ANSWERS_COUNT,
   FLASHCARD_TEXT_MAX_LENGTH,
 } = require('../helpers/constants');
 
@@ -55,6 +52,7 @@ exports.plugin = {
             question: Joi.string().max(QUESTION_MAX_LENGTH),
             qcuGoodAnswer: Joi.string().max(QC_ANSWER_MAX_LENGTH),
             qAnswers: Joi.array().items(Joi.object({
+              _id: Joi.objectId(),
               text: Joi.string().required(),
               correct: Joi.boolean(),
             })).min(1),

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -51,11 +51,6 @@ exports.plugin = {
             gappedText: Joi.string(),
             question: Joi.string().max(QUESTION_MAX_LENGTH),
             qcuGoodAnswer: Joi.string().max(QC_ANSWER_MAX_LENGTH),
-            qcAnswers: Joi.array().items(Joi.object({
-              _id: Joi.objectId(),
-              text: Joi.string().required(),
-              correct: Joi.boolean(),
-            })).min(1),
             orderedAnswers: Joi.array().items(Joi.string()).min(1).max(ORDER_THE_SEQUENCE_MAX_ANSWERS_COUNT),
             falsyGapAnswers: Joi.array().items(
               Joi.string().max(GAP_ANSWER_MAX_LENGTH)

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -51,7 +51,7 @@ exports.plugin = {
             gappedText: Joi.string(),
             question: Joi.string().max(QUESTION_MAX_LENGTH),
             qcuGoodAnswer: Joi.string().max(QC_ANSWER_MAX_LENGTH),
-            qAnswers: Joi.array().items(Joi.object({
+            qcAnswers: Joi.array().items(Joi.object({
               _id: Joi.objectId(),
               text: Joi.string().required(),
               correct: Joi.boolean(),

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -54,18 +54,14 @@ exports.plugin = {
             gappedText: Joi.string(),
             question: Joi.string().max(QUESTION_MAX_LENGTH),
             qcuGoodAnswer: Joi.string().max(QC_ANSWER_MAX_LENGTH),
-            qcmAnswers: Joi.array().items(Joi.object({
-              label: Joi.string().max(QC_ANSWER_MAX_LENGTH).required(),
-              correct: Joi.boolean().required(),
-            })).min(1).max(MULTIPLE_CHOICE_QUESTION_MAX_ANSWERS_COUNT),
+            qAnswers: Joi.array().items(Joi.object({
+              text: Joi.string().required(),
+              correct: Joi.boolean(),
+            })).min(1),
             orderedAnswers: Joi.array().items(Joi.string()).min(1).max(ORDER_THE_SEQUENCE_MAX_ANSWERS_COUNT),
-            qcuFalsyAnswers: Joi.array().items(
-              Joi.string().max(QC_ANSWER_MAX_LENGTH)
-            ).min(1).max(SINGLE_CHOICE_QUESTION_MAX_FALSY_ANSWERS_COUNT),
             falsyGapAnswers: Joi.array().items(
               Joi.string().max(GAP_ANSWER_MAX_LENGTH)
             ).min(1).max(FILL_THE_GAPS_MAX_ANSWERS_COUNT),
-            questionAnswers: Joi.array().items(Joi.string()).min(1).max(QUESTION_ANSWER_MAX_ANSWERS_COUNT),
             isQuestionAnswerMultipleChoiced: Joi.boolean(),
             explanation: Joi.string(),
             label: Joi.object().keys({

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -48,8 +48,8 @@ const checkOrderTheSequence = (payload, card) => {
 };
 
 const checkQuestionAnswer = (payload, card) => {
-  const { qAnswers } = payload;
-  if (qAnswers && qAnswers.length === 1 && card.qAnswers.length > 1) return Boom.badRequest();
+  const { qcAnswers } = payload;
+  if (qcAnswers && qcAnswers.length === 1 && card.qcAnswers.length > 1) return Boom.badRequest();
 
   return null;
 };
@@ -62,11 +62,11 @@ const checkFlashCard = (payload) => {
 };
 
 const checkMultipleChoiceQuestion = (payload, card) => {
-  const { qAnswers } = payload;
+  const { qcAnswers } = payload;
 
-  if (qAnswers) {
-    const noCorrectAnswer = !qAnswers.find(ans => ans.correct);
-    const removeRequiredAnswer = qAnswers.length === 1 && card.qAnswers.length > 1;
+  if (qcAnswers) {
+    const noCorrectAnswer = !qcAnswers.find(ans => ans.correct);
+    const removeRequiredAnswer = qcAnswers.length === 1 && card.qcAnswers.length > 1;
     if (removeRequiredAnswer || noCorrectAnswer) return Boom.badRequest();
   }
 
@@ -96,7 +96,7 @@ exports.authorizeCardUpdate = async (req) => {
 exports.authorizeCardAnswerCreation = async (req) => {
   const card = await Card.findOne({ _id: req.params._id }).lean();
   if (!card) throw Boom.notFound();
-  if (card.qAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT) return Boom.forbidden();
+  if (card.qcAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT) return Boom.forbidden();
 
   const activity = await Activity.findOne({ cards: req.params._id }).lean();
   if (activity.status === PUBLISHED) throw Boom.forbidden();
@@ -105,16 +105,16 @@ exports.authorizeCardAnswerCreation = async (req) => {
 };
 
 exports.authorizeCardAnswerUpdate = async (req) => {
-  const card = await Card.findOne({ _id: req.params._id, 'qAnswers._id': req.params.answerId }).lean();
+  const card = await Card.findOne({ _id: req.params._id, 'qcAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
 
   return null;
 };
 
 exports.authorizeCardAnswerDeletion = async (req) => {
-  const card = await Card.findOne({ _id: req.params._id, 'qAnswers._id': req.params.answerId }).lean();
+  const card = await Card.findOne({ _id: req.params._id, 'qcAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
-  if (card.qAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT) return Boom.forbidden();
+  if (card.qcAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT) return Boom.forbidden();
 
   const activity = await Activity.findOne({ cards: req.params._id }).lean();
   if (activity.status === PUBLISHED) throw Boom.forbidden();

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -48,8 +48,8 @@ const checkOrderTheSequence = (payload, card) => {
 };
 
 const checkQuestionAnswer = (payload, card) => {
-  const { questionAnswers } = payload;
-  if (questionAnswers && questionAnswers.length === 1 && card.questionAnswers.length > 1) return Boom.badRequest();
+  const { qAnswers } = payload;
+  if (qAnswers && qAnswers.length === 1 && card.qAnswers.length > 1) return Boom.badRequest();
 
   return null;
 };
@@ -62,11 +62,11 @@ const checkFlashCard = (payload) => {
 };
 
 const checkMultipleChoiceQuestion = (payload, card) => {
-  const { qcmAnswers } = payload;
+  const { qAnswers } = payload;
 
-  if (qcmAnswers) {
-    const noCorrectAnswer = !qcmAnswers.find(ans => ans.correct);
-    const removeRequiredAnswer = qcmAnswers.length === 1 && card.qcmAnswers.length > 1;
+  if (qAnswers) {
+    const noCorrectAnswer = !qAnswers.find(ans => ans.correct);
+    const removeRequiredAnswer = qAnswers.length === 1 && card.qAnswers.length > 1;
     if (removeRequiredAnswer || noCorrectAnswer) return Boom.badRequest();
   }
 
@@ -96,7 +96,7 @@ exports.authorizeCardUpdate = async (req) => {
 exports.authorizeCardAnswerCreation = async (req) => {
   const card = await Card.findOne({ _id: req.params._id }).lean();
   if (!card) throw Boom.notFound();
-  if (card.questionAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT) return Boom.forbidden();
+  if (card.qAnswers.length >= QUESTION_ANSWER_MAX_ANSWERS_COUNT) return Boom.forbidden();
 
   const activity = await Activity.findOne({ cards: req.params._id }).lean();
   if (activity.status === PUBLISHED) throw Boom.forbidden();
@@ -105,16 +105,16 @@ exports.authorizeCardAnswerCreation = async (req) => {
 };
 
 exports.authorizeCardAnswerUpdate = async (req) => {
-  const card = await Card.findOne({ _id: req.params._id, 'questionAnswers._id': req.params.answerId }).lean();
+  const card = await Card.findOne({ _id: req.params._id, 'qAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
 
   return null;
 };
 
 exports.authorizeCardAnswerDeletion = async (req) => {
-  const card = await Card.findOne({ _id: req.params._id, 'questionAnswers._id': req.params.answerId }).lean();
+  const card = await Card.findOne({ _id: req.params._id, 'qAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
-  if (card.questionAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT) return Boom.forbidden();
+  if (card.qAnswers.length <= QUESTION_ANSWER_MIN_ANSWERS_COUNT) return Boom.forbidden();
 
   const activity = await Activity.findOne({ cards: req.params._id }).lean();
   if (activity.status === PUBLISHED) throw Boom.forbidden();

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -4,10 +4,8 @@ const Card = require('../../models/Card');
 const {
   FILL_THE_GAPS,
   ORDER_THE_SEQUENCE,
-  MULTIPLE_CHOICE_QUESTION,
   FLASHCARD,
   PUBLISHED,
-  QUESTION_ANSWER,
   QUESTION_ANSWER_MAX_ANSWERS_COUNT,
   QUESTION_ANSWER_MIN_ANSWERS_COUNT,
   FLASHCARD_TEXT_MAX_LENGTH,
@@ -47,28 +45,9 @@ const checkOrderTheSequence = (payload, card) => {
   return null;
 };
 
-const checkQuestionAnswer = (payload, card) => {
-  const { qcAnswers } = payload;
-  if (qcAnswers && qcAnswers.length === 1 && card.qcAnswers.length > 1) return Boom.badRequest();
-
-  return null;
-};
-
 const checkFlashCard = (payload) => {
   const { text } = payload;
   if (text && text.length > FLASHCARD_TEXT_MAX_LENGTH) return Boom.badRequest();
-
-  return null;
-};
-
-const checkMultipleChoiceQuestion = (payload, card) => {
-  const { qcAnswers } = payload;
-
-  if (qcAnswers) {
-    const noCorrectAnswer = !qcAnswers.find(ans => ans.correct);
-    const removeRequiredAnswer = qcAnswers.length === 1 && card.qcAnswers.length > 1;
-    if (removeRequiredAnswer || noCorrectAnswer) return Boom.badRequest();
-  }
 
   return null;
 };
@@ -82,10 +61,6 @@ exports.authorizeCardUpdate = async (req) => {
       return checkFillTheGap(req.payload, card);
     case ORDER_THE_SEQUENCE:
       return checkOrderTheSequence(req.payload, card);
-    case MULTIPLE_CHOICE_QUESTION:
-      return checkMultipleChoiceQuestion(req.payload, card);
-    case QUESTION_ANSWER:
-      return checkQuestionAnswer(req.payload, card);
     case FLASHCARD:
       return checkFlashCard(req.payload);
     default:

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -79,7 +79,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         payload: {
           question: 'Que faire dans cette situation ?',
           qcuGoodAnswer: 'plein de trucs',
-          qAnswers: [
+          qcAnswers: [
             { _id: new ObjectID(), text: 'rien' },
             { _id: new ObjectID(), text: 'des trucs' },
             { _id: new ObjectID(), text: 'ou pas' },
@@ -92,7 +92,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         template: 'multiple_choice_question',
         payload: {
           question: 'Que faire dans cette situation ?',
-          qAnswers: [
+          qcAnswers: [
             { _id: new ObjectID(), text: 'un truc', correct: true },
             { _id: new ObjectID(), text: 'rien', correct: false },
           ],
@@ -224,14 +224,14 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
       const requests = [
         {
           msg: 'valid answers',
-          payload: { qAnswers: [{ text: 'toto' }], qcuGoodAnswer: 'c\'est le S' },
+          payload: { qcAnswers: [{ text: 'toto' }], qcuGoodAnswer: 'c\'est le S' },
           code: 200,
         },
-        { msg: 'missing qAnswers', payload: { qAnswers: [{ text: '' }] }, code: 400 },
+        { msg: 'missing qcAnswers', payload: { qcAnswers: [{ text: '' }] }, code: 400 },
         {
           msg: 'too many chars in falsy answers',
           payload: {
-            qAnswers: [{ text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz' }],
+            qcAnswers: [{ text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz' }],
           },
           code: 200, // A GÉRER ?
         },
@@ -265,20 +265,20 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
       const requests = [
         {
           msg: 'valid answers',
-          payload: { qAnswers: [{ text: 'vie', correct: true }, { text: 'gique', correct: false }] },
+          payload: { qcAnswers: [{ text: 'vie', correct: true }, { text: 'gique', correct: false }] },
           code: 200,
         },
-        { msg: 'missing label', payload: { qAnswers: [{ correct: true }] }, code: 400 },
-        { msg: 'missing correct', payload: { qAnswers: [{ text: 'et la bête' }] }, code: 400 },
+        { msg: 'missing label', payload: { qcAnswers: [{ correct: true }] }, code: 400 },
+        { msg: 'missing correct', payload: { qcAnswers: [{ text: 'et la bête' }] }, code: 400 },
         {
           msg: 'missing correct answer',
-          payload: { qAnswers: [{ text: 'époque', correct: false }, { text: 'et le clochard', correct: false }] },
+          payload: { qcAnswers: [{ text: 'époque', correct: false }, { text: 'et le clochard', correct: false }] },
           code: 400,
         },
         {
           msg: 'too many chars in answer',
           payload: {
-            qAnswers: [
+            qcAnswers: [
               {
                 text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz',
                 correct: true,
@@ -406,7 +406,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card.findById(card._id).lean();
-      expect(cardUpdated.qAnswers.length).toEqual(card.qAnswers.length + 1);
+      expect(cardUpdated.qcAnswers.length).toEqual(card.qcAnswers.length + 1);
     });
 
     it('should return 404 if invalid card id', async () => {
@@ -473,7 +473,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
   let authToken = null;
   beforeEach(populateDB);
   const card = cardsList[11];
-  const answer = card.qAnswers[0];
+  const answer = card.qcAnswers[0];
 
   describe('VENDOR_ADMIN', () => {
     beforeEach(async () => {
@@ -493,9 +493,9 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
       const cardUpdated = await Card.findById(card._id).lean();
       expect(cardUpdated).toEqual(expect.objectContaining({
         ...card,
-        qAnswers: [
-          { _id: card.qAnswers[0]._id, text: 'je suis un texte' },
-          card.qAnswers[1],
+        qcAnswers: [
+          { _id: card.qcAnswers[0]._id, text: 'je suis un texte' },
+          card.qcAnswers[1],
         ],
       }));
     });
@@ -526,7 +526,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
       const otherQACard = cardsList[12];
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qAnswers[0]._id.toHexString()}`,
+        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qcAnswers[0]._id.toHexString()}`,
         payload: { text: 'je suis un texte' },
         headers: { 'x-access-token': authToken },
       });
@@ -566,7 +566,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
   let authToken = null;
   beforeEach(populateDB);
   const card = cardsList[12];
-  const answer = card.qAnswers[0];
+  const answer = card.qcAnswers[0];
 
   describe('VENDOR_ADMIN', () => {
     beforeEach(async () => {
@@ -585,10 +585,10 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const cardUpdated = await Card.findById(card._id).lean();
       expect(cardUpdated).toEqual(expect.objectContaining({
         ...card,
-        qAnswers: [
-          card.qAnswers[1],
-          card.qAnswers[2],
-          card.qAnswers[3],
+        qcAnswers: [
+          card.qcAnswers[1],
+          card.qcAnswers[2],
+          card.qcAnswers[3],
         ],
       }));
     });
@@ -627,7 +627,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const otherQACard = cardsList[11];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qAnswers[0]._id.toHexString()}`,
+        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qcAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -638,7 +638,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const publishedCard = cardsList[13];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.qAnswers[0]._id.toHexString()}`,
+        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.qcAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -650,7 +650,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const response = await app.inject({
         method: 'DELETE',
         url: `/cards/${oneQuestionCard._id.toHexString()}
-          /answers/${oneQuestionCard.qAnswers[0]._id.toHexString()}`,
+          /answers/${oneQuestionCard.qcAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -79,7 +79,11 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         payload: {
           question: 'Que faire dans cette situation ?',
           qcuGoodAnswer: 'plein de trucs',
-          qcuFalsyAnswers: ['rien', 'des trucs', 'ou pas'],
+          qAnswers: [
+            { _id: new ObjectID(), text: 'rien' },
+            { _id: new ObjectID(), text: 'des trucs' },
+            { _id: new ObjectID(), text: 'ou pas' },
+          ],
           explanation: 'en fait on doit faire ça',
         },
         id: singleChoiceQuestionId,
@@ -88,7 +92,10 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         template: 'multiple_choice_question',
         payload: {
           question: 'Que faire dans cette situation ?',
-          qcmAnswers: [{ label: 'un truc', correct: true }, { label: 'rien', correct: false }],
+          qAnswers: [
+            { _id: new ObjectID(), text: 'un truc', correct: true },
+            { _id: new ObjectID(), text: 'rien', correct: false },
+          ],
           explanation: 'en fait on doit faire ça',
         },
         id: multipleChoiceQuestionId,
@@ -215,15 +222,18 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
 
     describe('Single choice question', () => {
       const requests = [
-        { msg: 'valid answers', payload: { qcuFalsyAnswers: ['toto'], qcuGoodAnswer: 'c\'est le S' }, code: 200 },
-        { msg: 'missing falsyAnswer', payload: { qcuFalsyAnswers: [] }, code: 400 },
-        { msg: 'too many answer', payload: { qcuFalsyAnswers: ['toto', 'toto', 'toto', 'toto'] }, code: 400 },
+        {
+          msg: 'valid answers',
+          payload: { qAnswers: [{ text: 'toto' }], qcuGoodAnswer: 'c\'est le S' },
+          code: 200,
+        },
+        { msg: 'missing qAnswers', payload: { qAnswers: [{ text: '' }] }, code: 400 },
         {
           msg: 'too many chars in falsy answers',
           payload: {
-            qcuFalsyAnswers: ['eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz'],
+            qAnswers: [{ text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz' }],
           },
-          code: 400,
+          code: 200, // A GÉRER ?
         },
         {
           msg: 'too many chars in good answer',
@@ -255,28 +265,28 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
       const requests = [
         {
           msg: 'valid answers',
-          payload: { qcmAnswers: [{ label: 'vie', correct: true }, { label: 'gique', correct: false }] },
+          payload: { qAnswers: [{ text: 'vie', correct: true }, { text: 'gique', correct: false }] },
           code: 200,
         },
-        { msg: 'missing label', payload: { qcmAnswers: [{ correct: true }] }, code: 400 },
-        { msg: 'missing correct', payload: { qcmAnswers: [{ label: 'et la bête' }] }, code: 400 },
+        { msg: 'missing label', payload: { qAnswers: [{ correct: true }] }, code: 400 },
+        { msg: 'missing correct', payload: { qAnswers: [{ text: 'et la bête' }] }, code: 400 },
         {
           msg: 'missing correct answer',
-          payload: { qcmAnswers: [{ label: 'époque', correct: false }, { label: 'et le clochard', correct: false }] },
+          payload: { qAnswers: [{ text: 'époque', correct: false }, { text: 'et le clochard', correct: false }] },
           code: 400,
         },
         {
           msg: 'too many chars in answer',
           payload: {
-            qcmAnswers: [
+            qAnswers: [
               {
-                label: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz',
+                text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz',
                 correct: true,
               },
-              { label: 'bleue', correct: false },
+              { text: 'bleue', correct: false },
             ],
           },
-          code: 400,
+          code: 200, // A GÉRER ?
         },
       ];
 
@@ -396,7 +406,7 @@ describe('CARDS ROUTES - POST /cards/{_id}/answer', () => {
       expect(response.statusCode).toBe(200);
 
       const cardUpdated = await Card.findById(card._id).lean();
-      expect(cardUpdated.questionAnswers.length).toEqual(card.questionAnswers.length + 1);
+      expect(cardUpdated.qAnswers.length).toEqual(card.qAnswers.length + 1);
     });
 
     it('should return 404 if invalid card id', async () => {
@@ -463,7 +473,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
   let authToken = null;
   beforeEach(populateDB);
   const card = cardsList[11];
-  const answer = card.questionAnswers[0];
+  const answer = card.qAnswers[0];
 
   describe('VENDOR_ADMIN', () => {
     beforeEach(async () => {
@@ -483,9 +493,9 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
       const cardUpdated = await Card.findById(card._id).lean();
       expect(cardUpdated).toEqual(expect.objectContaining({
         ...card,
-        questionAnswers: [
-          { _id: card.questionAnswers[0]._id, text: 'je suis un texte' },
-          card.questionAnswers[1],
+        qAnswers: [
+          { _id: card.qAnswers[0]._id, text: 'je suis un texte' },
+          card.qAnswers[1],
         ],
       }));
     });
@@ -516,7 +526,7 @@ describe('CARDS ROUTES - PUT /cards/{_id}/answers/{answerId}', () => {
       const otherQACard = cardsList[12];
       const response = await app.inject({
         method: 'PUT',
-        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.questionAnswers[0]._id.toHexString()}`,
+        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qAnswers[0]._id.toHexString()}`,
         payload: { text: 'je suis un texte' },
         headers: { 'x-access-token': authToken },
       });
@@ -556,7 +566,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
   let authToken = null;
   beforeEach(populateDB);
   const card = cardsList[12];
-  const answer = card.questionAnswers[0];
+  const answer = card.qAnswers[0];
 
   describe('VENDOR_ADMIN', () => {
     beforeEach(async () => {
@@ -575,10 +585,10 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const cardUpdated = await Card.findById(card._id).lean();
       expect(cardUpdated).toEqual(expect.objectContaining({
         ...card,
-        questionAnswers: [
-          card.questionAnswers[1],
-          card.questionAnswers[2],
-          card.questionAnswers[3],
+        qAnswers: [
+          card.qAnswers[1],
+          card.qAnswers[2],
+          card.qAnswers[3],
         ],
       }));
     });
@@ -617,7 +627,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const otherQACard = cardsList[11];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.questionAnswers[0]._id.toHexString()}`,
+        url: `/cards/${card._id.toHexString()}/answers/${otherQACard.qAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -628,7 +638,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const publishedCard = cardsList[13];
       const response = await app.inject({
         method: 'DELETE',
-        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.questionAnswers[0]._id.toHexString()}`,
+        url: `/cards/${publishedCard._id.toHexString()}/answers/${publishedCard.qAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 
@@ -640,7 +650,7 @@ describe('CARDS ROUTES - DELETE /cards/{_id}/answers/{answerId}', () => {
       const response = await app.inject({
         method: 'DELETE',
         url: `/cards/${oneQuestionCard._id.toHexString()}
-          /answers/${oneQuestionCard.questionAnswers[0]._id.toHexString()}`,
+          /answers/${oneQuestionCard.qAnswers[0]._id.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
 

--- a/tests/integration/cards.test.js
+++ b/tests/integration/cards.test.js
@@ -79,11 +79,6 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         payload: {
           question: 'Que faire dans cette situation ?',
           qcuGoodAnswer: 'plein de trucs',
-          qcAnswers: [
-            { _id: new ObjectID(), text: 'rien' },
-            { _id: new ObjectID(), text: 'des trucs' },
-            { _id: new ObjectID(), text: 'ou pas' },
-          ],
           explanation: 'en fait on doit faire ça',
         },
         id: singleChoiceQuestionId,
@@ -92,10 +87,6 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
         template: 'multiple_choice_question',
         payload: {
           question: 'Que faire dans cette situation ?',
-          qcAnswers: [
-            { _id: new ObjectID(), text: 'un truc', correct: true },
-            { _id: new ObjectID(), text: 'rien', correct: false },
-          ],
           explanation: 'en fait on doit faire ça',
         },
         id: multipleChoiceQuestionId,
@@ -223,17 +214,14 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
     describe('Single choice question', () => {
       const requests = [
         {
-          msg: 'valid answers',
-          payload: { qcAnswers: [{ text: 'toto' }], qcuGoodAnswer: 'c\'est le S' },
+          msg: 'valid good answer',
+          payload: { qcuGoodAnswer: 'c\'est le S' },
           code: 200,
         },
-        { msg: 'missing qcAnswers', payload: { qcAnswers: [{ text: '' }] }, code: 400 },
         {
-          msg: 'too many chars in falsy answers',
-          payload: {
-            qcAnswers: [{ text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz' }],
-          },
-          code: 200, // A GÉRER ?
+          msg: 'missing good answer',
+          payload: { qcuGoodAnswer: '' },
+          code: 400,
         },
         {
           msg: 'too many chars in good answer',
@@ -254,52 +242,6 @@ describe('CARDS ROUTES - PUT /cards/{_id}', () => {
           });
 
           const cardUpdated = await Card.findById(singleChoiceQuestionId).lean({ virtuals: true });
-
-          expect(response.statusCode).toBe(request.code);
-          expect(cardUpdated).toEqual(expect.objectContaining({ isValid: false }));
-        });
-      });
-    });
-
-    describe('Multiple choice question', () => {
-      const requests = [
-        {
-          msg: 'valid answers',
-          payload: { qcAnswers: [{ text: 'vie', correct: true }, { text: 'gique', correct: false }] },
-          code: 200,
-        },
-        { msg: 'missing label', payload: { qcAnswers: [{ correct: true }] }, code: 400 },
-        { msg: 'missing correct', payload: { qcAnswers: [{ text: 'et la bête' }] }, code: 400 },
-        {
-          msg: 'missing correct answer',
-          payload: { qcAnswers: [{ text: 'époque', correct: false }, { text: 'et le clochard', correct: false }] },
-          code: 400,
-        },
-        {
-          msg: 'too many chars in answer',
-          payload: {
-            qcAnswers: [
-              {
-                text: 'eeeeeyuiolkjhgfdasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdvdvdvfghjklzasdfghjklz',
-                correct: true,
-              },
-              { text: 'bleue', correct: false },
-            ],
-          },
-          code: 200, // A GÉRER ?
-        },
-      ];
-
-      requests.forEach((request) => {
-        it(`should return a ${request.code} if ${request.msg}`, async () => {
-          const response = await app.inject({
-            method: 'PUT',
-            url: `/cards/${multipleChoiceQuestionId.toHexString()}`,
-            payload: request.payload,
-            headers: { 'x-access-token': authToken },
-          });
-
-          const cardUpdated = await Card.findById(multipleChoiceQuestionId).lean({ virtuals: true });
 
           expect(response.statusCode).toBe(request.code);
           expect(cardUpdated).toEqual(expect.objectContaining({ isValid: false }));

--- a/tests/integration/seed/cardsSeed.js
+++ b/tests/integration/seed/cardsSeed.js
@@ -27,21 +27,21 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: MULTIPLE_CHOICE_QUESTION,
-    qAnswers: [{ correct: false, text: 'au bois dormant' }, { correct: true, text: 'et le clochard' }],
+    qcAnswers: [{ correct: false, text: 'au bois dormant' }, { correct: true, text: 'et le clochard' }],
   },
-  { _id: new ObjectID(), template: SINGLE_CHOICE_QUESTION, qAnswers: [{ text: 'le papa' }, { text: 'la maman' }] },
+  { _id: new ObjectID(), template: SINGLE_CHOICE_QUESTION, qcAnswers: [{ text: 'le papa' }, { text: 'la maman' }] },
   { _id: new ObjectID(), template: ORDER_THE_SEQUENCE, orderedAnswers: ['rien', 'des trucs'] },
   { _id: new ObjectID(), template: SURVEY },
   { _id: new ObjectID(), template: OPEN_QUESTION },
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    qAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
+    qcAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
   },
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    qAnswers: [
+    qcAnswers: [
       { text: 'bye bye', _id: new ObjectID() },
       { text: 'bye bye', _id: new ObjectID() },
       { text: 'bye bye', _id: new ObjectID() },
@@ -51,7 +51,7 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    qAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
+    qcAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
   },
 ];
 

--- a/tests/integration/seed/cardsSeed.js
+++ b/tests/integration/seed/cardsSeed.js
@@ -27,21 +27,21 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: MULTIPLE_CHOICE_QUESTION,
-    qcmAnswers: [{ correct: false, label: 'au bois dormant' }, { correct: true, label: 'et le clochard' }],
+    qAnswers: [{ correct: false, text: 'au bois dormant' }, { correct: true, text: 'et le clochard' }],
   },
-  { _id: new ObjectID(), template: SINGLE_CHOICE_QUESTION, qcuFalsyAnswers: ['le papa', 'la maman'] },
+  { _id: new ObjectID(), template: SINGLE_CHOICE_QUESTION, qAnswers: [{ text: 'le papa' }, { text: 'la maman' }] },
   { _id: new ObjectID(), template: ORDER_THE_SEQUENCE, orderedAnswers: ['rien', 'des trucs'] },
   { _id: new ObjectID(), template: SURVEY },
   { _id: new ObjectID(), template: OPEN_QUESTION },
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    questionAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
+    qAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
   },
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    questionAnswers: [
+    qAnswers: [
       { text: 'bye bye', _id: new ObjectID() },
       { text: 'bye bye', _id: new ObjectID() },
       { text: 'bye bye', _id: new ObjectID() },
@@ -51,7 +51,7 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: QUESTION_ANSWER,
-    questionAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
+    qAnswers: [{ text: 'hallo', _id: new ObjectID() }, { text: 'shalom', _id: new ObjectID() }],
   },
 ];
 

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -68,7 +68,7 @@ describe('addCardAnswer', () => {
   it('should add card answer', async () => {
     const cardId = new ObjectID();
     await CardHelper.addCardAnswer(cardId);
-    sinon.assert.calledOnceWithExactly(updateOne, { _id: cardId }, { $push: { qAnswers: { text: '' } } });
+    sinon.assert.calledOnceWithExactly(updateOne, { _id: cardId }, { $push: { qcAnswers: { text: '' } } });
   });
 });
 
@@ -86,8 +86,8 @@ describe('updateCardAnswer', () => {
     await CardHelper.updateCardAnswer(params, { text: 'test text' });
     sinon.assert.calledOnceWithExactly(
       updateOne,
-      { _id: params._id, 'qAnswers._id': params.answerId },
-      { $set: { 'qAnswers.$.text': 'test text' } }
+      { _id: params._id, 'qcAnswers._id': params.answerId },
+      { $set: { 'qcAnswers.$.text': 'test text' } }
     );
   });
 });
@@ -107,7 +107,7 @@ describe('deleteCardAnswer', () => {
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: params._id },
-      { $pull: { qAnswers: { _id: params.answerId } } }
+      { $pull: { qcAnswers: { _id: params.answerId } } }
     );
   });
 });

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -68,7 +68,7 @@ describe('addCardAnswer', () => {
   it('should add card answer', async () => {
     const cardId = new ObjectID();
     await CardHelper.addCardAnswer(cardId);
-    sinon.assert.calledOnceWithExactly(updateOne, { _id: cardId }, { $push: { questionAnswers: { text: '' } } });
+    sinon.assert.calledOnceWithExactly(updateOne, { _id: cardId }, { $push: { qAnswers: { text: '' } } });
   });
 });
 
@@ -86,8 +86,8 @@ describe('updateCardAnswer', () => {
     await CardHelper.updateCardAnswer(params, { text: 'test text' });
     sinon.assert.calledOnceWithExactly(
       updateOne,
-      { _id: params._id, 'questionAnswers._id': params.answerId },
-      { $set: { 'questionAnswers.$.text': 'test text' } }
+      { _id: params._id, 'qAnswers._id': params.answerId },
+      { $set: { 'qAnswers.$.text': 'test text' } }
     );
   });
 });
@@ -107,7 +107,7 @@ describe('deleteCardAnswer', () => {
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: params._id },
-      { $pull: { questionAnswers: { _id: params.answerId } } }
+      { $pull: { qAnswers: { _id: params.answerId } } }
     );
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendor

- Périmetre roles : admin / rof

- Cas d'usage : 
qcuFalsyAnswers, qcmAnswers et questionAnswers sont fondus en un seul champ qAnswers.
L'utilisation des qcm et des qcu se fera sous la même forme que question answer :
- ajout des champs answer en plus via un bouton
- passage par les routes /{_id}/answers (POST, PUT, DELETE)

Dans cette PR :
- uniquement la refonte en un seul champ
- le fait que qcm et qcu ne soit plus comme avant est voulu (préparation à l'ajout de réponse par bouton)
- on reste sur une modification par la route updateCard, donc les tests seront amenés à être changés. Pour l'instant je les ai adapté pour ne pas avoir d'erreurs et tester que le comportement reste bien le même malgré la fusion des champs.