### PR TITLE
COM-1780 - set adress in history if exists

### DIFF
--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -53,12 +53,12 @@ exports.createEventHistory = async (payload, credentials, action) => {
       customer,
       absence,
       internalHour,
-      address,
       misc,
       repetition,
     }),
   };
 
+  if (address && Object.keys(address).length) eventHistory.event.address = address;
   if (payload.sector) eventHistory.sectors = [payload.sector];
   if (payload.auxiliary) {
     eventHistory.auxiliaries = [payload.auxiliary];


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Coach / auxilaire

- Cas d'usage : Je peux supprimer les evenements qui ont un objet `address: {}`
