### PR TITLE
COM-1713: don't send refreshToken after create account

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -169,8 +169,8 @@ exports.createUser = async (userPayload, credentials) => {
   if (!credentials) {
     if (userPayload.origin !== MOBILE) return User.create(payload);
     const user = await User.create({ ...payload, firstMobileConnection: moment().toDate() });
-    return User.findOne({ _id: user._id })
-      .lean({ virtuals: true, autopopulate: true });
+
+    return User.findOne({ _id: user._id }).lean({ virtuals: true, autopopulate: true });
   }
 
   const companyId = payload.company || get(credentials, 'company._id');
@@ -181,8 +181,8 @@ exports.createUser = async (userPayload, credentials) => {
 
   if (role.name === TRAINER) {
     const user = await User.create({ ...payload, role: { [role.interface]: role._id } });
-    return User.findOne({ _id: user._id })
-      .lean({ virtuals: true });
+
+    return User.findOne({ _id: user._id }).lean({ virtuals: true });
   }
   const user = await User.create({ ...payload, role: { [role.interface]: role._id }, company: companyId });
 

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -168,9 +168,7 @@ exports.createUser = async (userPayload, credentials) => {
 
   if (!credentials) {
     if (userPayload.origin !== MOBILE) return User.create(payload);
-    const user = await User.create({ ...payload, firstMobileConnection: moment().toDate() });
-
-    return User.findOne({ _id: user._id }).lean({ virtuals: true, autopopulate: true });
+    return User.create({ ...payload, firstMobileConnection: moment().toDate() });
   }
 
   const companyId = payload.company || get(credentials, 'company._id');
@@ -179,11 +177,7 @@ exports.createUser = async (userPayload, credentials) => {
   const role = await Role.findById(userPayload.role, { name: 1, interface: 1 }).lean();
   if (!role) throw Boom.badRequest(translate[language].unknownRole);
 
-  if (role.name === TRAINER) {
-    const user = await User.create({ ...payload, role: { [role.interface]: role._id } });
-
-    return User.findOne({ _id: user._id }).lean({ virtuals: true });
-  }
+  if (role.name === TRAINER) return User.create({ ...payload, role: { [role.interface]: role._id } });
   const user = await User.create({ ...payload, role: { [role.interface]: role._id }, company: companyId });
 
   if (userPayload.sector) {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -270,6 +270,22 @@ function populateSectors(docs, next) {
   return next();
 }
 
+function formatPayload(doc, next) {
+  // eslint-disable-next-line no-param-reassign
+  if (get(doc, 'refreshToken')) doc.refreshToken = null;
+  // eslint-disable-next-line no-param-reassign
+  if (get(doc, 'passwordToken')) {
+    // eslint-disable-next-line no-param-reassign
+    doc.passwordToken.token = null;
+    // eslint-disable-next-line no-param-reassign
+    doc.passwordToken.expiresIn = null;
+  }
+  // eslint-disable-next-line no-param-reassign
+  if (get(doc, 'local.password')) doc.local.password = null;
+
+  return next();
+}
+
 UserSchema.virtual('sector', {
   ref: 'SectorHistory',
   localField: '_id',
@@ -316,6 +332,7 @@ UserSchema.pre('aggregate', validateAggregation);
 UserSchema.post('findOne', populateSector);
 UserSchema.post('findOneAndUpdate', populateSector);
 UserSchema.post('find', populateSectors);
+UserSchema.post('save', formatPayload);
 
 UserSchema.plugin(mongooseLeanVirtuals);
 UserSchema.plugin(autopopulate);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -273,16 +273,10 @@ function populateSectors(docs, next) {
 async function formatPayload(doc, next) {
   const payload = doc.toObject();
 
-  // eslint-disable-next-line no-param-reassign
   if (get(doc, 'refreshToken')) delete payload.refreshToken;
-
-  // eslint-disable-next-line no-param-reassign
   if (get(doc, 'passwordToken')) delete payload.passwordToken;
-
-  // eslint-disable-next-line no-param-reassign
   if (get(doc, 'local.password')) delete payload.local.password;
 
-  // eslint-disable-next-line no-param-reassign
   doc.overwrite(payload);
 
   return next();

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -270,18 +270,20 @@ function populateSectors(docs, next) {
   return next();
 }
 
-function formatPayload(doc, next) {
+async function formatPayload(doc, next) {
+  const payload = doc.toObject();
+
   // eslint-disable-next-line no-param-reassign
-  if (get(doc, 'refreshToken')) doc.refreshToken = null;
+  if (get(doc, 'refreshToken')) delete payload.refreshToken;
+
   // eslint-disable-next-line no-param-reassign
-  if (get(doc, 'passwordToken')) {
-    // eslint-disable-next-line no-param-reassign
-    doc.passwordToken.token = null;
-    // eslint-disable-next-line no-param-reassign
-    doc.passwordToken.expiresIn = null;
-  }
+  if (get(doc, 'passwordToken')) delete payload.passwordToken;
+
   // eslint-disable-next-line no-param-reassign
-  if (get(doc, 'local.password')) doc.local.password = null;
+  if (get(doc, 'local.password')) delete payload.local.password;
+
+  // eslint-disable-next-line no-param-reassign
+  doc.overwrite(payload);
 
   return next();
 }

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -75,8 +75,8 @@ describe('POST /users', () => {
       expect(user.local.email).toBe('newuser@alenvi.io');
       expect(user.contact.phone).toBe('0606060606');
       expect(user.firstMobileConnection).toBeDefined();
-      expect(res.result.data.user.refreshToken).toBeNull();
-      expect(res.result.data.user.local.password).toBeNull();
+      expect(res.result.data.user.refreshToken).not.toBeDefined();
+      expect(res.result.data.user.local.password).not.toBeDefined();
     });
     it('should not create user if password too short', async () => {
       const payload = {

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -75,6 +75,8 @@ describe('POST /users', () => {
       expect(user.local.email).toBe('newuser@alenvi.io');
       expect(user.contact.phone).toBe('0606060606');
       expect(user.firstMobileConnection).toBeDefined();
+      expect(res.result.data.user.refreshToken).toBeNull();
+      expect(res.result.data.user.local.password).toBeNull();
     });
     it('should not create user if password too short', async () => {
       const payload = {

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -641,12 +641,10 @@ describe('createUser', () => {
     sinon.assert.calledOnceWithExactly(momentToDate);
     sinon.assert.notCalled(createHistoryStub);
     sinon.assert.notCalled(roleFindById);
-    sinon.assert.calledOnceWithExactly(userCreate, {
-      ...payload,
-      refreshToken: sinon.match.string,
-      firstMobileConnection: date,
-      origin: MOBILE,
-    });
+    sinon.assert.calledOnceWithExactly(
+      userCreate,
+      { ...payload, refreshToken: sinon.match.string, firstMobileConnection: date, origin: MOBILE }
+    );
   });
 
   it('client admin - should create an auxiliary for his organization and handles sector', async () => {
@@ -666,33 +664,40 @@ describe('createUser', () => {
       origin: WEBAPP,
     };
 
-    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'auxiliary', interface: 'client' }],
-      ['lean']));
+    roleFindById.returns(SinonMongoose.stubChainedQueries(
+      [{ _id: roleId, name: 'auxiliary', interface: 'client' }],
+      ['lean']
+    ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
-      ['populate', 'lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser], ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
     sinon.assert.calledWithExactly(createHistoryStub, { _id: userId, sector: payload.sector }, companyId);
-    SinonMongoose.calledWithExactly(roleFindById, [
-      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
-      { query: 'lean' },
-    ]);
-    sinon.assert.calledOnceWithExactly(userCreate, {
-      identity: { lastname: 'Test' },
-      local: { email: 'toto@test.com' },
-      origin: WEBAPP,
-      company: companyId,
-      refreshToken: sinon.match.string,
-      role: { client: roleId },
-    });
-    SinonMongoose.calledWithExactly(userFindOne, [
-      { query: 'findOne', args: [{ _id: userId }] },
-      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
-      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
-    ]);
+    SinonMongoose.calledWithExactly(
+      roleFindById,
+      [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      userCreate,
+      {
+        identity: { lastname: 'Test' },
+        local: { email: 'toto@test.com' },
+        origin: WEBAPP,
+        company: companyId,
+        refreshToken: sinon.match.string,
+        role: { client: roleId },
+      }
+    );
+    SinonMongoose.calledWithExactly(
+      userFindOne,
+      [
+        { query: 'findOne', args: [{ _id: userId }] },
+        { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
+        { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+      ]
+    );
     sinon.assert.notCalled(userFindOneAndUpdate);
   });
 
@@ -706,30 +711,37 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'coach' } };
 
-    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'coach', interface: 'client' }],
-      ['lean']));
+    roleFindById.returns(SinonMongoose.stubChainedQueries(
+      [{ _id: roleId, name: 'coach', interface: 'client' }],
+      ['lean']
+    ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
-      ['populate', 'lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser], ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
     sinon.assert.notCalled(createHistoryStub);
-    SinonMongoose.calledWithExactly(roleFindById, [
-      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
-      { query: 'lean' },
-    ]);
-    sinon.assert.calledOnceWithExactly(userCreate, {
-      ...payload,
-      company: companyId,
-      refreshToken: sinon.match.string,
-    });
-    SinonMongoose.calledWithExactly(userFindOne, [
-      { query: 'findOne', args: [{ _id: userId }] },
-      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
-      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
-    ]);
+    SinonMongoose.calledWithExactly(
+      roleFindById,
+      [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      userCreate,
+      {
+        ...payload,
+        company: companyId,
+        refreshToken: sinon.match.string,
+      }
+    );
+    SinonMongoose.calledWithExactly(
+      userFindOne,
+      [
+        { query: 'findOne', args: [{ _id: userId }] },
+        { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
+        { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+      ]
+    );
   });
 
   it('vendor admin - should create a client admin with company', async () => {
@@ -743,29 +755,32 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'client_admin' } };
 
-    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'client_admin', interface: 'client' }],
-      ['lean']));
+    roleFindById.returns(SinonMongoose.stubChainedQueries(
+      [{ _id: roleId, name: 'client_admin', interface: 'client' }],
+      ['lean']
+    ));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
-      ['populate', 'lean']));
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser], ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    SinonMongoose.calledWithExactly(roleFindById, [
-      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
-      { query: 'lean' },
-    ]);
-    sinon.assert.calledOnceWithExactly(userCreate, {
-      ...payload,
-      role: { client: roleId },
-      refreshToken: sinon.match.string,
-    });
-    SinonMongoose.calledWithExactly(userFindOne, [
-      { query: 'findOne', args: [{ _id: userId }] },
-      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: payload.company } }] },
-      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
-    ]);
+    SinonMongoose.calledWithExactly(
+      roleFindById,
+      [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      userCreate,
+      { ...payload, role: { client: roleId }, refreshToken: sinon.match.string }
+    );
+    SinonMongoose.calledWithExactly(
+      userFindOne,
+      [
+        { query: 'findOne', args: [{ _id: userId }] },
+        { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: payload.company } }] },
+        { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+      ]
+    );
   });
 
   it('vendor admin - should create a trainer without company', async () => {
@@ -778,22 +793,23 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'trainer' } };
 
-    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'trainer', interface: 'vendor' }],
-      ['lean']));
+    roleFindById.returns(SinonMongoose.stubChainedQueries(
+      [{ _id: roleId, name: 'trainer', interface: 'vendor' }],
+      ['lean']
+    ));
     userCreate.returns(newUser);
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    SinonMongoose.calledWithExactly(roleFindById, [
-      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
-      { query: 'lean' },
-    ]);
-    sinon.assert.calledOnceWithExactly(userCreate, {
-      ...payload,
-      role: { vendor: roleId },
-      refreshToken: sinon.match.string,
-    });
+    SinonMongoose.calledWithExactly(
+      roleFindById,
+      [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      userCreate,
+      { ...payload, role: { vendor: roleId }, refreshToken: sinon.match.string }
+    );
   });
 
   it('vendor admin - should create a user without role but with company', async () => {
@@ -826,8 +842,7 @@ describe('createUser', () => {
       origin: WEBAPP,
     };
     try {
-      roleFindById.returns(SinonMongoose.stubChainedQueries([null],
-        ['lean']));
+      roleFindById.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
 
       await UsersHelper.createUser(payload, { company: { _id: companyId } });
     } catch (e) {
@@ -835,10 +850,10 @@ describe('createUser', () => {
     } finally {
       sinon.assert.notCalled(createHistoryStub);
       sinon.assert.notCalled(userCreate);
-      SinonMongoose.calledWithExactly(roleFindById, [
-        { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
-        { query: 'lean' },
-      ]);
+      SinonMongoose.calledWithExactly(
+        roleFindById,
+        [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
+      );
     }
   });
 });

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -641,6 +641,7 @@ describe('createUser', () => {
     sinon.assert.calledOnceWithExactly(momentToDate);
     sinon.assert.notCalled(createHistoryStub);
     sinon.assert.notCalled(roleFindById);
+    sinon.assert.notCalled(userFindOne);
     sinon.assert.calledOnceWithExactly(
       userCreate,
       { ...payload, refreshToken: sinon.match.string, firstMobileConnection: date, origin: MOBILE }
@@ -802,6 +803,7 @@ describe('createUser', () => {
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
+    sinon.assert.notCalled(userFindOne);
     SinonMongoose.calledWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -636,6 +636,12 @@ describe('createUser', () => {
       .withExactArgs({ ...payload, refreshToken: sinon.match.string, firstMobileConnection: date, origin: MOBILE })
       .once()
       .returns(payload);
+    UserMock.expects('findOne')
+      .withExactArgs({ _id: payload._id })
+      .chain('lean')
+      .withExactArgs({ virtuals: true, autopopulate: true })
+      .returns(payload);
+    UserMock.expects('findOne').never();
 
     const result = await UsersHelper.createUser(payload, null);
 
@@ -776,6 +782,11 @@ describe('createUser', () => {
       .returns({ _id: roleId, name: 'trainer', interface: 'vendor' });
     UserMock.expects('create')
       .withExactArgs({ ...payload, role: { vendor: roleId }, refreshToken: sinon.match.string })
+      .returns(newUser);
+    UserMock.expects('findOne')
+      .withExactArgs({ _id: newUser._id })
+      .chain('lean')
+      .withExactArgs({ virtuals: true })
       .returns(newUser);
     UserMock.expects('findOne').never();
 

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -634,8 +634,6 @@ describe('createUser', () => {
 
     momentToDate.returns(date);
     userCreate.returns(payload);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([payload],
-      ['lean']));
 
     const result = await UsersHelper.createUser(payload, null);
 
@@ -649,10 +647,6 @@ describe('createUser', () => {
       firstMobileConnection: date,
       origin: MOBILE,
     });
-    SinonMongoose.calledWithExactly(userFindOne, [
-      { query: 'findOne', args: [{ _id: payload._id }] },
-      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
-    ]);
   });
 
   it('client admin - should create an auxiliary for his organization and handles sector', async () => {
@@ -787,8 +781,6 @@ describe('createUser', () => {
     roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'trainer', interface: 'vendor' }],
       ['lean']));
     userCreate.returns(newUser);
-    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
-      ['lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
@@ -802,10 +794,6 @@ describe('createUser', () => {
       role: { vendor: roleId },
       refreshToken: sinon.match.string,
     });
-    SinonMongoose.calledWithExactly(userFindOne, [
-      { query: 'findOne', args: [{ _id: newUser._id }] },
-      { query: 'lean', args: [{ virtuals: true }] },
-    ]);
   });
 
   it('vendor admin - should create a user without role but with company', async () => {

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 const Boom = require('@hapi/boom');
 const flat = require('flat');
 const omit = require('lodash/omit');
+const SinonMongoose = require('../sinonMongoose');
 const UsersHelper = require('../../../src/helpers/users');
 const SectorHistoriesHelper = require('../../../src/helpers/sectorHistories');
 const translate = require('../../../src/helpers/translate');
@@ -573,8 +574,10 @@ describe('createAndSaveFile', () => {
 });
 
 describe('createUser', () => {
-  let UserMock;
-  let RoleMock;
+  let userFindOne;
+  let roleFindById;
+  let userCreate;
+  let userFindOneAndUpdate;
   let objectIdStub;
   let createHistoryStub;
   let momentToDate;
@@ -582,16 +585,20 @@ describe('createUser', () => {
   const roleId = new ObjectID();
 
   beforeEach(() => {
-    UserMock = sinon.mock(User);
-    RoleMock = sinon.mock(Role);
+    userFindOne = sinon.stub(User, 'findOne');
+    roleFindById = sinon.stub(Role, 'findById');
+    userCreate = sinon.stub(User, 'create');
+    userFindOneAndUpdate = sinon.stub(User, 'findOneAndUpdate');
     objectIdStub = sinon.stub(mongoose.Types, 'ObjectId').returns(userId);
     createHistoryStub = sinon.stub(SectorHistoriesHelper, 'createHistory');
     momentToDate = sinon.stub(momentProto, 'toDate');
   });
 
   afterEach(() => {
-    UserMock.restore();
-    RoleMock.restore();
+    userFindOne.restore();
+    roleFindById.restore();
+    userCreate.restore();
+    userFindOneAndUpdate.restore();
     objectIdStub.restore();
     createHistoryStub.restore();
     momentToDate.restore();
@@ -605,19 +612,15 @@ describe('createUser', () => {
       origin: WEBAPP,
     };
 
-    RoleMock.expects('findById').never();
-    UserMock.expects('findOne').never();
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, refreshToken: sinon.match.string })
-      .once()
-      .returns({ identity: payload.identity, local: payload.local, contact: payload.contact });
+    userCreate.returns({ identity: payload.identity, local: payload.local, contact: payload.contact });
 
     const result = await UsersHelper.createUser(payload, null);
 
     expect(result).toEqual({ identity: payload.identity, local: payload.local, contact: payload.contact });
-    RoleMock.verify();
-    UserMock.verify();
     sinon.assert.notCalled(createHistoryStub);
+    sinon.assert.notCalled(userFindOne);
+    sinon.assert.notCalled(roleFindById);
+    sinon.assert.calledOnceWithExactly(userCreate, { ...payload, refreshToken: sinon.match.string });
   });
 
   it('should set firstMobileConnection if origin is mobile', async () => {
@@ -630,26 +633,26 @@ describe('createUser', () => {
     const date = '2020-12-08T13:45:25.437Z';
 
     momentToDate.returns(date);
-    RoleMock.expects('findById').never();
-    UserMock.expects('findOne').never();
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, refreshToken: sinon.match.string, firstMobileConnection: date, origin: MOBILE })
-      .once()
-      .returns(payload);
-    UserMock.expects('findOne')
-      .withExactArgs({ _id: payload._id })
-      .chain('lean')
-      .withExactArgs({ virtuals: true, autopopulate: true })
-      .returns(payload);
-    UserMock.expects('findOne').never();
+    userCreate.returns(payload);
+    userFindOne.returns(SinonMongoose.stubChainedQueries([payload],
+      ['lean']));
 
     const result = await UsersHelper.createUser(payload, null);
 
     expect(result).toEqual(payload);
-    RoleMock.verify();
-    UserMock.verify();
     sinon.assert.calledOnceWithExactly(momentToDate);
     sinon.assert.notCalled(createHistoryStub);
+    sinon.assert.notCalled(roleFindById);
+    sinon.assert.calledOnceWithExactly(userCreate, {
+      ...payload,
+      refreshToken: sinon.match.string,
+      firstMobileConnection: date,
+      origin: MOBILE,
+    });
+    SinonMongoose.calledWithExactly(userFindOne, [
+      { query: 'findOne', args: [{ _id: payload._id }] },
+      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+    ]);
   });
 
   it('client admin - should create an auxiliary for his organization and handles sector', async () => {
@@ -669,35 +672,34 @@ describe('createUser', () => {
       origin: WEBAPP,
     };
 
-    RoleMock.expects('findById')
-      .withExactArgs(payload.role, { name: 1, interface: 1 })
-      .chain('lean')
-      .returns({ _id: roleId, name: 'auxiliary', interface: 'client' });
-    UserMock.expects('create')
-      .withExactArgs({
-        identity: { lastname: 'Test' },
-        local: { email: 'toto@test.com' },
-        origin: WEBAPP,
-        company: companyId,
-        refreshToken: sinon.match.string,
-        role: { client: roleId },
-      })
-      .returns(newUser);
-    UserMock.expects('findOne')
-      .withExactArgs({ _id: userId })
-      .chain('populate')
-      .withExactArgs({ path: 'sector', select: '_id sector', match: { company: companyId } })
-      .chain('lean')
-      .withExactArgs({ virtuals: true, autopopulate: true })
-      .returns(newUser);
-    UserMock.expects('findOneAndUpdate').never();
+    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'auxiliary', interface: 'client' }],
+      ['lean']));
+    userCreate.returns(newUser);
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
+      ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    RoleMock.verify();
-    UserMock.verify();
     sinon.assert.calledWithExactly(createHistoryStub, { _id: userId, sector: payload.sector }, companyId);
+    SinonMongoose.calledWithExactly(roleFindById, [
+      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
+      { query: 'lean' },
+    ]);
+    sinon.assert.calledOnceWithExactly(userCreate, {
+      identity: { lastname: 'Test' },
+      local: { email: 'toto@test.com' },
+      origin: WEBAPP,
+      company: companyId,
+      refreshToken: sinon.match.string,
+      role: { client: roleId },
+    });
+    SinonMongoose.calledWithExactly(userFindOne, [
+      { query: 'findOne', args: [{ _id: userId }] },
+      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
+      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+    ]);
+    sinon.assert.notCalled(userFindOneAndUpdate);
   });
 
   it('client admin - should create a coach for his organization', async () => {
@@ -710,27 +712,30 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'coach' } };
 
-    RoleMock.expects('findById')
-      .withExactArgs(payload.role, { name: 1, interface: 1 })
-      .chain('lean')
-      .returns({ _id: roleId, name: 'coach', interface: 'client' });
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, company: companyId, refreshToken: sinon.match.string })
-      .returns(newUser);
-    UserMock.expects('findOne')
-      .withExactArgs({ _id: userId })
-      .chain('populate')
-      .withExactArgs({ path: 'sector', select: '_id sector', match: { company: companyId } })
-      .chain('lean')
-      .withExactArgs({ virtuals: true, autopopulate: true })
-      .returns(newUser);
+    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'coach', interface: 'client' }],
+      ['lean']));
+    userCreate.returns(newUser);
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
+      ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    RoleMock.verify();
-    UserMock.verify();
     sinon.assert.notCalled(createHistoryStub);
+    SinonMongoose.calledWithExactly(roleFindById, [
+      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
+      { query: 'lean' },
+    ]);
+    sinon.assert.calledOnceWithExactly(userCreate, {
+      ...payload,
+      company: companyId,
+      refreshToken: sinon.match.string,
+    });
+    SinonMongoose.calledWithExactly(userFindOne, [
+      { query: 'findOne', args: [{ _id: userId }] },
+      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
+      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+    ]);
   });
 
   it('vendor admin - should create a client admin with company', async () => {
@@ -744,26 +749,29 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'client_admin' } };
 
-    RoleMock.expects('findById')
-      .withExactArgs(payload.role, { name: 1, interface: 1 })
-      .chain('lean')
-      .returns({ _id: roleId, name: 'client_admin', interface: 'client' });
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, role: { client: roleId }, refreshToken: sinon.match.string })
-      .returns(newUser);
-    UserMock.expects('findOne')
-      .withExactArgs({ _id: userId })
-      .chain('populate')
-      .withExactArgs({ path: 'sector', select: '_id sector', match: { company: payload.company } })
-      .chain('lean')
-      .withExactArgs({ virtuals: true, autopopulate: true })
-      .returns(newUser);
+    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'client_admin', interface: 'client' }],
+      ['lean']));
+    userCreate.returns(newUser);
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
+      ['populate', 'lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    RoleMock.verify();
-    UserMock.verify();
+    SinonMongoose.calledWithExactly(roleFindById, [
+      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
+      { query: 'lean' },
+    ]);
+    sinon.assert.calledOnceWithExactly(userCreate, {
+      ...payload,
+      role: { client: roleId },
+      refreshToken: sinon.match.string,
+    });
+    SinonMongoose.calledWithExactly(userFindOne, [
+      { query: 'findOne', args: [{ _id: userId }] },
+      { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: payload.company } }] },
+      { query: 'lean', args: [{ virtuals: true, autopopulate: true }] },
+    ]);
   });
 
   it('vendor admin - should create a trainer without company', async () => {
@@ -776,25 +784,28 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId, role: { _id: roleId, name: 'trainer' } };
 
-    RoleMock.expects('findById')
-      .withExactArgs(payload.role, { name: 1, interface: 1 })
-      .chain('lean')
-      .returns({ _id: roleId, name: 'trainer', interface: 'vendor' });
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, role: { vendor: roleId }, refreshToken: sinon.match.string })
-      .returns(newUser);
-    UserMock.expects('findOne')
-      .withExactArgs({ _id: newUser._id })
-      .chain('lean')
-      .withExactArgs({ virtuals: true })
-      .returns(newUser);
-    UserMock.expects('findOne').never();
+    roleFindById.returns(SinonMongoose.stubChainedQueries([{ _id: roleId, name: 'trainer', interface: 'vendor' }],
+      ['lean']));
+    userCreate.returns(newUser);
+    userFindOne.returns(SinonMongoose.stubChainedQueries([newUser],
+      ['lean']));
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
 
     expect(result).toEqual(newUser);
-    RoleMock.verify();
-    UserMock.verify();
+    SinonMongoose.calledWithExactly(roleFindById, [
+      { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
+      { query: 'lean' },
+    ]);
+    sinon.assert.calledOnceWithExactly(userCreate, {
+      ...payload,
+      role: { vendor: roleId },
+      refreshToken: sinon.match.string,
+    });
+    SinonMongoose.calledWithExactly(userFindOne, [
+      { query: 'findOne', args: [{ _id: newUser._id }] },
+      { query: 'lean', args: [{ virtuals: true }] },
+    ]);
   });
 
   it('vendor admin - should create a user without role but with company', async () => {
@@ -807,43 +818,39 @@ describe('createUser', () => {
     };
     const newUser = { ...payload, _id: userId };
 
-    RoleMock.expects('findById').never();
-    UserMock.expects('findOne').never();
-    UserMock.expects('create')
-      .withExactArgs({ ...payload, refreshToken: sinon.match.string })
-      .returns(newUser);
+    userCreate.returns(newUser);
 
     const result = await UsersHelper.createUser(payload, { company: { _id: companyId } });
     expect(result).toEqual(newUser);
 
-    RoleMock.verify();
-    UserMock.verify();
     sinon.assert.notCalled(createHistoryStub);
+    sinon.assert.notCalled(roleFindById);
+    sinon.assert.notCalled(userFindOne);
+    sinon.assert.calledOnceWithExactly(userCreate, { ...payload, refreshToken: sinon.match.string });
   });
 
   it('should return a 400 error if role does not exist', async () => {
+    const companyId = new ObjectID();
+    const payload = {
+      identity: { lastname: 'Test', firstname: 'Toto' },
+      local: { email: 'toto@test.com' },
+      role: roleId,
+      origin: WEBAPP,
+    };
     try {
-      const companyId = new ObjectID();
-      const payload = {
-        identity: { lastname: 'Test', firstname: 'Toto' },
-        local: { email: 'toto@test.com' },
-        role: roleId,
-        origin: WEBAPP,
-      };
-
-      RoleMock.expects('findById')
-        .withExactArgs(payload.role, { name: 1, interface: 1 })
-        .chain('lean')
-        .returns(null);
-      UserMock.expects('create').never();
+      roleFindById.returns(SinonMongoose.stubChainedQueries([null],
+        ['lean']));
 
       await UsersHelper.createUser(payload, { company: { _id: companyId } });
     } catch (e) {
       expect(e).toEqual(Boom.badRequest('Le rôle n\'existe pas'));
     } finally {
-      RoleMock.verify();
-      UserMock.verify();
       sinon.assert.notCalled(createHistoryStub);
+      sinon.assert.notCalled(userCreate);
+      SinonMongoose.calledWithExactly(roleFindById, [
+        { query: 'findById', args: [payload.role, { name: 1, interface: 1 }] },
+        { query: 'lean' },
+      ]);
     }
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : tous

- Périmetre roles : formateur & sans role

- Cas d'usage : ne pas renvoyer le refreshToken et le mot de passe quand on créé un utilisateur formateur depuis la web app ou apprenant depuis le mobile


overwrite : https://mongoosejs.com/docs/documents.html