### PR TITLE
COM-1804 fix memory leak when error from puppeteer

### DIFF
--- a/src/helpers/pdf.js
+++ b/src/helpers/pdf.js
@@ -55,7 +55,7 @@ exports.generatePdf = async (data, templateUrl, options = { format: 'A4', printB
 
     return pdf;
   } catch (e) {
-    browser.close();
+    await browser.close();
     throw e;
   }
 };

--- a/tests/unit/helpers/pdf.test.js
+++ b/tests/unit/helpers/pdf.test.js
@@ -1,5 +1,9 @@
 const sinon = require('sinon');
+const path = require('path');
 const expect = require('expect');
+const puppeteer = require('puppeteer');
+const handlebars = require('handlebars');
+const util = require('util');
 const PdfHelper = require('../../../src/helpers/pdf');
 
 describe('formatSurchargeHourForPdf', () => {
@@ -43,5 +47,77 @@ describe('formatEventSurchargesForPdf', () => {
       { percentage: 15, startHour: '18d', endHour: '20d' },
     ]);
     sinon.assert.calledTwice(formatSurchargeHourForPdf);
+  });
+});
+
+describe('generatePdf', () => {
+  let puppeteerLaunch;
+  let pathResolve;
+  let handlebarsRegisterHelper;
+  let handlebarsCompile;
+  let readFileStub;
+
+  beforeEach(() => {
+    puppeteerLaunch = sinon.stub(puppeteer, 'launch');
+    pathResolve = sinon.stub(path, 'resolve');
+    handlebarsRegisterHelper = sinon.stub(handlebars, 'registerHelper');
+    handlebarsCompile = sinon.stub(handlebars, 'compile');
+    readFileStub = sinon.stub(PdfHelper, 'readFile');
+  });
+
+  afterEach(() => {
+    puppeteerLaunch.restore();
+    pathResolve.restore();
+    handlebarsRegisterHelper.restore();
+    handlebarsCompile.restore();
+    readFileStub.restore();
+  });
+
+  it('should generate pdf', async () => {
+    puppeteerLaunch.returns({
+      newPage: sinon.stub().returns({ setContent: sinon.stub(), pdf: sinon.stub().returns('result') }),
+      close: sinon.stub(),
+    });
+    pathResolve.returns('templatepath');
+    handlebarsCompile.returns(sinon.stub().returns('html'));
+    readFileStub.returns('123');
+
+    const result = await PdfHelper.generatePdf({ data: 'data' }, 'url');
+
+    expect(result).toBe('result');
+
+    sinon.assert.calledWithExactly(
+      puppeteerLaunch,
+      { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+    );
+    sinon.assert.calledWithExactly(puppeteerLaunch.getCall(0).returnValue.newPage);
+    sinon.assert.calledWithExactly(pathResolve, './', 'url');
+    sinon.assert.calledWithExactly(readFileStub, 'templatepath', 'utf8');
+    sinon.assert.calledTwice(handlebarsRegisterHelper);
+    sinon.assert.calledWithExactly(handlebarsCompile, '123');
+    sinon.assert.calledWithExactly(handlebarsCompile.getCall(0).returnValue, { data: 'data' });
+    sinon.assert.calledWithExactly(
+      puppeteerLaunch.getCall(0).returnValue.newPage.getCall(0).returnValue.setContent,
+      'html'
+    );
+    sinon.assert.calledWithExactly(
+      puppeteerLaunch.getCall(0).returnValue.newPage.getCall(0).returnValue.pdf,
+      { format: 'A4', printBackground: true }
+    );
+    sinon.assert.calledWithExactly(puppeteerLaunch.getCall(0).returnValue.close);
+  });
+
+  it('should call browser.close even though puppeteer threw an error', async () => {
+    puppeteerLaunch.returns({
+      newPage: () => { throw new Error('test'); },
+      close: sinon.stub(),
+    });
+
+    try {
+      await PdfHelper.generatePdf({}, 'url');
+      sinon.expect(true).toBe(false); // should not execute because error is thrown
+    } catch (e) {
+      sinon.assert.calledOnce(puppeteerLaunch.getCall(0).returnValue.close);
+    }
   });
 });

--- a/tests/unit/helpers/pdf.test.js
+++ b/tests/unit/helpers/pdf.test.js
@@ -3,7 +3,6 @@ const path = require('path');
 const expect = require('expect');
 const puppeteer = require('puppeteer');
 const handlebars = require('handlebars');
-const util = require('util');
 const PdfHelper = require('../../../src/helpers/pdf');
 
 describe('formatSurchargeHourForPdf', () => {


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : verifier que la generation des pdf: facture, avoir, convocation, feuilles d'emargement, attestation fiscale fonctionnent toujours. 
Vous pouvez aussi simuler une erreur a la ligne avant browser.newPage() si vous voulez voir ce qu'il se passe en cas d'erreur.
