### PR TITLE
COM-1696: populate categories

### DIFF
--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -36,6 +36,7 @@ exports.listELearning = async (credentials) => {
         },
       ],
     })
+    .populate('categories')
     .lean();
 };
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -94,6 +94,8 @@ describe('listELearning', () => {
           },
         ],
       })
+      .chain('populate')
+      .withExactArgs('categories')
       .chain('lean')
       .once()
       .returns(programsList);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : mobile

- Périmetre roles : tous

- Cas d'usage : les catégories sont populés dans programmes afin de récupérer le nom d'une catégorie et de pouvoir ranger les programmes par catégories dans catalog
