### PR TITLE
COM-1744 - add extension for absence

### DIFF
--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -75,6 +75,7 @@ const EventSchema = mongoose.Schema(
     },
     absence: { type: String, enum: ABSENCE_TYPES, required() { return this.type === ABSENCE; } },
     absenceNature: { type: String, enum: ABSENCE_NATURES, required() { return this.type === ABSENCE; } },
+    extension: { type: mongoose.Schema.Types.ObjectId, ref: 'Event' },
     address: {
       type: mongoose.Schema(addressSchemaDefinition, { _id: false, id: false }),
       required() { return this.type === INTERVENTION; },

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -123,6 +123,7 @@ const getEventsGroupedBy = async (rules, groupById, companyId) => Event.aggregat
       internalHour: 1,
       absence: 1,
       absenceNature: 1,
+      extension: 1,
       address: 1,
       misc: 1,
       attachment: 1,

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -123,7 +123,6 @@ const getEventsGroupedBy = async (rules, groupById, companyId) => Event.aggregat
       internalHour: 1,
       absence: 1,
       absenceNature: 1,
-      extension: 1,
       address: 1,
       misc: 1,
       attachment: 1,

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -68,6 +68,7 @@ exports.plugin = {
               .when('absenceNature', { is: Joi.valid(HOURLY), then: Joi.valid(UNJUSTIFIED) }),
             absenceNature: Joi.string().valid(...ABSENCE_NATURES)
               .when('type', { is: Joi.valid(ABSENCE), then: Joi.required() }),
+            extension: Joi.objectId(),
             attachment: Joi.object().keys({
               driveId: Joi.string(),
               link: Joi.string(),

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -135,18 +135,27 @@ exports.checkEventCreationOrUpdate = async (req) => {
   }
 
   if (req.payload.auxiliary) {
-    const auxiliary = await User.findOne(({ _id: req.payload.auxiliary, company: companyId })).lean();
+    const auxiliary = await User.countDocuments(({ _id: req.payload.auxiliary, company: companyId }));
     if (!auxiliary) throw Boom.forbidden();
   }
 
   if (req.payload.sector) {
-    const sector = await Sector.findOne(({ _id: req.payload.sector, company: companyId })).lean();
+    const sector = await Sector.countDocuments(({ _id: req.payload.sector, company: companyId }));
     if (!sector) throw Boom.forbidden();
   }
 
   if (req.payload.internalHour) {
-    const internalHour = await InternalHour.findOne(({ _id: req.payload.internalHour, company: companyId })).lean();
+    const internalHour = await InternalHour.countDocuments(({ _id: req.payload.internalHour, company: companyId }));
     if (!internalHour) throw Boom.forbidden();
+  }
+
+  if (req.payload.extension) {
+    const extendedAbsence = await Event.countDocuments(({
+      _id: req.payload.extension,
+      absenceNature: req.payload.absenceNature,
+      absence: req.payload.absence,
+    }));
+    if (!extendedAbsence) throw Boom.forbidden();
   }
 
   return null;

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -9,7 +9,15 @@ const User = require('../../models/User');
 const InternalHour = require('../../models/InternalHour');
 const translate = require('../../helpers/translate');
 const UtilsHelper = require('../../helpers/utils');
-const { AUXILIARY } = require('../../helpers/constants');
+const {
+  AUXILIARY,
+  MATERNITY_LEAVE,
+  PATERNITY_LEAVE,
+  PARENTAL_LEAVE,
+  WORK_ACCIDENT,
+  TRANSPORT_ACCIDENT,
+  ILLNESS,
+} = require('../../helpers/constants');
 
 const { language } = translate;
 
@@ -150,12 +158,15 @@ exports.checkEventCreationOrUpdate = async (req) => {
   }
 
   if (req.payload.extension) {
-    const extendedAbsence = await Event.countDocuments(({
+    if (![MATERNITY_LEAVE, PATERNITY_LEAVE, PARENTAL_LEAVE, WORK_ACCIDENT, TRANSPORT_ACCIDENT, ILLNESS]
+      .includes(req.payload.absence)) throw Boom.forbidden();
+
+    const extendedAbsence = await Event.findOne(({
       _id: req.payload.extension,
-      absenceNature: req.payload.absenceNature,
       absence: req.payload.absence,
-    }));
+    })).lean();
     if (!extendedAbsence) throw Boom.forbidden();
+    if (extendedAbsence.startDate > req.payload.startDate) throw Boom.forbidden();
   }
 
   return null;

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -29,6 +29,8 @@ const {
   ILLNESS,
   DAILY,
   EVERY_DAY,
+  PAID_LEAVE,
+  UNPAID_LEAVE,
 } = require('../../src/helpers/constants');
 const Repetition = require('../../src/models/Repetition');
 const Event = require('../../src/models/Event');
@@ -567,6 +569,7 @@ describe('EVENTS ROUTES', () => {
       beforeEach(async () => {
         authToken = await getToken('client_admin');
       });
+
       it('should create an internal hour', async () => {
         const payload = {
           type: INTERNAL_HOUR,
@@ -1003,6 +1006,49 @@ describe('EVENTS ROUTES', () => {
             city: 'Antony',
             location: { type: 'Point', coordinates: [2.377133, 48.801389] },
           },
+        };
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toEqual(403);
+      });
+
+      it('should create an extended absence', async () => {
+        const payload = {
+          type: ABSENCE,
+          startDate: '2019-01-23T10:00:00',
+          endDate: '2019-01-23T12:30:00',
+          auxiliary: eventsList[1].auxiliary,
+          absenceNature: DAILY,
+          absence: PAID_LEAVE,
+          extension: eventsList[1]._id,
+        };
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toEqual(200);
+        expect(response.result.data.event).toBeDefined();
+      });
+
+      it('should return 403 if absence extension and extended absence are not the same nature', async () => {
+        const payload = {
+          type: ABSENCE,
+          startDate: '2019-01-23T10:00:00',
+          endDate: '2019-01-23T12:30:00',
+          auxiliary: eventsList[1].auxiliary,
+          absenceNature: DAILY,
+          absence: UNPAID_LEAVE,
+          extension: eventsList[1]._id,
         };
 
         const response = await app.inject({

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -23,6 +23,7 @@ const {
   ABSENCE,
   INTERVENTION,
   WEBAPP,
+  PARENTAL_LEAVE,
 } = require('../../../src/helpers/constants');
 
 const auxiliaryId = new ObjectID();
@@ -684,6 +685,18 @@ const eventsList = [
       city: 'Antony',
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    repetition: { frequency: NEVER },
+    type: ABSENCE,
+    absence: PARENTAL_LEAVE,
+    absenceNature: DAILY,
+    startDate: '2019-01-19T14:00:18.653Z',
+    endDate: '2019-01-19T17:00:18.653Z',
+    auxiliary: auxiliaries[0]._id,
+    createdAt: '2019-01-11T08:38:18.653Z',
   },
 ];
 


### PR DESCRIPTION
- [] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : vendor

- Périmetre roles : coach / admin / vendor

- Cas d'usage : 
Je peux créer un absence sur le planning auxiliaire qui est le prolongement d'une absence existante
