### PR TITLE
COM-1769 category list without sinon-mongoose

### DIFF
--- a/tests/unit/helpers/categories.test.js
+++ b/tests/unit/helpers/categories.test.js
@@ -34,9 +34,7 @@ describe('list', () => {
   it('should return categories', async () => {
     const categoriesList = [{ name: 'ma première catégorie' }, { name: 'ma seconde catégorie' }];
 
-    list.returns(
-      SinonMongoose.stubChainedQueries([categoriesList], ['populate', 'lean'])
-    );
+    list.returns(SinonMongoose.stubChainedQueries([categoriesList]));
 
     const result = await CategoryHelper.list();
 

--- a/tests/unit/helpers/categories.test.js
+++ b/tests/unit/helpers/categories.test.js
@@ -3,8 +3,7 @@ const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const Category = require('../../../src/models/Category');
 const CategoryHelper = require('../../../src/helpers/categories');
-
-require('sinon-mongoose');
+const SinonMongoose = require('../sinonMongoose');
 
 describe('create', () => {
   let save;
@@ -24,28 +23,29 @@ describe('create', () => {
 });
 
 describe('list', () => {
-  let CategoryMock;
+  let list;
   beforeEach(() => {
-    CategoryMock = sinon.mock(Category);
+    list = sinon.stub(Category, 'find');
   });
   afterEach(() => {
-    CategoryMock.restore();
+    list.restore();
   });
 
   it('should return categories', async () => {
     const categoriesList = [{ name: 'ma première catégorie' }, { name: 'ma seconde catégorie' }];
 
-    CategoryMock.expects('find')
-      .once()
-      .chain('populate')
-      .withExactArgs({ path: 'programsCount' })
-      .chain('lean')
-      .once()
-      .returns(categoriesList);
+    list.returns(
+      SinonMongoose.stubChainedQueries([categoriesList], ['populate', 'lean'])
+    );
 
     const result = await CategoryHelper.list();
 
     expect(result).toMatchObject(categoriesList);
+    SinonMongoose.calledWithExactly(list, [
+      { query: 'find' },
+      { query: 'populate', args: { path: 'programsCount' } },
+      { query: 'lean' },
+    ]);
   });
 });
 


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [np] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendeur

- Périmetre roles : rof admin

- Cas d'usage : plus besoin de ce satané sinon-mongoose pour lister nos belles catégories!
