### PR TITLE
COM-1744 - Add extension in absence export

### DIFF
--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -164,10 +164,13 @@ const absenceExportHeader = [
   'Début',
   'Fin',
   'Equivalent heures contrat',
+  'Prolongation',
+  'Absence d\'origine',
   'Divers',
 ];
 
 exports.formatAbsence = (absence) => {
+  console.log('skusku', absence.extension);
   const hours = exports.getAbsenceHours(absence, absence.auxiliary.contracts);
   const datetimeFormat = absence.absenceNature === HOURLY ? 'DD/MM/YYYY HH:mm' : 'DD/MM/YYYY';
 
@@ -182,6 +185,8 @@ exports.formatAbsence = (absence) => {
     moment(absence.startDate).format(datetimeFormat),
     moment(absence.endDate).format(datetimeFormat),
     UtilsHelper.formatFloatForExport(hours),
+    absence.extension ? 'oui' : 'non',
+    absence.extension ? moment(absence.extension.startDate).format(datetimeFormat) : '',
     absence.misc || '',
   ];
 };

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -170,7 +170,6 @@ const absenceExportHeader = [
 ];
 
 exports.formatAbsence = (absence) => {
-  console.log('skusku', absence.extension);
   const hours = exports.getAbsenceHours(absence, absence.auxiliary.contracts);
   const datetimeFormat = absence.absenceNature === HOURLY ? 'DD/MM/YYYY HH:mm' : 'DD/MM/YYYY';
 

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -221,6 +221,7 @@ exports.getAbsencesForExport = async (start, end, credentials) => {
         { path: 'contracts', match: { company: companyId } },
       ],
     })
+    .populate({ path: 'extension', select: 'startDate' })
     .lean({ autopopulate: true });
 };
 

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -111,9 +111,9 @@ describe('GET /exports/absence/history', () => {
       expect(response.result).toBeDefined();
       const rows = response.result.split('\r\n');
       expect(rows).toEqual([
-        '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Divers"',
-        `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"test absence"`,
-        `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";`,
+        '\ufeff"Id Auxiliaire";"Auxiliaire - Prénom";"Auxiliaire - Nom";"Auxiliaire - Titre";"Équipe";"Type";"Nature";"Début";"Fin";"Equivalent heures contrat";"Prolongation";"Absence d\'origine";"Divers"',
+        `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Absence injustifiée";"Horaire";"19/01/2019 14:00";"19/01/2019 16:00";"2,00";"non";;"test absence"`,
+        `${auxiliaryList[0]._id.toHexString()};"Lulu";"UIUI";"M.";"Etoile";"Congé";"Journalière";"19/01/2019";"21/01/2019";"4,00";"non";;`,
       ]);
     });
   });

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -475,7 +475,7 @@ describe('exportAbsencesHistory', () => {
     'Absence d\'origine',
     'Divers',
   ];
-  const start = '2019-05-20T08:00:00'; // inutile ?
+  const start = '2019-05-20T08:00:00';
   const end = '2019-05-20T22:00:00';
   let getAbsencesForExport;
   let formatAbsence;

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -380,7 +380,7 @@ describe('formatAbsence', () => {
     getAbsenceHours.restore();
   });
 
-  it('should return an array with the header and 1 row for daily absence', async () => {
+  it('should return an array with the header and 1 row for hourly absence', async () => {
     const event = {
       type: 'absence',
       absence: 'unjustified_absence',
@@ -411,12 +411,14 @@ describe('formatAbsence', () => {
       '20/05/2019 08:00',
       '20/05/2019 10:00',
       '2,00',
+      'non',
+      '',
       '',
     ]);
     sinon.assert.calledOnceWithExactly(getAbsenceHours, event, event.auxiliary.contracts);
   });
 
-  it('should return an array with the header and 1 row for hourly absence', async () => {
+  it('should return an array with the header and 1 row for daily absence', async () => {
     const event = {
       type: 'absence',
       absence: 'leave',
@@ -432,6 +434,7 @@ describe('formatAbsence', () => {
       },
       startDate: '2019-05-20T08:00:00',
       endDate: '2019-05-20T22:00:00',
+      extension: { _id: new ObjectID(), startDate: '2019-04-20T08:00:00' },
       misc: 'brbr',
     };
     getAbsenceHours.returns(4);
@@ -448,6 +451,8 @@ describe('formatAbsence', () => {
       '20/05/2019',
       '20/05/2019',
       '4,00',
+      'oui',
+      '20/04/2019',
       'brbr',
     ]);
     sinon.assert.calledOnceWithExactly(getAbsenceHours, event, event.auxiliary.contracts);
@@ -466,6 +471,8 @@ describe('exportAbsencesHistory', () => {
     'Début',
     'Fin',
     'Equivalent heures contrat',
+    'Prolongation',
+    'Absence d\'origine',
     'Divers',
   ];
   const start = '2019-05-20T08:00:00'; // inutile ?
@@ -509,7 +516,7 @@ describe('exportAbsencesHistory', () => {
     const credentials = { company: { _id: '1234567890' } };
     const formattedAbsence = [new ObjectID(), 'Jean-Claude', 'VAN DAMME', '', 'Girafes - 75', 'Absence injustifiée',
       'Horaire',
-      '20/05/2019 08:00', '21/05/2019 10:00', '26,00', ''];
+      '20/05/2019 08:00', '21/05/2019 10:00', '26,00', 'non', '', ''];
 
     getAbsencesForExport.returns([event]);
     formatAbsence.returns(formattedAbsence);
@@ -543,11 +550,11 @@ describe('exportAbsencesHistory', () => {
     };
     const credentials = { company: { _id: '1234567890' } };
     const formattedAbsenceRow = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé', 'Journalière',
-      '20/05/2019', '31/05/2019', '40,00', 'brbr'];
+      '20/05/2019', '31/05/2019', '40,00', 'non', '', 'brbr'];
     const formattedAbsenceRow2 = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé',
-      'Journalière', '01/06/2019', '30/06/2019', '96,00', 'brbr'];
+      'Journalière', '01/06/2019', '30/06/2019', '96,00', 'non', '', 'brbr'];
     const formattedAbsenceRow3 = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé',
-      'Journalière', '01/07/2019', '20/07/2019', '72,00', 'brbr'];
+      'Journalière', '01/07/2019', '20/07/2019', '72,00', 'non', '', 'brbr'];
 
     getAbsencesForExport.returns([event]);
     formatAbsence.onCall(0).returns(formattedAbsenceRow);
@@ -582,15 +589,16 @@ describe('exportAbsencesHistory', () => {
       },
       startDate: '2019-05-20T08:00:00',
       endDate: '2019-07-01T22:00:00',
+      extension: { _id: new ObjectID(), startDate: '2019-04-20T08:00:00' },
       misc: 'brbr',
     };
     const credentials = { company: { _id: '1234567890' } };
     const formattedAbsenceRow = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé',
-      'Journalière', '20/05/2019', '31/05/2019', '40,00', 'brbr'];
+      'Journalière', '20/05/2019', '31/05/2019', '40,00', 'oui', '2019/04/20', 'brbr'];
     const formattedAbsenceRow2 = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé',
-      'Journalière', '01/06/2019', '30/06/2019', '96,00', 'brbr'];
+      'Journalière', '01/06/2019', '30/06/2019', '96,00', 'oui', '2019/04/20', 'brbr'];
     const formattedAbsenceRow3 = [event.auxiliary._id, 'Princess', 'CAROLYN', '', 'Etoiles - 75', 'Congé',
-      'Journalière', '01/07/2019', '01/07/2019', '4,00', 'brbr'];
+      'Journalière', '01/07/2019', '01/07/2019', '4,00', 'oui', '2019/04/20', 'brbr'];
 
     getAbsencesForExport.returns([event]);
     formatAbsence.onCall(0).returns(formattedAbsenceRow);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration - np

- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : 
Sur l'export d'absence (Exports > Historique > Absence), je vois 2 nouvelles colonnes 'Prolongation' et  'Absence d'origine', ayant respectivement oui/non si l'absence est une prolongation et la date de l'absence d'origine si c'est le cas.