### PR TITLE
COM-1742: send image for subprograms from back

### DIFF
--- a/src/helpers/subPrograms.js
+++ b/src/helpers/subPrograms.js
@@ -34,7 +34,7 @@ exports.updateSubProgram = async (subProgramId, payload) => {
 
 exports.listELearningDraft = async () => {
   const subPrograms = await SubProgram.find({ status: DRAFT })
-    .populate({ path: 'program', select: '_id name description' })
+    .populate({ path: 'program', select: '_id name description image' })
     .populate({ path: 'steps', select: 'type' })
     .lean({ virtuals: true });
   return subPrograms.filter(sp => sp.steps.length && sp.isStrictlyELearning);

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -238,7 +238,7 @@ describe('listELearningDraft', () => {
     SubProgramMock.expects('find')
       .withExactArgs({ status: 'draft' })
       .chain('populate')
-      .withExactArgs({ path: 'program', select: '_id name description' })
+      .withExactArgs({ path: 'program', select: '_id name description image' })
       .chain('populate')
       .withExactArgs({ path: 'steps', select: 'type' })
       .chain('lean')


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : mobile

- Périmetre roles : vendeur admin / rof

- Cas d'usage : dans formations à tester je reçois l'image associé au programme quand elle existe
