### PR TITLE
Com 1741

### DIFF
--- a/tests/unit/data/rights.test.js
+++ b/tests/unit/data/rights.test.js
@@ -8,6 +8,7 @@ const {
   TRAINER,
   TRAINING_ORGANISATION_MANAGER,
   VENDOR_ADMIN,
+  AUXILIARY_WITHOUT_COMPANY,
 } = require('../../../src/helpers/constants');
 
 describe('checking the format of right.js file', () => {
@@ -19,6 +20,8 @@ describe('checking the format of right.js file', () => {
   });
 
   it('a role must have the permissions associated with the role below it (client side)', async () => {
+    const auxiliaryWithoutCompanyPermissions = rights
+      .filter(right => right.rolesConcerned.includes(AUXILIARY_WITHOUT_COMPANY)).map(right => right.permission);
     const auxiliaryPermissions = rights
       .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
     const planningReferentPermissions = rights
@@ -29,6 +32,7 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN)).map(right => right.permission);
 
     const arePermissionsIncludedList = [
+      auxiliaryWithoutCompanyPermissions.map(permission => auxiliaryPermissions.includes(permission)),
       auxiliaryPermissions.map(permission => planningReferentPermissions.includes(permission)),
       planningReferentPermissions.map(permission => coachPermissions.includes(permission)),
       coachPermissions.map(permission => clientAdminPermissions.includes(permission)),

--- a/tests/unit/data/rights.test.js
+++ b/tests/unit/data/rights.test.js
@@ -26,7 +26,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
 
     const arePermissionsIncluded = auxiliaryWithoutCompanyPermissions
-      .map(permission => auxiliaryPermissions.includes(permission)).every(value => value);
+      .map(permission => auxiliaryPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });
@@ -38,7 +39,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
 
     const arePermissionsIncluded = auxiliaryPermissions
-      .map(permission => planningReferentPermissions.includes(permission)).every(value => value);
+      .map(permission => planningReferentPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });
@@ -50,7 +52,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
 
     const arePermissionsIncluded = planningReferentPermissions
-      .map(permission => coachPermissions.includes(permission)).every(value => value);
+      .map(permission => coachPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });
@@ -62,7 +65,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN)).map(right => right.permission);
 
     const arePermissionsIncluded = coachPermissions
-      .map(permission => clientAdminPermissions.includes(permission)).every(value => value);
+      .map(permission => clientAdminPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });
@@ -74,7 +78,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
 
     const arePermissionsIncluded = trainerPermissions
-      .map(permission => trainingOrganisationManagerPermissions.includes(permission)).every(value => value);
+      .map(permission => trainingOrganisationManagerPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });
@@ -86,7 +91,8 @@ describe('checking the format of right.js file', () => {
       .filter(right => right.rolesConcerned.includes(VENDOR_ADMIN)).map(right => right.permission);
 
     const arePermissionsIncluded = trainingOrganisationManagerPermissions
-      .map(permission => vendorAdminPermissions.includes(permission)).every(value => value);
+      .map(permission => vendorAdminPermissions.includes(permission))
+      .every(value => value);
 
     expect(arePermissionsIncluded).toBeTruthy();
   });

--- a/tests/unit/data/rights.test.js
+++ b/tests/unit/data/rights.test.js
@@ -1,5 +1,14 @@
 const expect = require('expect');
 const { rights } = require('../../../src/data/rights');
+const {
+  AUXILIARY,
+  PLANNING_REFERENT,
+  COACH,
+  CLIENT_ADMIN,
+  TRAINER,
+  TRAINING_ORGANISATION_MANAGER,
+  VENDOR_ADMIN,
+} = require('../../../src/helpers/constants');
 
 describe('checking the format of right.js file', () => {
   it('there must be only one right per permission', async () => {
@@ -7,5 +16,40 @@ describe('checking the format of right.js file', () => {
     const noDuplicatedRights = new Set(permissions).size === permissions.length;
 
     expect(noDuplicatedRights).toBeTruthy();
+  });
+
+  it('a role must have the permissions associated with the role below it (client side)', async () => {
+    const auxiliaryPermissions = rights
+      .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
+    const planningReferentPermissions = rights
+      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
+    const coachPermissions = rights
+      .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
+    const clientAdminPermissions = rights
+      .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN)).map(right => right.permission);
+
+    const arePermissionsIncludedList = [
+      auxiliaryPermissions.map(permission => planningReferentPermissions.includes(permission)),
+      planningReferentPermissions.map(permission => coachPermissions.includes(permission)),
+      coachPermissions.map(permission => clientAdminPermissions.includes(permission)),
+    ];
+
+    expect(arePermissionsIncludedList.every(value => value)).toBeTruthy();
+  });
+
+  it('a role must have the permissions associated with the role below it (vendor side)', async () => {
+    const trainerPermissions = rights
+      .filter(right => right.rolesConcerned.includes(TRAINER)).map(right => right.permission);
+    const trainingOrganisationManagerPermissions = rights
+      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
+    const vendorAdminPermissions = rights
+      .filter(right => right.rolesConcerned.includes(VENDOR_ADMIN)).map(right => right.permission);
+
+    const arePermissionsIncludedList = [
+      trainerPermissions.map(permission => trainingOrganisationManagerPermissions.includes(permission)),
+      trainingOrganisationManagerPermissions.map(permission => vendorAdminPermissions.includes(permission)),
+    ];
+
+    expect(arePermissionsIncludedList.every(value => value)).toBeTruthy();
   });
 });

--- a/tests/unit/data/rights.test.js
+++ b/tests/unit/data/rights.test.js
@@ -21,9 +21,11 @@ describe('checking the format of right.js file', () => {
 
   it('an auxiliary must have the permissions associated with an auxiliary without company', async () => {
     const auxiliaryWithoutCompanyPermissions = rights
-      .filter(right => right.rolesConcerned.includes(AUXILIARY_WITHOUT_COMPANY)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(AUXILIARY_WITHOUT_COMPANY))
+      .map(right => right.permission);
     const auxiliaryPermissions = rights
-      .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(AUXILIARY))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = auxiliaryWithoutCompanyPermissions
       .map(permission => auxiliaryPermissions.includes(permission))
@@ -34,9 +36,11 @@ describe('checking the format of right.js file', () => {
 
   it('a planing referent must have the permissions associated with an auxiliary', async () => {
     const auxiliaryPermissions = rights
-      .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(AUXILIARY))
+      .map(right => right.permission);
     const planningReferentPermissions = rights
-      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = auxiliaryPermissions
       .map(permission => planningReferentPermissions.includes(permission))
@@ -47,9 +51,11 @@ describe('checking the format of right.js file', () => {
 
   it('a coach must have the permissions associated with a planning referent', async () => {
     const planningReferentPermissions = rights
-      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT))
+      .map(right => right.permission);
     const coachPermissions = rights
-      .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(COACH))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = planningReferentPermissions
       .map(permission => coachPermissions.includes(permission))
@@ -60,9 +66,11 @@ describe('checking the format of right.js file', () => {
 
   it('a client admin must have the permissions associated with a coach', async () => {
     const coachPermissions = rights
-      .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(COACH))
+      .map(right => right.permission);
     const clientAdminPermissions = rights
-      .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = coachPermissions
       .map(permission => clientAdminPermissions.includes(permission))
@@ -73,9 +81,11 @@ describe('checking the format of right.js file', () => {
 
   it('a ROF must have the permissions associated with a trainer', async () => {
     const trainerPermissions = rights
-      .filter(right => right.rolesConcerned.includes(TRAINER)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(TRAINER))
+      .map(right => right.permission);
     const trainingOrganisationManagerPermissions = rights
-      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = trainerPermissions
       .map(permission => trainingOrganisationManagerPermissions.includes(permission))
@@ -86,9 +96,11 @@ describe('checking the format of right.js file', () => {
 
   it('a vendor admin must have the permissions associated with a ROF', async () => {
     const trainingOrganisationManagerPermissions = rights
-      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER))
+      .map(right => right.permission);
     const vendorAdminPermissions = rights
-      .filter(right => right.rolesConcerned.includes(VENDOR_ADMIN)).map(right => right.permission);
+      .filter(right => right.rolesConcerned.includes(VENDOR_ADMIN))
+      .map(right => right.permission);
 
     const arePermissionsIncluded = trainingOrganisationManagerPermissions
       .map(permission => vendorAdminPermissions.includes(permission))

--- a/tests/unit/data/rights.test.js
+++ b/tests/unit/data/rights.test.js
@@ -19,41 +19,75 @@ describe('checking the format of right.js file', () => {
     expect(noDuplicatedRights).toBeTruthy();
   });
 
-  it('a role must have the permissions associated with the role below it (client side)', async () => {
+  it('an auxiliary must have the permissions associated with an auxiliary without company', async () => {
     const auxiliaryWithoutCompanyPermissions = rights
       .filter(right => right.rolesConcerned.includes(AUXILIARY_WITHOUT_COMPANY)).map(right => right.permission);
     const auxiliaryPermissions = rights
       .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
+
+    const arePermissionsIncluded = auxiliaryWithoutCompanyPermissions
+      .map(permission => auxiliaryPermissions.includes(permission)).every(value => value);
+
+    expect(arePermissionsIncluded).toBeTruthy();
+  });
+
+  it('a planing referent must have the permissions associated with an auxiliary', async () => {
+    const auxiliaryPermissions = rights
+      .filter(right => right.rolesConcerned.includes(AUXILIARY)).map(right => right.permission);
     const planningReferentPermissions = rights
       .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
+
+    const arePermissionsIncluded = auxiliaryPermissions
+      .map(permission => planningReferentPermissions.includes(permission)).every(value => value);
+
+    expect(arePermissionsIncluded).toBeTruthy();
+  });
+
+  it('a coach must have the permissions associated with a planning referent', async () => {
+    const planningReferentPermissions = rights
+      .filter(right => right.rolesConcerned.includes(PLANNING_REFERENT)).map(right => right.permission);
+    const coachPermissions = rights
+      .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
+
+    const arePermissionsIncluded = planningReferentPermissions
+      .map(permission => coachPermissions.includes(permission)).every(value => value);
+
+    expect(arePermissionsIncluded).toBeTruthy();
+  });
+
+  it('a client admin must have the permissions associated with a coach', async () => {
     const coachPermissions = rights
       .filter(right => right.rolesConcerned.includes(COACH)).map(right => right.permission);
     const clientAdminPermissions = rights
       .filter(right => right.rolesConcerned.includes(CLIENT_ADMIN)).map(right => right.permission);
 
-    const arePermissionsIncludedList = [
-      auxiliaryWithoutCompanyPermissions.map(permission => auxiliaryPermissions.includes(permission)),
-      auxiliaryPermissions.map(permission => planningReferentPermissions.includes(permission)),
-      planningReferentPermissions.map(permission => coachPermissions.includes(permission)),
-      coachPermissions.map(permission => clientAdminPermissions.includes(permission)),
-    ];
+    const arePermissionsIncluded = coachPermissions
+      .map(permission => clientAdminPermissions.includes(permission)).every(value => value);
 
-    expect(arePermissionsIncludedList.every(value => value)).toBeTruthy();
+    expect(arePermissionsIncluded).toBeTruthy();
   });
 
-  it('a role must have the permissions associated with the role below it (vendor side)', async () => {
+  it('a ROF must have the permissions associated with a trainer', async () => {
     const trainerPermissions = rights
       .filter(right => right.rolesConcerned.includes(TRAINER)).map(right => right.permission);
+    const trainingOrganisationManagerPermissions = rights
+      .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
+
+    const arePermissionsIncluded = trainerPermissions
+      .map(permission => trainingOrganisationManagerPermissions.includes(permission)).every(value => value);
+
+    expect(arePermissionsIncluded).toBeTruthy();
+  });
+
+  it('a vendor admin must have the permissions associated with a ROF', async () => {
     const trainingOrganisationManagerPermissions = rights
       .filter(right => right.rolesConcerned.includes(TRAINING_ORGANISATION_MANAGER)).map(right => right.permission);
     const vendorAdminPermissions = rights
       .filter(right => right.rolesConcerned.includes(VENDOR_ADMIN)).map(right => right.permission);
 
-    const arePermissionsIncludedList = [
-      trainerPermissions.map(permission => trainingOrganisationManagerPermissions.includes(permission)),
-      trainingOrganisationManagerPermissions.map(permission => vendorAdminPermissions.includes(permission)),
-    ];
+    const arePermissionsIncluded = trainingOrganisationManagerPermissions
+      .map(permission => vendorAdminPermissions.includes(permission)).every(value => value);
 
-    expect(arePermissionsIncludedList.every(value => value)).toBeTruthy();
+    expect(arePermissionsIncluded).toBeTruthy();
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : mobile & webapp

- Périmetre roles : auxiliary_without_company, auxiliary, planing_referent, coach, admin_client, trainer, rof, admin

- Cas d'usage : tests pour vérifier que les droits de chaque rôle sont bien inclus dans ceux des rôles supérieurs.


NB : le test pour auxiliary_without_company ne tourne sur rien car actuellement ils n'ont aucun droits