### PR TITLE
Com 1691 put

### DIFF
--- a/src/controllers/cardController.js
+++ b/src/controllers/cardController.js
@@ -28,7 +28,7 @@ const addAnswer = async (req) => {
 
 const updateAnswer = async (req) => {
   try {
-    await CardHelper.updateCardAnswer(req.params, req.payload);
+    await CardHelper.updateCardAnswer(req.pre.card, req.params, req.payload);
 
     return { message: translate[language].cardUpdated };
   } catch (e) {

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -2,7 +2,7 @@ const flat = require('flat');
 const Card = require('../models/Card');
 const Activity = require('../models/Activity');
 const GCloudStorageHelper = require('./gCloudStorage');
-const { QUESTION_ANSWER } = require('./constants');
+const { MULTIPLE_CHOICE_QUESTION, SINGLE_CHOICE_QUESTION, QUESTION_ANSWER } = require('./constants');
 
 exports.addCard = async (activityId, payload) => {
   const card = await Card.create(payload);
@@ -17,7 +17,7 @@ exports.updateCard = async (cardId, payload) => Card.updateOne(
 exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { qcAnswers: { text: '' } } });
 
 exports.getAnswerKeyToUpdate = (template) => {
-  if ([QUESTION_ANSWER].includes(template)) return 'qcAnswers';
+  if ([MULTIPLE_CHOICE_QUESTION, SINGLE_CHOICE_QUESTION, QUESTION_ANSWER].includes(template)) return 'qcAnswers';
 
   return '';
 };

--- a/src/helpers/cards.js
+++ b/src/helpers/cards.js
@@ -2,6 +2,7 @@ const flat = require('flat');
 const Card = require('../models/Card');
 const Activity = require('../models/Activity');
 const GCloudStorageHelper = require('./gCloudStorage');
+const { QUESTION_ANSWER } = require('./constants');
 
 exports.addCard = async (activityId, payload) => {
   const card = await Card.create(payload);
@@ -15,10 +16,20 @@ exports.updateCard = async (cardId, payload) => Card.updateOne(
 
 exports.addCardAnswer = async cardId => Card.updateOne({ _id: cardId }, { $push: { qcAnswers: { text: '' } } });
 
-exports.updateCardAnswer = async (params, payload) => Card.updateOne(
-  { _id: params._id, 'qcAnswers._id': params.answerId },
-  { $set: { 'qcAnswers.$.text': payload.text } }
-);
+exports.getAnswerKeyToUpdate = (template) => {
+  if ([QUESTION_ANSWER].includes(template)) return 'qcAnswers';
+
+  return '';
+};
+
+exports.updateCardAnswer = async (card, params, payload) => {
+  const key = exports.getAnswerKeyToUpdate(card.template);
+
+  return Card.updateOne(
+    { _id: card._id, [`${key}._id`]: params.answerId },
+    { $set: flat({ [`${key}.$`]: payload }) }
+  );
+};
 
 exports.deleteCardAnswer = async params => Card.updateOne(
   { _id: params._id }, { $pull: { qcAnswers: { _id: params.answerId } } }

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -90,9 +90,9 @@ exports.plugin = {
             answerId: Joi.objectId().required(),
           }),
           payload: Joi.object({
-            text: Joi.string().required(),
-            correct: Joi.string(),
-          }),
+            text: Joi.string(),
+            correct: Joi.boolean(),
+          }).min(1),
         },
         auth: { scope: ['programs:edit'] },
         pre: [{ method: authorizeCardAnswerUpdate, assign: 'card' }],

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -91,10 +91,11 @@ exports.plugin = {
           }),
           payload: Joi.object({
             text: Joi.string().required(),
+            correct: Joi.string(),
           }),
         },
         auth: { scope: ['programs:edit'] },
-        pre: [{ method: authorizeCardAnswerUpdate }],
+        pre: [{ method: authorizeCardAnswerUpdate, assign: 'card' }],
       },
       handler: updateAnswer,
     });

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -1,5 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
+const has = require('lodash/has');
 const Card = require('../../models/Card');
 const {
   FILL_THE_GAPS,
@@ -84,7 +85,7 @@ exports.authorizeCardAnswerUpdate = async (req) => {
   const card = await Card.findOne({ _id: req.params._id, 'qcAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
 
-  if ('correct' in req.payload && card.template !== MULTIPLE_CHOICE_QUESTION) throw Boom.badRequest();
+  if (has(req.payload, 'correct') && card.template !== MULTIPLE_CHOICE_QUESTION) throw Boom.badRequest();
 
   return card;
 };

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -9,6 +9,7 @@ const {
   QUESTION_ANSWER_MAX_ANSWERS_COUNT,
   QUESTION_ANSWER_MIN_ANSWERS_COUNT,
   FLASHCARD_TEXT_MAX_LENGTH,
+  MULTIPLE_CHOICE_QUESTION,
 } = require('../../helpers/constants');
 const Activity = require('../../models/Activity');
 
@@ -83,7 +84,7 @@ exports.authorizeCardAnswerUpdate = async (req) => {
   const card = await Card.findOne({ _id: req.params._id, 'qcAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
 
-  return null;
+  return card;
 };
 
 exports.authorizeCardAnswerDeletion = async (req) => {

--- a/src/routes/preHandlers/cards.js
+++ b/src/routes/preHandlers/cards.js
@@ -84,6 +84,8 @@ exports.authorizeCardAnswerUpdate = async (req) => {
   const card = await Card.findOne({ _id: req.params._id, 'qcAnswers._id': req.params.answerId }).lean();
   if (!card) throw Boom.notFound();
 
+  if ('correct' in req.payload && card.template !== MULTIPLE_CHOICE_QUESTION) throw Boom.badRequest();
+
   return card;
 };
 

--- a/tests/integration/seed/cardsSeed.js
+++ b/tests/integration/seed/cardsSeed.js
@@ -27,9 +27,16 @@ const cardsList = [
   {
     _id: new ObjectID(),
     template: MULTIPLE_CHOICE_QUESTION,
-    qcAnswers: [{ correct: false, text: 'au bois dormant' }, { correct: true, text: 'et le clochard' }],
+    qcAnswers: [
+      { _id: new ObjectID(), correct: false, text: 'au bois dormant' },
+      { _id: new ObjectID(), correct: true, text: 'et le clochard' },
+    ],
   },
-  { _id: new ObjectID(), template: SINGLE_CHOICE_QUESTION, qcAnswers: [{ text: 'le papa' }, { text: 'la maman' }] },
+  {
+    _id: new ObjectID(),
+    template: SINGLE_CHOICE_QUESTION,
+    qcAnswers: [{ _id: new ObjectID(), text: 'le papa' }, { _id: new ObjectID(), text: 'la maman' }],
+  },
   { _id: new ObjectID(), template: ORDER_THE_SEQUENCE, orderedAnswers: ['rien', 'des trucs'] },
   { _id: new ObjectID(), template: SURVEY },
   { _id: new ObjectID(), template: OPEN_QUESTION },


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendor

- Périmetre roles : admin / rof

- Cas d'usage : 
Suite du changement sur qcAnswers. L'édition de réponse pour QCM et QCU passe désormais par la route updateQuestionAnswer.
Changement dans l'utilisation de QCM (vu avec Sophie) :
- désormais le texte et la box sont indépendants : on peut avoir une carte qcm sans réponse valide, la carte sera bien sûr  invalide mais réponses seront gardées en back.

Reste à faire :
la route post et delete pour ajouter de nouvelles réponses et les enlever