### PR TITLE
Com 1747 reset counter

### DIFF
--- a/src/helpers/draftFinalPay.js
+++ b/src/helpers/draftFinalPay.js
@@ -38,7 +38,7 @@ exports.getDraftFinalPayByAuxiliary = async (auxiliary, events, prevPay, company
     hoursCounter,
     mutual: !get(auxiliary, 'administrative.mutualFund.has'),
     diff: get(prevPay, 'diff') || DraftPayHelper.computeDiff(null, null, 0, 0),
-    previousMonthHoursCounter: get(prevPay, 'hoursCounter'),
+    previousMonthHoursCounter: get(prevPay, 'hoursCounter') || 0,
     endDate: contract.endDate,
     endReason: contract.endReason,
     endNotificationDate: contract.endNotificationDate,

--- a/src/helpers/draftFinalPay.js
+++ b/src/helpers/draftFinalPay.js
@@ -37,7 +37,7 @@ exports.getDraftFinalPayByAuxiliary = async (auxiliary, events, prevPay, company
     startDate: moment(query.startDate).isBefore(contract.startDate) ? contract.startDate : query.startDate,
     hoursCounter,
     mutual: !get(auxiliary, 'administrative.mutualFund.has'),
-    diff: prevPay.diff,
+    diff: get(prevPay, 'diff') || DraftPayHelper.computeDiff(null, null, 0, 0),
     previousMonthHoursCounter: prevPay.hoursCounter,
     endDate: contract.endDate,
     endReason: contract.endReason,
@@ -67,7 +67,10 @@ exports.getDraftFinalPay = async (query, credentials) => {
   ]);
 
   const eventsByAuxiliary = await EventRepository.getEventsToPay(start, end, auxiliaries.map(a => a._id), companyId);
-  const prevPayList = await DraftPayHelper.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
+  const isJanuary = moment(query.startDate).month() === 0;
+  const prevPayList = isJanuary
+    ? []
+    : await DraftPayHelper.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
 
   const draftFinalPay = [];
   for (const auxiliary of auxiliaries) {

--- a/src/helpers/draftFinalPay.js
+++ b/src/helpers/draftFinalPay.js
@@ -38,7 +38,7 @@ exports.getDraftFinalPayByAuxiliary = async (auxiliary, events, prevPay, company
     hoursCounter,
     mutual: !get(auxiliary, 'administrative.mutualFund.has'),
     diff: get(prevPay, 'diff') || DraftPayHelper.computeDiff(null, null, 0, 0),
-    previousMonthHoursCounter: prevPay.hoursCounter,
+    previousMonthHoursCounter: get(prevPay, 'hoursCounter'),
     endDate: contract.endDate,
     endReason: contract.endReason,
     endNotificationDate: contract.endNotificationDate,

--- a/src/helpers/draftFinalPay.js
+++ b/src/helpers/draftFinalPay.js
@@ -67,8 +67,8 @@ exports.getDraftFinalPay = async (query, credentials) => {
   ]);
 
   const eventsByAuxiliary = await EventRepository.getEventsToPay(start, end, auxiliaries.map(a => a._id), companyId);
-  const isJanuary = moment(query.startDate).month() === 0;
-  const prevPayList = isJanuary
+  // Counter is reset on January
+  const prevPayList = moment(query.startDate).month() === 0
     ? []
     : await DraftPayHelper.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
 

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -476,8 +476,10 @@ exports.computeDraftPay = async (auxiliaries, query, credentials) => {
   const auxIds = auxiliaries.map(aux => aux._id);
   const eventsByAuxiliary = await EventRepository.getEventsToPay(startDate, endDate, auxIds, companyId);
 
-  const isJanuary = moment(query.startDate).month() === 0;
-  const prevPayList = isJanuary ? [] : await exports.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
+  // Counter is reset on January
+  const prevPayList = moment(query.startDate).month() === 0
+    ? []
+    : await exports.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
 
   const draftPay = [];
   for (const aux of auxiliaries) {

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -379,7 +379,7 @@ exports.computeAuxiliaryDraftPay = async (aux, contract, eventsToPay, prevPay, c
     ...monthBalance,
     hoursCounter,
     mutual: !get(aux, 'administrative.mutualFund.has'),
-    diff: get(prevPay, 'diff') || computeDiff(null, null, 0, 0),
+    diff: get(prevPay, 'diff') || exports.computeDiff(null, null, 0, 0),
     previousMonthHoursCounter: get(prevPay, 'hoursCounter') || 0,
   };
 };
@@ -417,7 +417,7 @@ const getDiff = (prevPay, hours, key) => {
   return Math.round(diff * 100) / 100;
 };
 
-const computeDiff = (prevPay, hours, absenceDiff, workedHoursDiff) => ({
+exports.computeDiff = (prevPay, hours, absenceDiff, workedHoursDiff) => ({
   absencesHours: absenceDiff,
   workedHours: workedHoursDiff,
   internalHours: getDiff(prevPay, hours, 'internalHours'),
@@ -441,7 +441,7 @@ exports.computePrevPayDiff = async (auxiliary, eventsToPay, prevPay, query, dist
 
   return {
     auxiliary: auxiliary._id,
-    diff: computeDiff(prevPay, hours, absenceDiff, workedHoursDiff),
+    diff: exports.computeDiff(prevPay, hours, absenceDiff, workedHoursDiff),
     hoursCounter: prevPay && prevPay.hoursCounter ? prevPay.hoursCounter : 0,
   };
 };
@@ -464,7 +464,7 @@ exports.getPreviousMonthPay = async (auxiliaries, query, surcharges, dm, company
   return Promise.all(prevPayDiff);
 };
 
-exports.computeDraftPayByAuxiliary = async (auxiliaries, query, credentials) => {
+exports.computeDraftPay = async (auxiliaries, query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
   const { startDate, endDate } = query;
   const [company, surcharges, dm] = await Promise.all([
@@ -505,5 +505,5 @@ exports.getDraftPay = async (query, credentials) => {
   const auxiliaries = await ContractRepository.getAuxiliariesToPay(contractRules, endDate, 'pays', companyId);
   if (auxiliaries.length === 0) return [];
 
-  return exports.computeDraftPayByAuxiliary(auxiliaries, { startDate, endDate }, credentials);
+  return exports.computeDraftPay(auxiliaries, { startDate, endDate }, credentials);
 };

--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -384,7 +384,7 @@ exports.computeAuxiliaryDraftPay = async (aux, contract, eventsToPay, prevPay, c
   };
 };
 
-exports.computePrevPayDetailDiff = (hours, prevPay, detailType) => {
+exports.computePrevPayDetailDiff = (prevPay, hours, detailType) => {
   const details = hours && hours[detailType] ? cloneDeep(hours[detailType]) : {};
   if (!prevPay) return details;
 
@@ -424,10 +424,10 @@ exports.computeDiff = (prevPay, hours, absenceDiff, workedHoursDiff) => ({
   paidTransportHours: getDiff(prevPay, hours, 'paidTransportHours'),
   notSurchargedAndNotExempt: getDiff(prevPay, hours, 'notSurchargedAndNotExempt'),
   surchargedAndNotExempt: getDiff(prevPay, hours, 'surchargedAndNotExempt'),
-  surchargedAndNotExemptDetails: exports.computePrevPayDetailDiff(hours, prevPay, 'surchargedAndNotExemptDetails'),
+  surchargedAndNotExemptDetails: exports.computePrevPayDetailDiff(prevPay, hours, 'surchargedAndNotExemptDetails'),
   notSurchargedAndExempt: getDiff(prevPay, hours, 'notSurchargedAndExempt'),
   surchargedAndExempt: getDiff(prevPay, hours, 'surchargedAndExempt'),
-  surchargedAndExemptDetails: exports.computePrevPayDetailDiff(hours, prevPay, 'surchargedAndExemptDetails'),
+  surchargedAndExemptDetails: exports.computePrevPayDetailDiff(prevPay, hours, 'surchargedAndExemptDetails'),
   hoursBalance: absenceDiff + workedHoursDiff,
 });
 

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -75,7 +75,7 @@ exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, 
   const prevPay = await Pay.findOne({ month: prevMonth, auxiliary: auxiliaryId }).lean();
 
   const payQuery = { startDate, endDate };
-  const [draft] = await DraftPayHelper.computeDraftPayByAuxiliary([{ ...auxiliary, prevPay }], payQuery, credentials);
+  const [draft] = await DraftPayHelper.computeDraftPay([{ ...auxiliary, prevPay }], payQuery, credentials);
 
   const firstMonthContract = moment(startDate).startOf('M').isSameOrBefore(contract.startDate);
 

--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -2,16 +2,11 @@ const cloneDeep = require('lodash/cloneDeep');
 const get = require('lodash/get');
 const Boom = require('@hapi/boom');
 const moment = require('moment');
-const { ObjectID } = require('mongodb');
 const Pay = require('../models/Pay');
 const User = require('../models/User');
-const Company = require('../models/Company');
-const DistanceMatrix = require('../models/DistanceMatrix');
-const Surcharge = require('../models/Surcharge');
 const DraftPayHelper = require('./draftPay');
 const ContractHelper = require('./contracts');
 const UtilsHelper = require('./utils');
-const EventRepository = require('../repositories/EventRepository');
 const SectorHistoryRepository = require('../repositories/SectorHistoryRepository');
 const SectorHistory = require('./sectorHistories');
 
@@ -57,71 +52,42 @@ exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) =
 });
 
 exports.hoursBalanceDetail = async (query, credentials) => {
-  const companyId = get(credentials, 'company._id', null);
   const startDate = moment(query.month, 'MM-YYYY').startOf('M').toDate();
   const endDate = moment(query.month, 'MM-YYYY').endOf('M').toDate();
 
-  if (query.sector) return this.hoursBalanceDetailBySector(query.sector, startDate, endDate, companyId);
+  if (query.sector) return this.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
-  return this.hoursBalanceDetailByAuxiliary(query.auxiliary, startDate, endDate, companyId);
+  return this.hoursBalanceDetailByAuxiliary(query.auxiliary, startDate, endDate, credentials);
 };
 
-exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, companyId) => {
+exports.hoursBalanceDetailByAuxiliary = async (auxiliaryId, startDate, endDate, credentials) => {
+  const companyId = get(credentials, 'company._id', null);
   const sectorsId = await SectorHistory.getAuxiliarySectors(auxiliaryId, companyId, startDate, endDate);
   const month = moment(startDate).format('MM-YYYY');
   const pay = await Pay.findOne({ auxiliary: auxiliaryId, month }).lean();
   if (pay) return { ...pay, sectors: sectorsId, counterAndDiffRelevant: true };
 
   const auxiliary = await User.findOne({ _id: auxiliaryId }).populate('contracts').lean();
-  const prevMonth = moment(month, 'MM-YYYY').subtract(1, 'M').format('MM-YYYY');
-  const prevPay = await Pay.findOne({ month: prevMonth, auxiliary: auxiliaryId }).lean();
-  const payQuery = { startDate, endDate };
-  const [company, surcharges, distanceMatrix] = await Promise.all([
-    Company.findOne({ _id: companyId }).lean(),
-    Surcharge.find({ company: companyId }).lean(),
-    DistanceMatrix.find({ company: companyId }).lean(),
-  ]);
-
-  const prevPayList = await DraftPayHelper.getPreviousMonthPay(
-    [{ ...auxiliary, prevPay }],
-    payQuery,
-    surcharges,
-    distanceMatrix,
-    companyId
-  );
-  const prevPayWithDiff = prevPayList.length ? prevPayList[0] : null;
   const contract = exports.getContract(auxiliary.contracts, startDate, endDate);
   if (!contract) throw Boom.badRequest();
 
-  const auxiliaryEvents =
-    await EventRepository.getEventsToPay(startDate, endDate, [new ObjectID(auxiliaryId)], companyId);
-  const events = auxiliaryEvents[0] ? auxiliaryEvents[0] : { events: [], absences: [] };
+  const prevMonth = moment(month, 'MM-YYYY').subtract(1, 'M').format('MM-YYYY');
+  const prevPay = await Pay.findOne({ month: prevMonth, auxiliary: auxiliaryId }).lean();
 
-  const draft = await DraftPayHelper.computeAuxiliaryDraftPay(
-    auxiliary,
-    contract,
-    events,
-    prevPayWithDiff,
-    company,
-    payQuery,
-    distanceMatrix,
-    surcharges
-  );
+  const payQuery = { startDate, endDate };
+  const [draft] = await DraftPayHelper.computeDraftPayByAuxiliary([{ ...auxiliary, prevPay }], payQuery, credentials);
 
   const firstMonthContract = moment(startDate).startOf('M').isSameOrBefore(contract.startDate);
 
   return draft ? { ...draft, sectors: sectorsId, counterAndDiffRelevant: !!prevPay || firstMonthContract } : null;
 };
 
-exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, companyId) => {
+exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, credentials) => {
+  const companyId = get(credentials, 'company._id', null);
   const sectors = UtilsHelper.formatObjectIdsArray(sector);
 
-  const auxiliariesIds = await SectorHistoryRepository.getUsersFromSectorHistories(
-    startDate,
-    endDate,
-    sectors,
-    companyId
-  );
+  const auxiliariesIds =
+    await SectorHistoryRepository.getUsersFromSectorHistories(startDate, endDate, sectors, companyId);
   const result = [];
   const auxiliaries = await User.find({ company: companyId, _id: { $in: auxiliariesIds.map(aux => aux.auxiliaryId) } })
     .populate('contracts')
@@ -132,7 +98,7 @@ exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, companyI
     const contract = exports.getContract(auxiliary.contracts, startDate, endDate);
     if (!contract) continue;
 
-    const hbd = await exports.hoursBalanceDetailByAuxiliary(auxiliary._id, startDate, endDate, companyId);
+    const hbd = await exports.hoursBalanceDetailByAuxiliary(auxiliary._id, startDate, endDate, credentials);
     result.push({ ...hbd, auxiliaryId: auxiliary._id, identity: auxiliary.identity, picture: auxiliary.picture });
   }
 

--- a/tests/integration/pay.test.js
+++ b/tests/integration/pay.test.js
@@ -446,7 +446,7 @@ describe('PAY ROUTES - GET /pays/export/{type}', () => {
     it('should export contract ends for pay', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/pay/export/contract_end?startDate=2022-10-01T00:00:00&endDate=2022-10-31T23:59:59',
+        url: '/pay/export/contract_end?startDate=2022-11-01T00:00:00&endDate=2022-11-30T23:59:59',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/seed/paySeed.js
+++ b/tests/integration/seed/paySeed.js
@@ -95,7 +95,7 @@ const contracts = [{
   company: authCompany._id,
   startDate: '2021-12-03T23:00:00',
   _id: contractId2,
-  endDate: '2022-10-03T23:00:00',
+  endDate: '2022-11-03T23:00:00',
   endNotificationDate: '2022-03-03T23:00:00',
   endReason: 'resignation',
   versions: [
@@ -117,7 +117,7 @@ const contracts = [{
     },
     {
       createdAt: '2021-12-04T16:34:04',
-      endDate: '2022-10-03T23:00:00',
+      endDate: '2022-11-03T23:00:00',
       grossHourlyRate: 10.28,
       startDate: '2022-10-01T23:00:01',
       weeklyHours: 7,

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -95,7 +95,6 @@ describe('getDraftFinalPayByAuxiliary', () => {
       notSurchargedAndNotExempt: 15,
       surchargedAndNotExempt: 9,
       hoursBalance: 4,
-      hoursCounter: 16,
       transport: 26.54,
       phoneFees: 29.6,
     };
@@ -113,6 +112,7 @@ describe('getDraftFinalPayByAuxiliary', () => {
     expect(result).toBeDefined();
     expect(result).toEqual({
       ...computedPay,
+      hoursCounter: 16,
       auxiliaryId: '1234567890',
       auxiliary: { _id: '1234567890' },
       startDate: '2019-05-01T00:00:00',
@@ -154,7 +154,6 @@ describe('getDraftFinalPayByAuxiliary', () => {
       notSurchargedAndNotExempt: 15,
       surchargedAndNotExempt: 9,
       hoursBalance: 4,
-      hoursCounter: 16,
       transport: 26.54,
       phoneFees: 29.6,
     };
@@ -173,6 +172,7 @@ describe('getDraftFinalPayByAuxiliary', () => {
     expect(result).toBeDefined();
     expect(result).toEqual({
       ...computedPay,
+      hoursCounter: 4,
       auxiliaryId: '1234567890',
       auxiliary: { _id: '1234567890' },
       startDate: '2019-05-01T00:00:00',

--- a/tests/unit/helpers/draftFinalPay.test.js
+++ b/tests/unit/helpers/draftFinalPay.test.js
@@ -59,13 +59,16 @@ describe('getContractMonthInfo', () => {
 describe('getDraftFinalPayByAuxiliary', () => {
   let computeBalance;
   let genericData;
+  let computeDiff;
   beforeEach(() => {
     computeBalance = sinon.stub(DraftPayHelper, 'computeBalance');
     genericData = sinon.stub(DraftPayHelper, 'genericData');
+    computeDiff = sinon.stub(DraftPayHelper, 'computeDiff');
   });
   afterEach(() => {
     computeBalance.restore();
     genericData.restore();
+    computeDiff.restore();
   });
 
   it('should return draft pay for one auxiliary', async () => {
@@ -125,6 +128,67 @@ describe('getDraftFinalPayByAuxiliary', () => {
       diff: { workedHours: 3, hoursBalance: 2 },
       previousMonthHoursCounter: 10,
     });
+    sinon.assert.notCalled(computeDiff);
+  });
+
+  it('should return draft pay for one auxiliary if no prevPay', async () => {
+    const aux = {
+      _id: '1234567890',
+      identity: { firstname: 'Hugo', lastname: 'Lloris' },
+      sector: { name: 'La ruche' },
+      contracts: [{
+        startDate: '2019-03-02T00:00:00',
+        endDate: '2019-05-17T23:59:59',
+        endReason: 'plus envie',
+        endNotificationDate: '2019-05-12T23:59:59',
+      }],
+      administrative: { mutualFund: { has: true } },
+    };
+    const events = { events: [[{ auxiliary: '1234567890' }]], absences: [] };
+    const company = { rhConfig: { phoneFeeAmount: 37 } };
+    const query = { startDate: '2019-05-01T00:00:00', endDate: '2019-05-31T23:59:59' };
+    const computedPay = {
+      startDate: '2019-05-01T00:00:00',
+      contractHours: 150,
+      workedHours: 138,
+      notSurchargedAndNotExempt: 15,
+      surchargedAndNotExempt: 9,
+      hoursBalance: 4,
+      hoursCounter: 16,
+      transport: 26.54,
+      phoneFees: 29.6,
+    };
+    computeBalance.returns(computedPay);
+    computeDiff.returns({ workedHours: 0, hoursBalance: 0 });
+    genericData.returns({
+      auxiliaryId: '1234567890',
+      auxiliary: { _id: '1234567890' },
+      overtimeHours: 0,
+      additionalHours: 0,
+      bonus: 0,
+      month: '05-2019',
+    });
+
+    const result = await DraftFinalPayHelper.getDraftFinalPayByAuxiliary(aux, events, null, company, query, [], []);
+    expect(result).toBeDefined();
+    expect(result).toEqual({
+      ...computedPay,
+      auxiliaryId: '1234567890',
+      auxiliary: { _id: '1234567890' },
+      startDate: '2019-05-01T00:00:00',
+      overtimeHours: 0,
+      additionalHours: 0,
+      bonus: 0,
+      mutual: false,
+      month: '05-2019',
+      endDate: '2019-05-17T23:59:59',
+      endNotificationDate: '2019-05-12T23:59:59',
+      endReason: 'plus envie',
+      compensation: 0,
+      diff: { workedHours: 0, hoursBalance: 0 },
+      previousMonthHoursCounter: 0,
+    });
+    sinon.assert.calledOnceWithExactly(computeDiff, null, null, 0, 0);
   });
 });
 

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -47,12 +47,12 @@ describe('getContractMonthInfo', () => {
     expect(result).toBeDefined();
     expect(result.contractHours).toBe(104);
     expect(result.workedDaysRatio).toBe(1 / 4);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getDaysRatioBetweenTwoDates,
       moment('2019-05-06').startOf('M').toDate(),
       moment('2019-05-06').endOf('M').toDate()
     );
-    sinon.assert.calledWithExactly(getContractInfo, versions[1], query, 4);
+    sinon.assert.calledOnceWithExactly(getContractInfo, versions[1], query, 4);
   });
 });
 
@@ -433,7 +433,7 @@ describe('getTransportInfo', () => {
       destinations: 'paradis',
       mode: 'repos',
     };
-    sinon.assert.calledWithExactly(getOrCreateDistanceMatrix, query, companyId);
+    sinon.assert.calledOnceWithExactly(getOrCreateDistanceMatrix, query, companyId);
     expect(result).toEqual({ duration: 2, distance: 3 });
   });
 });
@@ -552,7 +552,7 @@ describe('getPaidTransportInfo', () => {
     const result = await DraftPayHelper.getPaidTransportInfo(event, prevEvent, []);
 
     expect(result).toBeDefined();
-    sinon.assert.calledWithExactly(getTransportInfo, [], 'tamalou', 'jébobolà', 'driving', event.company);
+    sinon.assert.calledOnceWithExactly(getTransportInfo, [], 'tamalou', 'jébobolà', 'driving', event.company);
   });
 
   it('should compute transit transport', async () => {
@@ -704,7 +704,13 @@ describe('getEventHours', () => {
     const result = await DraftPayHelper.getEventHours(event, prevEvent, service, details, distanceMatrix);
     expect(result).toBeDefined();
     expect(result).toEqual({ surcharged: 10, notSurcharged: 2.5, paidTransportHours: 0.5 });
-    sinon.assert.calledWithExactly(getSurchargeSplit, event, { sunday: 10 }, details, { distance: 12, duration: 30 });
+    sinon.assert.calledOnceWithExactly(
+      getSurchargeSplit,
+      event,
+      { sunday: 10 },
+      details,
+      { distance: 12, duration: 30 }
+    );
   });
 });
 
@@ -883,7 +889,7 @@ describe('getPayFromEvents', () => {
     const result = await DraftPayHelper.getPayFromEvents(events, auxiliary, [], surcharges, query);
 
     expect(result).toBeDefined();
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getMatchingVersion,
       '2019-07-12T09:00:00',
       { versions: [{ startDate: '2019-02-22T00:00:00' }], surcharge: surchargeId },
@@ -936,7 +942,7 @@ describe('getPayFromEvents', () => {
       internalHours: 0,
       paidTransportHours: 2,
     });
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getEventHours,
       { ...events[0][0], auxiliary },
       false,
@@ -991,7 +997,7 @@ describe('getPayFromEvents', () => {
       paidTransportHours: 3,
       internalHours: 0,
     });
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getEventHours,
       { ...events[0][0], auxiliary },
       false,
@@ -1029,7 +1035,7 @@ describe('getPayFromEvents', () => {
       internalHours: 5,
       paidTransportHours: 2,
     });
-    sinon.assert.calledWithExactly(getEventHours, { ...events[0][0], auxiliary }, false, null, {}, []);
+    sinon.assert.calledOnceWithExactly(getEventHours, { ...events[0][0], auxiliary }, false, null, {}, []);
     sinon.assert.notCalled(getMatchingVersion);
   });
 
@@ -1378,8 +1384,8 @@ describe('computeBalance', () => {
       hoursToWork: 131,
       holidaysHours: 3,
     });
-    sinon.assert.calledWithExactly(getPayFromEvents, [events.events[1]], auxiliary, [], [], query);
-    sinon.assert.calledWithExactly(getPayFromAbsences, [events.absences[0], events.absences[1]], contract, query);
+    sinon.assert.calledOnceWithExactly(getPayFromEvents, [events.events[1]], auxiliary, [], [], query);
+    sinon.assert.calledOnceWithExactly(getPayFromAbsences, [events.absences[0], events.absences[1]], contract, query);
   });
 
   it('should return balance without phoneFees', async () => {
@@ -1424,8 +1430,8 @@ describe('computeBalance', () => {
       hoursToWork: 131,
       holidaysHours: 3,
     });
-    sinon.assert.calledWithExactly(getPayFromEvents, [events.events[1]], auxiliary, [], [], query);
-    sinon.assert.calledWithExactly(getPayFromAbsences, [events.absences[0], events.absences[1]], contract, query);
+    sinon.assert.calledOnceWithExactly(getPayFromEvents, [events.events[1]], auxiliary, [], [], query);
+    sinon.assert.calledOnceWithExactly(getPayFromAbsences, [events.absences[0], events.absences[1]], contract, query);
   });
 
   it('should return balance, contract ends during this month', async () => {
@@ -1458,8 +1464,8 @@ describe('computeBalance', () => {
     getTransportRefund.returns(26.54);
 
     await DraftPayHelper.computeBalance(auxiliary, contract, events, company, query, [], []);
-    sinon.assert.calledWithExactly(getPayFromEvents, [events.events[0]], auxiliary, [], [], query);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(getPayFromEvents, [events.events[0]], auxiliary, [], [], query);
+    sinon.assert.calledOnceWithExactly(
       getPayFromAbsences,
       [events.absences[0], events.absences[2], events.absences[3]],
       contract,
@@ -1523,7 +1529,7 @@ describe('computeAuxiliaryDraftPay', () => {
       overtimeHours: 0,
       additionalHours: 0,
     });
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computeBalance,
       aux,
       { startDate: '2019-05-13T00:00:00' },
@@ -1593,7 +1599,7 @@ describe('computeAuxiliaryDraftPay', () => {
       overtimeHours: 0,
       additionalHours: 0,
     });
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computeBalance,
       aux,
       { startDate: '2019-05-13T00:00:00' },
@@ -1841,14 +1847,14 @@ describe('getPreviousMonthPay', () => {
     const result = await DraftPayHelper.getPreviousMonthPay(auxiliaries, query, surcharges, dm, companyId);
 
     expect(result).toBeDefined();
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getEventsToPay,
       moment(query.startDate).subtract(1, 'M').startOf('M').toDate(),
       moment(query.endDate).subtract(1, 'M').endOf('M').toDate(),
       [auxiliaryId],
       companyId
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computePrevPayDiff,
       auxiliaries[0],
       payData[0],
@@ -1947,7 +1953,7 @@ describe('computeDraftPay', () => {
     const result = await DraftPayHelper.computeDraftPay([aux], query, credentials);
 
     expect(result).toEqual([]);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getPreviousMonthPay,
       [aux],
       query,
@@ -1993,7 +1999,7 @@ describe('computeDraftPay', () => {
 
     expect(result).toBeDefined();
     expect(result).toEqual([{ hoursBalance: 120 }]);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getPreviousMonthPay,
       auxiliaries,
       query,
@@ -2001,7 +2007,7 @@ describe('computeDraftPay', () => {
       [{ _id: 'dm' }],
       companyId
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computeAuxiliaryDraftPay,
       { _id: auxiliaryId, sector: { name: 'Abeilles' }, contracts: [{ _id: '1234567890' }] },
       { _id: '1234567890' },
@@ -2041,7 +2047,7 @@ describe('computeDraftPay', () => {
 
     expect(result).toEqual([{ hoursBalance: 120 }]);
     sinon.assert.notCalled(getPreviousMonthPay);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computeAuxiliaryDraftPay,
       { _id: auxiliaryId, sector: { name: 'Abeilles' }, contracts: [{ _id: '1234567890' }] },
       { _id: '1234567890' },
@@ -2079,7 +2085,7 @@ describe('getDraftPay', () => {
     const result = await DraftPayHelper.getDraftPay(query, credentials);
 
     expect(result).toEqual([]);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getAuxiliariesToPay,
       {
         startDate: { $lte: end },
@@ -2100,7 +2106,7 @@ describe('getDraftPay', () => {
     getAuxiliariesToPay.returns(auxiliaries);
     await DraftPayHelper.getDraftPay(query, credentials);
 
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       getAuxiliariesToPay,
       {
         startDate: { $lte: end },
@@ -2110,7 +2116,7 @@ describe('getDraftPay', () => {
       'pays',
       credentials.company._id
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       computeDraftPay,
       auxiliaries,
       { startDate: moment(query.startDate).startOf('d').toDate(), endDate: moment(query.endDate).endOf('d').toDate() },

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1610,33 +1610,22 @@ describe('computePrevPayDetailDiff', () => {
   it('should compute previous pay if hours and prevPay are defined', () => {
     const hours = {
       surchargedAndExemptDetails: {
-        qwertyuiop: {
-          evenings: { hours: 23 },
-          saturdays: { hours: 23 },
-        },
+        qwertyuiop: { evenings: { hours: 23 }, saturdays: { hours: 23 } },
         asdfghjkl: { christmas: { hours: 5 } },
       },
     };
     const prevPay = {
       surchargedAndExemptDetails: [
-        {
-          planId: 'qwertyuiop',
-          evenings: { hours: 2 },
-          sundays: { hours: 3 },
-        },
+        { planId: 'qwertyuiop', evenings: { hours: 2 }, sundays: { hours: 3 } },
         { planId: 'zxcvbnm', evenings: { hours: 4 } },
       ],
     };
     const detailType = 'surchargedAndExemptDetails';
 
-    const result = DraftPayHelper.computePrevPayDetailDiff(hours, prevPay, detailType);
+    const result = DraftPayHelper.computePrevPayDetailDiff(prevPay, hours, detailType);
 
     expect(result).toEqual({
-      qwertyuiop: {
-        evenings: { hours: 21 },
-        saturdays: { hours: 23 },
-        sundays: { hours: -3 },
-      },
+      qwertyuiop: { evenings: { hours: 21 }, saturdays: { hours: 23 }, sundays: { hours: -3 } },
       asdfghjkl: { christmas: { hours: 5 } },
       zxcvbnm: { evenings: { hours: -4 } },
     });
@@ -1645,25 +1634,17 @@ describe('computePrevPayDetailDiff', () => {
   it('should compute previous pay if hours is defined but not prevPay', () => {
     const hours = {
       surchargedAndExemptDetails: {
-        qwertyuiop: {
-          evenings: { hours: 23 },
-          saturdays: { hours: 23 },
-        },
+        qwertyuiop: { evenings: { hours: 23 }, saturdays: { hours: 23 } },
         asdfghjkl: { christmas: { hours: 5 } },
       },
     };
-    const prevPay = {
-      surchargedAndExemptDetails: [],
-    };
+    const prevPay = { surchargedAndExemptDetails: [] };
     const detailType = 'surchargedAndExemptDetails';
 
-    const result = DraftPayHelper.computePrevPayDetailDiff(hours, prevPay, detailType);
+    const result = DraftPayHelper.computePrevPayDetailDiff(prevPay, hours, detailType);
 
     expect(result).toEqual({
-      qwertyuiop: {
-        evenings: { hours: 23 },
-        saturdays: { hours: 23 },
-      },
+      qwertyuiop: { evenings: { hours: 23 }, saturdays: { hours: 23 } },
       asdfghjkl: { christmas: { hours: 5 } },
     });
   });
@@ -1672,23 +1653,16 @@ describe('computePrevPayDetailDiff', () => {
     const hours = {};
     const prevPay = {
       surchargedAndExemptDetails: [
-        {
-          planId: 'qwertyuiop',
-          evenings: { hours: 2 },
-          sundays: { hours: 3 },
-        },
+        { planId: 'qwertyuiop', evenings: { hours: 2 }, sundays: { hours: 3 } },
         { planId: 'zxcvbnm', evenings: { hours: 4 } },
       ],
     };
     const detailType = 'surchargedAndExemptDetails';
 
-    const result = DraftPayHelper.computePrevPayDetailDiff(hours, prevPay, detailType);
+    const result = DraftPayHelper.computePrevPayDetailDiff(prevPay, hours, detailType);
 
     expect(result).toEqual({
-      qwertyuiop: {
-        evenings: { hours: -2 },
-        sundays: { hours: -3 },
-      },
+      qwertyuiop: { evenings: { hours: -2 }, sundays: { hours: -3 } },
       zxcvbnm: { evenings: { hours: -4 } },
     });
   });
@@ -1716,9 +1690,7 @@ describe('computePrevPayDiff', () => {
     const query = { startDate: '2019-09-01T00:00:00', endDate: '2019-09-30T23:59:59' };
     const auxiliary = { _id: '1234567890', contracts: [{ _id: 'poiuytre' }] };
     const events = [{ _id: new ObjectID() }];
-
-    getContractMonthInfo.returns({ contractHours: 34 });
-    getPayFromEvents.returns({
+    const hours = {
       workedHours: 24,
       notSurchargedAndNotExempt: 12,
       surchargedAndNotExempt: 3,
@@ -1728,7 +1700,9 @@ describe('computePrevPayDiff', () => {
       surchargedAndExemptDetails: {},
       internalHours: 0,
       paidTransportHours: 0,
-    });
+    };
+    getContractMonthInfo.returns({ contractHours: 34 });
+    getPayFromEvents.returns(hours);
     getPayFromAbsences.returns(5);
     computePrevPayDetailDiff.returnsArg(2);
 
@@ -1751,6 +1725,8 @@ describe('computePrevPayDiff', () => {
       },
       hoursCounter: 0,
     });
+    sinon.assert.calledWithExactly(computePrevPayDetailDiff.getCall(0), null, hours, 'surchargedAndNotExemptDetails');
+    sinon.assert.calledWithExactly(computePrevPayDetailDiff.getCall(1), null, hours, 'surchargedAndExemptDetails');
   });
 
   it('should return diff with prevPay', async () => {
@@ -1772,8 +1748,7 @@ describe('computePrevPayDiff', () => {
       internalHours: 1,
       paidTransportHours: 3,
     };
-
-    getPayFromEvents.returns({
+    const hours = {
       workedHours: 24,
       notSurchargedAndNotExempt: 12,
       surchargedAndNotExempt: 3,
@@ -1783,7 +1758,9 @@ describe('computePrevPayDiff', () => {
       surchargedAndExemptDetails: {},
       internalHours: 2,
       paidTransportHours: 4,
-    });
+    };
+
+    getPayFromEvents.returns(hours);
     getPayFromAbsences.returns(-2);
     computePrevPayDetailDiff.returnsArg(2);
 
@@ -1806,6 +1783,13 @@ describe('computePrevPayDiff', () => {
       },
       hoursCounter: 3,
     });
+    sinon.assert.calledWithExactly(
+      computePrevPayDetailDiff.getCall(0),
+      prevPay,
+      hours,
+      'surchargedAndNotExemptDetails'
+    );
+    sinon.assert.calledWithExactly(computePrevPayDetailDiff.getCall(1), prevPay, hours, 'surchargedAndExemptDetails');
   });
 });
 

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -9,7 +9,6 @@ const User = require('../../../src/models/User');
 const PayHelper = require('../../../src/helpers/pay');
 const DraftPayHelper = require('../../../src/helpers/draftPay');
 const ContractHelper = require('../../../src/helpers/contracts');
-const EventRepository = require('../../../src/repositories/EventRepository');
 const SectorHistoryRepository = require('../../../src/repositories/SectorHistoryRepository');
 const SectorHistoryHelper = require('../../../src/helpers/sectorHistories');
 
@@ -431,7 +430,7 @@ describe('hoursBalanceDetailBySector', () => {
       credentials.company._id
     );
     sinon.assert.calledWithExactly(getContractStub, [contract], startDate, endDate);
-    sinon.assert.calledWithExactly( hoursBalanceDetailByAuxiliary, auxiliaryId, startDate, endDate, credentials s);
+    sinon.assert.calledWithExactly(hoursBalanceDetailByAuxiliary, auxiliaryId, startDate, endDate, credentials);
   });
 
   it('should return the info for many sectors', async () => {

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -6,9 +6,6 @@ const { ObjectID } = require('mongodb');
 const SinonMongoose = require('../sinonMongoose');
 const Pay = require('../../../src/models/Pay');
 const User = require('../../../src/models/User');
-const Company = require('../../../src/models/Company');
-const Surcharge = require('../../../src/models/Surcharge');
-const DistanceMatrix = require('../../../src/models/DistanceMatrix');
 const PayHelper = require('../../../src/helpers/pay');
 const DraftPayHelper = require('../../../src/helpers/draftPay');
 const ContractHelper = require('../../../src/helpers/contracts');
@@ -167,15 +164,15 @@ describe('hoursBalanceDetail', () => {
   const endDate = moment(month, 'MM-YYYY').endOf('M').toDate();
 
   let hoursBalanceDetailBySectorStub;
-  let hoursBalanceDetailByAuxiliaryStub;
+  let hoursBalanceDetailByAuxiliary;
 
   beforeEach(() => {
     hoursBalanceDetailBySectorStub = sinon.stub(PayHelper, 'hoursBalanceDetailBySector');
-    hoursBalanceDetailByAuxiliaryStub = sinon.stub(PayHelper, 'hoursBalanceDetailByAuxiliary');
+    hoursBalanceDetailByAuxiliary = sinon.stub(PayHelper, 'hoursBalanceDetailByAuxiliary');
   });
   afterEach(() => {
     hoursBalanceDetailBySectorStub.restore();
-    hoursBalanceDetailByAuxiliaryStub.restore();
+    hoursBalanceDetailByAuxiliary.restore();
   });
 
   it('should call hoursBalanceDetailBySector', async () => {
@@ -185,30 +182,18 @@ describe('hoursBalanceDetail', () => {
     const result = await PayHelper.hoursBalanceDetail(query, credentials);
 
     expect(result).toEqual({ data: 'ok' });
-    sinon.assert.notCalled(hoursBalanceDetailByAuxiliaryStub);
-    sinon.assert.calledWithExactly(
-      hoursBalanceDetailBySectorStub,
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    sinon.assert.notCalled(hoursBalanceDetailByAuxiliary);
+    sinon.assert.calledWithExactly(hoursBalanceDetailBySectorStub, query.sector, startDate, endDate, credentials);
   });
 
   it('should call hoursBalanceDetailByAuxiliary', async () => {
     const query = { auxiliary: new ObjectID(), month };
-    hoursBalanceDetailByAuxiliaryStub.returns({ data: 'ok' });
+    hoursBalanceDetailByAuxiliary.returns({ data: 'ok' });
 
     const result = await PayHelper.hoursBalanceDetail(query, credentials);
 
     expect(result).toEqual({ data: 'ok' });
-    sinon.assert.calledWithExactly(
-      hoursBalanceDetailByAuxiliaryStub,
-      query.auxiliary,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    sinon.assert.calledWithExactly(hoursBalanceDetailByAuxiliary, query.auxiliary, startDate, endDate, credentials);
     sinon.assert.notCalled(hoursBalanceDetailBySectorStub);
   });
 });
@@ -223,102 +208,47 @@ describe('hoursBalanceDetailByAuxiliary', () => {
   const companyId = new ObjectID();
   const credentials = { company: { _id: companyId } };
   const prevPay = { _id: new ObjectID() };
-  const surcharges = [{ name: 'week-end' }];
-  const distanceMatrix = {
-    data: {
-      rows: [{
-        elements: [{ distance: { value: 363998 }, duration: { value: 13790 } }],
-      }],
-    },
-    status: 200,
-  };
-  const company = { _id: companyId };
-  const prevPayList = [{ hours: 10 }];
 
   let payFindOne;
   let userFindOne;
-  let companyFindOne;
-  let surchargeFind;
-  let distanceMatrixFind;
-  let getAuxiliarySectorsStub;
-  let getEventsToPayStub;
-  let getPreviousMonthPayStub;
+  let getAuxiliarySectors;
   let getContractStub;
-  let computeAuxiliaryDraftPayStub;
+  let computeDraftPayByAuxiliary;
 
   beforeEach(() => {
     payFindOne = sinon.stub(Pay, 'findOne');
     userFindOne = sinon.stub(User, 'findOne');
-    companyFindOne = sinon.stub(Company, 'findOne');
-    surchargeFind = sinon.stub(Surcharge, 'find');
-    distanceMatrixFind = sinon.stub(DistanceMatrix, 'find');
-    getAuxiliarySectorsStub = sinon.stub(SectorHistoryHelper, 'getAuxiliarySectors');
-    getEventsToPayStub = sinon.stub(EventRepository, 'getEventsToPay');
-    getPreviousMonthPayStub = sinon.stub(DraftPayHelper, 'getPreviousMonthPay');
+    getAuxiliarySectors = sinon.stub(SectorHistoryHelper, 'getAuxiliarySectors');
     getContractStub = sinon.stub(PayHelper, 'getContract');
-    computeAuxiliaryDraftPayStub = sinon.stub(DraftPayHelper, 'computeAuxiliaryDraftPay');
+    computeDraftPayByAuxiliary = sinon.stub(DraftPayHelper, 'computeDraftPayByAuxiliary');
   });
 
   afterEach(() => {
     payFindOne.restore();
     userFindOne.restore();
-    companyFindOne.restore();
-    surchargeFind.restore();
-    distanceMatrixFind.restore();
-    getAuxiliarySectorsStub.restore();
-    getEventsToPayStub.restore();
-    getPreviousMonthPayStub.restore();
+    getAuxiliarySectors.restore();
     getContractStub.restore();
-    computeAuxiliaryDraftPayStub.restore();
+    computeDraftPayByAuxiliary.restore();
   });
 
   it('should return draftPay', async () => {
-    const events = [{ _id: new ObjectID() }];
     const sectorId = new ObjectID();
-    const auxiliaryEvent = { auxiliary: { _id: auxiliaryId }, events, absences: [] };
     const auxiliary = { _id: auxiliaryId, contracts: { startDate: '2018-11-01' } };
+    const contract = { startDate: '2018-11-12' };
+    const draft = { name: 'brouillon' };
 
-    getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
-    getEventsToPayStub.returns([auxiliaryEvent]);
-
+    getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, prevPay], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([surcharges], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
-
-    const contract = { startDate: '2018-11-12' };
     getContractStub.returns(contract);
-    getPreviousMonthPayStub.returns(prevPayList);
-    const draft = { name: 'brouillon', sectors: [sectorId.toHexString()], counterAndDiffRelevant: true };
-    computeAuxiliaryDraftPayStub.returns(draft);
+    computeDraftPayByAuxiliary.returns([draft]);
 
-    const result =
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+    const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
-    expect(result).toEqual(draft);
-    sinon.assert.calledWithExactly(getAuxiliarySectorsStub, auxiliaryId, companyId, startDate, endDate);
-    sinon.assert.calledWithExactly(getEventsToPayStub, startDate, endDate, [new ObjectID(auxiliaryId)], companyId);
-    sinon.assert.calledWithExactly(
-      getPreviousMonthPayStub,
-      [{ ...auxiliary, prevPay }],
-      query,
-      surcharges,
-      distanceMatrix,
-      companyId
-    );
+    expect(result).toEqual({ ...draft, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
+    sinon.assert.calledWithExactly(getAuxiliarySectors, auxiliaryId, companyId, startDate, endDate);
     sinon.assert.calledWithExactly(getContractStub, auxiliary.contracts, startDate, endDate);
-    sinon.assert.calledWithExactly(
-      computeAuxiliaryDraftPayStub,
-      auxiliary,
-      contract,
-      auxiliaryEvent,
-      prevPayList[0],
-      company,
-      query,
-      distanceMatrix,
-      surcharges
-    );
+    sinon.assert.calledWithExactly(computeDraftPayByAuxiliary, [{ ...auxiliary, prevPay }], query, credentials);
     SinonMongoose.calledWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
@@ -336,146 +266,92 @@ describe('hoursBalanceDetailByAuxiliary', () => {
         { query: 'lean' },
       ]
     );
-    SinonMongoose.calledWithExactly(
-      companyFindOne,
-      [{ query: 'findOne', args: [{ _id: companyId }] }, { query: 'lean' }]
-    );
-    SinonMongoose.calledWithExactly(
-      surchargeFind,
-      [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
-    );
-    SinonMongoose.calledWithExactly(
-      distanceMatrixFind,
-      [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
-    );
   });
 
   it('should return draftPay with counterAndDiffRelevant if contract has just started', async () => {
-    const events = [{ _id: new ObjectID() }];
     const sectorId = new ObjectID();
-    const auxiliaryEvent = { auxiliary: { _id: auxiliaryId }, events, absences: [] };
     const auxiliary = { _id: auxiliaryId, contracts: { startDate: '2018-11-01' } };
+    const contract = { startDate: moment().startOf('day').toDate() };
+    const draft = { name: 'brouillon' };
 
-    getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
-    getEventsToPayStub.returns([auxiliaryEvent]);
-
+    getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, null], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([surcharges], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
-
-    const contract = { startDate: moment().startOf('day').toDate() };
     getContractStub.returns(contract);
-    getPreviousMonthPayStub.returns(prevPayList);
-    const draft = { name: 'brouillon', sectors: [sectorId.toHexString()], counterAndDiffRelevant: true };
-    computeAuxiliaryDraftPayStub.returns(draft);
+    computeDraftPayByAuxiliary.returns([draft]);
 
-    const result =
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+    const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
-    expect(result).toEqual(draft);
+    expect(result).toEqual({ ...draft, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
   });
 
   it('should return draftPay with counterAndDiffRelevant to false if no prevPay and not firstmonth', async () => {
-    const events = [{ _id: new ObjectID() }];
     const sectorId = new ObjectID();
-    const auxiliaryEvent = { auxiliary: { _id: auxiliaryId }, events, absences: [] };
     const auxiliary = { _id: auxiliaryId, contracts: { startDate: '2018-11-01' } };
+    const contract = { startDate: '2018-12-01' };
+    const draft = { name: 'brouillon' };
 
-    getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
-    getEventsToPayStub.returns([auxiliaryEvent]);
-
+    getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, null], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([surcharges], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
-
-    const contract = { startDate: '2018-12-01' };
     getContractStub.returns(contract);
-    getPreviousMonthPayStub.returns(prevPayList);
-    const draft = { name: 'brouillon', sectors: [sectorId.toHexString()], counterAndDiffRelevant: false };
-    computeAuxiliaryDraftPayStub.returns(draft);
+    computeDraftPayByAuxiliary.returns([draft]);
 
-    const result =
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+    const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
-    expect(result).toEqual(draft);
+    expect(result).toEqual({ ...draft, sectors: [sectorId.toHexString()], counterAndDiffRelevant: false });
   });
 
   it('should return pay if it exists', async () => {
     const pay = { _id: new ObjectID() };
     const sectorId = new ObjectID();
 
-    getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
+    getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([pay], ['lean']));
 
-    const result =
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+    const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
     expect(result).toEqual({ ...pay, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
-    sinon.assert.notCalled(getEventsToPayStub);
-    sinon.assert.notCalled(getPreviousMonthPayStub);
     sinon.assert.notCalled(getContractStub);
-    sinon.assert.notCalled(computeAuxiliaryDraftPayStub);
+    sinon.assert.notCalled(computeDraftPayByAuxiliary);
     SinonMongoose.calledWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
     );
     sinon.assert.notCalled(userFindOne);
-    sinon.assert.notCalled(companyFindOne);
-    sinon.assert.notCalled(surchargeFind);
-    sinon.assert.notCalled(distanceMatrixFind);
   });
 
   it('should return 400 if no contract', async () => {
-    const events = [{ _id: new ObjectID() }];
     const sectorId = new ObjectID();
     const auxiliary = { _id: auxiliaryId, contracts: { startDate: '2018-11-01' } };
     try {
-      getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
-      getEventsToPayStub.returns([]);
-      getPreviousMonthPayStub.returns(prevPayList);
-      getEventsToPayStub.returns([{ auxiliary: { _id: auxiliaryId }, events, absences: [] }]);
+      getAuxiliarySectors.returns([sectorId.toHexString()]);
 
       payFindOne.returns(SinonMongoose.stubChainedQueries([null, prevPay], ['lean']));
       userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-      companyFindOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
-      surchargeFind.returns(SinonMongoose.stubChainedQueries([surcharges], ['lean']));
-      distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
 
       getContractStub.returns();
 
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
     } catch (e) {
       expect(e).toEqual(Boom.badRequest());
     } finally {
-      sinon.assert.notCalled(computeAuxiliaryDraftPayStub);
+      sinon.assert.notCalled(computeDraftPayByAuxiliary);
     }
   });
 
   it('should return null if no draftPay', async () => {
-    const events = [{ _id: new ObjectID() }];
     const sectorId = new ObjectID();
-    const auxiliaryEvent = { auxiliary: { _id: auxiliaryId }, events, absences: [] };
     const auxiliary = { _id: auxiliaryId, contracts: { startDate: '2018-11-01' } };
+    const contract = { startDate: '2018-11-12' };
 
-    getAuxiliarySectorsStub.returns([sectorId.toHexString()]);
-    getEventsToPayStub.returns([auxiliaryEvent]);
+    getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, prevPay], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-    companyFindOne.returns(SinonMongoose.stubChainedQueries([company], ['lean']));
-    surchargeFind.returns(SinonMongoose.stubChainedQueries([surcharges], ['lean']));
-    distanceMatrixFind.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
-
-    computeAuxiliaryDraftPayStub.returns();
-    const contract = { startDate: '2018-11-12' };
+    computeDraftPayByAuxiliary.returns([]);
     getContractStub.returns(contract);
-    getPreviousMonthPayStub.returns(prevPayList);
 
-    const result =
-      await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials.company._id);
+    const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
     expect(result).toBe(null);
   });
@@ -489,18 +365,18 @@ describe('hoursBalanceDetailBySector', () => {
 
   let getUsersFromSectorHistoriesStub;
   let getContractStub;
-  let hoursBalanceDetailByAuxiliaryStub;
+  let hoursBalanceDetailByAuxiliary;
   let UserMock;
   beforeEach(() => {
     getUsersFromSectorHistoriesStub = sinon.stub(SectorHistoryRepository, 'getUsersFromSectorHistories');
     getContractStub = sinon.stub(PayHelper, 'getContract');
-    hoursBalanceDetailByAuxiliaryStub = sinon.stub(PayHelper, 'hoursBalanceDetailByAuxiliary');
+    hoursBalanceDetailByAuxiliary = sinon.stub(PayHelper, 'hoursBalanceDetailByAuxiliary');
     UserMock = sinon.mock(User);
   });
   afterEach(() => {
     getUsersFromSectorHistoriesStub.restore();
     getContractStub.restore();
-    hoursBalanceDetailByAuxiliaryStub.restore();
+    hoursBalanceDetailByAuxiliary.restore();
     UserMock.verify();
   });
 
@@ -516,12 +392,7 @@ describe('hoursBalanceDetailBySector', () => {
       .chain('lean')
       .returns([]);
 
-    const result = await PayHelper.hoursBalanceDetailBySector(
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    const result = await PayHelper.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
     expect(result).toEqual([]);
     sinon.assert.calledWithExactly(
@@ -537,26 +408,19 @@ describe('hoursBalanceDetailBySector', () => {
     const query = { sector: new ObjectID() };
     const auxiliaryId = new ObjectID();
     const usersFromSectorHistories = [{ auxiliaryId }];
-    getUsersFromSectorHistoriesStub.returns(usersFromSectorHistories);
     const contract = { _id: 'poiuytre' };
-    UserMock
-      .expects('find')
+
+    UserMock.expects('find')
       .withExactArgs({ company: credentials.company._id, _id: { $in: [auxiliaryId] } })
       .chain('populate')
       .withExactArgs('contracts')
       .chain('lean')
       .returns([{ _id: auxiliaryId, contracts: [contract], identity: 'test', picture: 'toto' }]);
-
     getContractStub.returns(contract);
+    getUsersFromSectorHistoriesStub.returns(usersFromSectorHistories);
+    hoursBalanceDetailByAuxiliary.returns({ auxiliary: auxiliaryId, hours: 10 });
 
-    hoursBalanceDetailByAuxiliaryStub.returns({ auxiliary: auxiliaryId, hours: 10 });
-
-    const result = await PayHelper.hoursBalanceDetailBySector(
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    const result = await PayHelper.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
     expect(result).toEqual([{ auxiliaryId, auxiliary: auxiliaryId, hours: 10, identity: 'test', picture: 'toto' }]);
     sinon.assert.calledWithExactly(
@@ -567,13 +431,7 @@ describe('hoursBalanceDetailBySector', () => {
       credentials.company._id
     );
     sinon.assert.calledWithExactly(getContractStub, [contract], startDate, endDate);
-    sinon.assert.calledWithExactly(
-      hoursBalanceDetailByAuxiliaryStub,
-      auxiliaryId,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    sinon.assert.calledWithExactly( hoursBalanceDetailByAuxiliary, auxiliaryId, startDate, endDate, credentials s);
   });
 
   it('should return the info for many sectors', async () => {
@@ -595,16 +453,10 @@ describe('hoursBalanceDetailBySector', () => {
 
     getContractStub.onCall(0).returns(contracts[0]);
     getContractStub.onCall(1).returns(contracts[1]);
+    hoursBalanceDetailByAuxiliary.onCall(0).returns({ auxiliary: auxiliaryIds[0], hours: 10 });
+    hoursBalanceDetailByAuxiliary.onCall(1).returns({ auxiliary: auxiliaryIds[1], hours: 16 });
 
-    hoursBalanceDetailByAuxiliaryStub.onCall(0).returns({ auxiliary: auxiliaryIds[0], hours: 10 });
-    hoursBalanceDetailByAuxiliaryStub.onCall(1).returns({ auxiliary: auxiliaryIds[1], hours: 16 });
-
-    const result = await PayHelper.hoursBalanceDetailBySector(
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    const result = await PayHelper.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
     expect(result).toEqual([
       { auxiliaryId: auxiliaryIds[0], auxiliary: auxiliaryIds[0], hours: 10, identity: 'test', picture: 'toto' },
@@ -620,18 +472,18 @@ describe('hoursBalanceDetailBySector', () => {
     sinon.assert.calledWithExactly(getContractStub.getCall(0), [contracts[0]], startDate, endDate);
     sinon.assert.calledWithExactly(getContractStub.getCall(1), [contracts[1]], startDate, endDate);
     sinon.assert.calledWithExactly(
-      hoursBalanceDetailByAuxiliaryStub.getCall(0),
+      hoursBalanceDetailByAuxiliary.getCall(0),
       auxiliaryIds[0],
       startDate,
       endDate,
-      credentials.company._id
+      credentials
     );
     sinon.assert.calledWithExactly(
-      hoursBalanceDetailByAuxiliaryStub.getCall(1),
+      hoursBalanceDetailByAuxiliary.getCall(1),
       auxiliaryIds[1],
       startDate,
       endDate,
-      credentials.company._id
+      credentials
     );
   });
 
@@ -648,12 +500,7 @@ describe('hoursBalanceDetailBySector', () => {
       .chain('lean')
       .returns([{ _id: auxiliaryId, name: 'titi' }]);
 
-    const result = await PayHelper.hoursBalanceDetailBySector(
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    const result = await PayHelper.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
     expect(result).toEqual([]);
     sinon.assert.calledWithExactly(
@@ -664,7 +511,7 @@ describe('hoursBalanceDetailBySector', () => {
       credentials.company._id
     );
     sinon.assert.notCalled(getContractStub);
-    sinon.assert.notCalled(hoursBalanceDetailByAuxiliaryStub);
+    sinon.assert.notCalled(hoursBalanceDetailByAuxiliary);
   });
 
   it('should not take into account if auxiliary does not currently have contract', async () => {
@@ -683,12 +530,7 @@ describe('hoursBalanceDetailBySector', () => {
 
     getContractStub.returns();
 
-    const result = await PayHelper.hoursBalanceDetailBySector(
-      query.sector,
-      startDate,
-      endDate,
-      credentials.company._id
-    );
+    const result = await PayHelper.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
     expect(result).toEqual([]);
     sinon.assert.calledWithExactly(
@@ -699,7 +541,7 @@ describe('hoursBalanceDetailBySector', () => {
       credentials.company._id
     );
     sinon.assert.calledWithExactly(getContractStub, [contract], startDate, endDate);
-    sinon.assert.notCalled(hoursBalanceDetailByAuxiliaryStub);
+    sinon.assert.notCalled(hoursBalanceDetailByAuxiliary);
   });
 });
 

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -212,14 +212,14 @@ describe('hoursBalanceDetailByAuxiliary', () => {
   let userFindOne;
   let getAuxiliarySectors;
   let getContractStub;
-  let computeDraftPayByAuxiliary;
+  let computeDraftPay;
 
   beforeEach(() => {
     payFindOne = sinon.stub(Pay, 'findOne');
     userFindOne = sinon.stub(User, 'findOne');
     getAuxiliarySectors = sinon.stub(SectorHistoryHelper, 'getAuxiliarySectors');
     getContractStub = sinon.stub(PayHelper, 'getContract');
-    computeDraftPayByAuxiliary = sinon.stub(DraftPayHelper, 'computeDraftPayByAuxiliary');
+    computeDraftPay = sinon.stub(DraftPayHelper, 'computeDraftPay');
   });
 
   afterEach(() => {
@@ -227,7 +227,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     userFindOne.restore();
     getAuxiliarySectors.restore();
     getContractStub.restore();
-    computeDraftPayByAuxiliary.restore();
+    computeDraftPay.restore();
   });
 
   it('should return draftPay', async () => {
@@ -240,14 +240,14 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, prevPay], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
     getContractStub.returns(contract);
-    computeDraftPayByAuxiliary.returns([draft]);
+    computeDraftPay.returns([draft]);
 
     const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
     expect(result).toEqual({ ...draft, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
     sinon.assert.calledWithExactly(getAuxiliarySectors, auxiliaryId, companyId, startDate, endDate);
     sinon.assert.calledWithExactly(getContractStub, auxiliary.contracts, startDate, endDate);
-    sinon.assert.calledWithExactly(computeDraftPayByAuxiliary, [{ ...auxiliary, prevPay }], query, credentials);
+    sinon.assert.calledWithExactly(computeDraftPay, [{ ...auxiliary, prevPay }], query, credentials);
     SinonMongoose.calledWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
@@ -277,7 +277,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, null], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
     getContractStub.returns(contract);
-    computeDraftPayByAuxiliary.returns([draft]);
+    computeDraftPay.returns([draft]);
 
     const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
@@ -294,7 +294,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, null], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
     getContractStub.returns(contract);
-    computeDraftPayByAuxiliary.returns([draft]);
+    computeDraftPay.returns([draft]);
 
     const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);
 
@@ -312,7 +312,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
 
     expect(result).toEqual({ ...pay, sectors: [sectorId.toHexString()], counterAndDiffRelevant: true });
     sinon.assert.notCalled(getContractStub);
-    sinon.assert.notCalled(computeDraftPayByAuxiliary);
+    sinon.assert.notCalled(computeDraftPay);
     SinonMongoose.calledWithExactly(
       payFindOne,
       [{ query: 'findOne', args: [{ auxiliary: auxiliaryId, month }] }, { query: 'lean' }]
@@ -335,7 +335,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     } catch (e) {
       expect(e).toEqual(Boom.badRequest());
     } finally {
-      sinon.assert.notCalled(computeDraftPayByAuxiliary);
+      sinon.assert.notCalled(computeDraftPay);
     }
   });
 
@@ -347,7 +347,7 @@ describe('hoursBalanceDetailByAuxiliary', () => {
     getAuxiliarySectors.returns([sectorId.toHexString()]);
     payFindOne.returns(SinonMongoose.stubChainedQueries([null, prevPay], ['lean']));
     userFindOne.returns(SinonMongoose.stubChainedQueries([auxiliary]));
-    computeDraftPayByAuxiliary.returns([]);
+    computeDraftPay.returns([]);
     getContractStub.returns(contract);
 
     const result = await PayHelper.hoursBalanceDetailByAuxiliary(auxiliaryId, startDate, endDate, credentials);


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : Client

- Périmetre roles : Coach / Auxiliaire

- Cas d'usage : Le compteur d'heures des auxiliaires est remis à zéro en janvier 
en janvier le compteur d'heures correspond au solde du mois. pour tous les autres mois il correspond a la somme du compteur du mois précédent et du solde d'heures du mois. 
C'est visible sur le tableau de bord individuel et la page paie mensuelle.

Pour les tests, voila ce que j'ai regardé. N'hesitez pas a verifier plus si vous vus rendez compte que ce n'est pas suffisant : 
- sur la page de paie mensuelle du mois de janvier, j'ai bien 0 sur diff, compteur M-1. le compteur correspond au solde
- sur la page de paie mensuelle des autre mois, je vois une diff, un compteur M-1, et compteur = solde + compteur M - 1
- idem sur la page de fin de contrat
- sur le tableau de bord individuel : pour le mois de janvier, le compteur correspond au solde
- sur le tableau de bord individuel : pour les autres mois, le compteur correspond au solde + compteur M - 1
