### PR TITLE
COM-1795 - Fix Apple Logo

### DIFF
--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 const handlebars = require('handlebars');
 const path = require('path');
 const fs = require('fs');
@@ -93,7 +94,33 @@ const welcomeTraineeContent = () => `<p>Bonjour,</p>
     à cliquer sur “c’est ma première connexion” pour vous créer un mot de passe. 
   </p>
   <p>Bien cordialement,<br>
-    L'équipe Compani</p>`;
+    L'équipe Compani</p>
+  <br>
+  ${GooglePlayAndAppStoreButtons()}
+  `;
+
+const GooglePlayAndAppStoreButtons = () => `
+  <table width="100%" cellspacing="0" cellpadding="0">
+    <tr>
+      <td>
+        <table cellspacing="0" cellpadding="0">
+          <tr>
+            <td>
+              <a href="https://play.google.com/store/apps/details?id=com.alenvi.compani&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1" target="_blank" style="display: inline-block; padding-right: 15px">
+                <img style="width: 150px" alt='Disponible sur Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png' />           
+              </a>
+            </td>
+            <td>
+              <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" target="_blank" style="display: inline-block;">
+                <img style="width: 130px" alt='Disponible sur App Store' src='https://storage.googleapis.com/compani-programme-test/media-aezr-20210115163447' />           
+              </a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <p>Google Play et le logo Google Play sont des marques de Google LLC.</p>`;
 
 module.exports = {
   baseWelcomeContent,

--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -107,7 +107,7 @@ const GooglePlayAndAppStoreButtons = () => `
           <tr>
             <td>
               <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" target="_blank" style="display: inline-block; padding-right: 15px">
-                <img style="width: 130px" alt='Disponible sur App Store' src='https://storage.googleapis.com/compani-programme-test/media-aezr-20210115163447' />           
+                <img style="width: 140px" alt='Disponible sur App Store' src='https://storage.googleapis.com/compani-main/app-store-logo.png' />
               </a>
             </td>
             <td>

--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -106,15 +106,15 @@ const GooglePlayAndAppStoreButtons = () => `
         <table cellspacing="0" cellpadding="0">
           <tr>
             <td>
-              <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" target="_blank" style="display: inline-block; padding-right: 15px">
-                <img style="width: 140px" alt='Disponible sur App Store' src='https://storage.googleapis.com/compani-main/app-store-logo.png' />
+              <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" style="display: inline-block;">
+                <img src="https://storage.googleapis.com/compani-main/appstore-logo.png" alt="Download on the App Store" style="height: 40px;">
               </a>
             </td>
             <td>
-            <a href="https://play.google.com/store/apps/details?id=com.alenvi.compani&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1" target="_blank" style="display: inline-block;">
-              <img style="width: 150px" alt='Disponible sur Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png' />           
-            </a>
-          </td>
+              <a href="https://play.google.com/store/apps/details?id=com.alenvi.compani&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1" target="_blank" style="display: inline-block;">
+                <img style="height: 60px" alt='Disponible sur Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png' />
+              </a>
+            </td>
           </tr>
         </table>
       </td>

--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -106,15 +106,15 @@ const GooglePlayAndAppStoreButtons = () => `
         <table cellspacing="0" cellpadding="0">
           <tr>
             <td>
-              <a href="https://play.google.com/store/apps/details?id=com.alenvi.compani&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1" target="_blank" style="display: inline-block; padding-right: 15px">
-                <img style="width: 150px" alt='Disponible sur Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png' />           
-              </a>
-            </td>
-            <td>
-              <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" target="_blank" style="display: inline-block;">
+              <a href="https://apps.apple.com/us/app/compani-formation/id1516691161?itsct=apps_box&amp;itscg=30200" target="_blank" style="display: inline-block; padding-right: 15px">
                 <img style="width: 130px" alt='Disponible sur App Store' src='https://storage.googleapis.com/compani-programme-test/media-aezr-20210115163447' />           
               </a>
             </td>
+            <td>
+            <a href="https://play.google.com/store/apps/details?id=com.alenvi.compani&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1" target="_blank" style="display: inline-block;">
+              <img style="width: 150px" alt='Disponible sur Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png' />           
+            </a>
+          </td>
           </tr>
         </table>
       </td>

--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -120,7 +120,7 @@ const GooglePlayAndAppStoreButtons = () => `
       </td>
     </tr>
   </table>
-  <p>Google Play et le logo Google Play sont des marques de Google LLC.</p>`;
+  <p style="color: grey; font-size: 8px">Google Play et le logo Google Play sont des marques de Google LLC.</p>`;
 
 module.exports = {
   baseWelcomeContent,


### PR DESCRIPTION
- [ ] Mon code est testé unitairement -np
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : vendor / client

- Périmetre roles : admin / rof

- Cas d'usage : 
Lorsque j'ajoute un apprenant, dans le mail qu'il reçoit je vois les logos Apple et Google Play

Ce qu'il reste à faire : 
La seule solution que j'ai trouvée est d'upload le logo d'Apple (téléchargeable ici https://tools.applemediaservices.com/app-store/) dans GCS et de linker vers cette image.
Ici j'ai upload sur le bucket program-test, mais je pense que sa place est plus dans compani-main.


Résumé des règles de chaque logo :
https://www.mobizel.com/usage-des-badges-play-store-et-app-store/