### PR TITLE
Allow app validation

### DIFF
--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -1,4 +1,4 @@
 exports.checkUpdate = async (apiVersion) => {
   const majorApiVersion = process.env.API_VERSION.replace(/\.[0-9]+\.[0-9]+$/, '');
-  return majorApiVersion !== apiVersion;
+  return majorApiVersion > apiVersion;
 };

--- a/tests/unit/helpers/version.test.js
+++ b/tests/unit/helpers/version.test.js
@@ -9,13 +9,18 @@ describe('checkUpdate', () => {
     process.env.API_VERSION = '';
   });
 
-  it('should return true if not same version', async () => {
+  it('should return true if lower version in mobile', async () => {
     const result = await VersionHelper.checkUpdate('1');
     expect(result).toBeTruthy();
   });
 
   it('should return false if same version', async () => {
     const result = await VersionHelper.checkUpdate('2');
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if greater version in mobile', async () => {
+    const result = await VersionHelper.checkUpdate('3');
     expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
sur iphone et android on envoie une build avec `apiVersion: 1`
or pour le moment, sur le server de l'api la version c'est 0
donc apple ne va pas pouvoir tester l'app
j'ai changé l'inégalité en strictement superieur : 
- si l'api recoit du mobile une version superieur a la sienne (maj future) : c'est bon car le mobile est en avance
- si elle recoit la meme : version actuellement en prod donc c'est bon car le mobile est a jour
- si elle recoit une version inferieure, il faut mettre a jour car le mobile est en retard
