### PR TITLE
COM-1711 set firstMobileConnection when creating a user from mobile

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -196,6 +196,7 @@ exports.createUser = async (userPayload, credentials) => {
   const { sector, role: roleId, ...payload } = cloneDeep(userPayload);
   const companyId = payload.company || get(credentials, 'company._id', null);
 
+  if (userPayload.origin === MOBILE) payload.firstMobileConnection = moment().toDate();
   if (!roleId || !credentials) return User.create({ ...payload, refreshToken: uuidv4() });
 
   const role = await Role.findById(roleId, { name: 1, interface: 1 }).lean();

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -69,13 +69,14 @@ describe('POST /users', () => {
       const res = await app.inject({ method: 'POST', url: '/users', payload });
 
       expect(res.statusCode).toBe(200);
-      expect(res.result.data.user._id).toEqual(expect.any(Object));
 
-      const user = await User.findById(res.result.data.user._id).lean();
+      const { user } = res.result.data;
+      expect(user._id).toEqual(expect.any(Object));
       expect(user.identity.firstname).toBe('Test');
       expect(user.identity.lastname).toBe('Kirk');
       expect(user.local.email).toBe('newuser@alenvi.io');
       expect(user.contact.phone).toBe('0606060606');
+      expect(user.firstMobileConnection).toBeDefined();
     });
   });
 
@@ -109,6 +110,7 @@ describe('POST /users', () => {
       expect(res.result.data.user.identity.lastname).toBe(payload.identity.lastname);
       expect(res.result.data.user.local.email).toBe(payload.local.email);
       expect(res.result.data.user.serialNumber).toEqual(expect.any(String));
+      expect(res.result.data.user.firstMobileConnection).toBeUndefined();
 
       const userSectorHistory = await SectorHistory
         .findOne({ auxiliary: res.result.data.user._id, sector: userSectors[0]._id, startDate: { $exists: false } })


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : mobile

- Périmetre roles : aucun

- Cas d'usage : Quand je cree un compte sur mobile, firstMobileConnection est directement defini
