### PR TITLE
Com 1747

### DIFF
--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -82,7 +82,7 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
       $or: [{ endDate: { $gt: startDate } }, { endDate: { $exists: false } }],
     },
     { sector: 1 }
-  ).lean() || [];
+  ).lean();
   const sectorsId = [...new Set(sectors.map(sh => sh.sector.toHexString()))];
 
   const month = moment(startDate).format('MM-YYYY');
@@ -124,7 +124,7 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
   );
 
   const firstMonthContract = moment(startDate).startOf('month').isSameOrBefore(contract.startDate);
-  return { ...draft, sectors: sectorsId, counterAndDiffRelevant: !!prevPay || firstMonthContract } || null;
+  return draft ? { ...draft, sectors: sectorsId, counterAndDiffRelevant: !!prevPay || firstMonthContract } : null;
 };
 
 exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, companyId) => {

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -87,7 +87,7 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
 
   const month = moment(startDate).format('MM-YYYY');
   const pay = await Pay.findOne({ auxiliary: auxiliaryId, month }).lean();
-  if (pay) return { ...pay, sectors: sectorsId };
+  if (pay) return { ...pay, sectors: sectorsId, counterAndDiffRelevant: true };
 
   const auxiliary = await User.findOne({ _id: auxiliaryId }).populate('contracts').lean();
   const prevMonth = moment(month, 'MM-YYYY').subtract(1, 'M').format('MM-YYYY');
@@ -123,7 +123,8 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
     surcharges
   );
 
-  return { ...draft, sectors: sectorsId } || null;
+  const firstMonthContract = moment(startDate).startOf('month').isSameOrBefore(contract.startDate);
+  return { ...draft, sectors: sectorsId, counterAndDiffRelevant: !!prevPay || firstMonthContract } || null;
 };
 
 exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, companyId) => {

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -121,7 +121,7 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
     surcharges
   );
 
-  return { ...draft, sectors: sectors.map(sh => sh.sector) } || null;
+  return { ...draft, sectors: [...new Set(sectors.map(sh => sh.sector.toHexString()))] } || null;
 };
 
 exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, companyId) => {

--- a/src/helpers/sectorHistories.js
+++ b/src/helpers/sectorHistories.js
@@ -104,3 +104,17 @@ exports.updateEndDate = async (auxiliaryId, endDate) => SectorHistory.updateOne(
   { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
   { $set: { endDate: moment(endDate).endOf('day').toDate() } }
 );
+
+exports.getAuxiliarySectors = async (auxiliaryId, companyId, startDate, endDate) => {
+  const sectors = await SectorHistory.find(
+    {
+      company: companyId,
+      auxiliary: auxiliaryId,
+      startDate: { $lt: endDate },
+      $or: [{ endDate: { $gt: startDate } }, { endDate: { $exists: false } }],
+    },
+    { sector: 1 }
+  ).lean();
+
+  return [...new Set(sectors.map(sh => sh.sector.toHexString()))];
+};

--- a/src/repositories/SectorHistoryRepository.js
+++ b/src/repositories/SectorHistoryRepository.js
@@ -184,7 +184,6 @@ exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
       },
     },
     { $unwind: { path: '$events' } },
-    { $addFields: { 'events.sector': '$sector' } },
     { $replaceRoot: { newRoot: '$events' } },
     { $addFields: { duration: { $divide: [{ $subtract: ['$endDate', '$startDate'] }, 60 * 60 * 1000] } } },
     {
@@ -192,7 +191,6 @@ exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
         _id: { auxiliary: '$auxiliary', customer: '$customer' },
         duration: { $sum: '$duration' },
         events: { $addToSet: '$$ROOT' },
-        sectors: { $addToSet: '$sector' },
       },
     },
     {
@@ -200,7 +198,6 @@ exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
         _id: { auxiliary: '$_id.auxiliary' },
         customerCount: { $sum: 1 },
         duration: { $sum: '$duration' },
-        sectors: { $addToSet: '$sectors' },
       },
     },
     {
@@ -208,13 +205,6 @@ exports.getPaidInterventionStats = async (auxiliaryIds, month, companyId) => {
         _id: '$_id.auxiliary',
         customerCount: 1,
         duration: 1,
-        sectors: {
-          $reduce: {
-            input: '$sectors',
-            initialValue: [],
-            in: { $setUnion: ['$$value', '$$this'] },
-          },
-        },
       },
     },
   ]).option({ company: companyId });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration - np

- Périmetre interface : client

- Périmetre roles : auxiliaire/coach/admin

- Cas d'usage : Sur le tableau de bord, je vois le compteur 
Trois cas: 
- mois passés: verifier que la valeur correspond a celle de la paie enregistre en bdd
- mois en cours: le compteur doit correspondre a ce qu'il y a sur la page de la paie
- mois suivant: le compteur ne doit pas s'afficher

Vous pouvez egalement verifier les autres valeurs (doit etre coherent avec le planning) car j'ai fait quelques changements a ce niveau la egalement. 

Note: dans les tests unitaires, pour eviter que ce soit trop verbeux, j'ai enleve les 'callwithexactly' lorsque cela ne me paraissait pas pertinent (test similaire a un autre avec un petit changement n'impliquant pas les valeurs passées a d'autres fonctions). Dites moi ce que vous en pensez :) 
