### PR TITLE
Com 1831

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -35,7 +35,8 @@ momentRange.extendMoment(moment);
 
 const { language } = translate;
 
-const isRepetition = event => event.repetition && event.repetition.frequency && event.repetition.frequency !== NEVER;
+exports.isRepetition = event =>
+  event.repetition && event.repetition.frequency && event.repetition.frequency !== NEVER;
 
 exports.list = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
@@ -58,7 +59,7 @@ exports.createEvent = async (payload, credentials) => {
 
   await EventHistoriesHelper.createEventHistoryOnCreate(payload, credentials);
 
-  const isRepeatedEvent = isRepetition(event);
+  const isRepeatedEvent = exports.isRepetition(event);
   const hasConflicts = await EventsValidationHelper.hasConflicts(event);
   if (event.type === INTERVENTION && event.auxiliary && isRepeatedEvent && hasConflicts) {
     const auxiliary = await User.findOne({ _id: event.auxiliary })
@@ -248,7 +249,7 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
     await EventsRepetitionHelper.updateRepetition(event, eventPayload, credentials);
   } else {
     const miscUpdatedOnly = eventPayload.misc && exports.isMiscOnlyUpdated(event, eventPayload);
-    const payload = exports.formatEditionPayload(event, eventPayload, isRepetition(event) && !miscUpdatedOnly);
+    const payload = exports.formatEditionPayload(event, eventPayload, exports.isRepetition(event) && !miscUpdatedOnly);
     await Event.updateOne({ _id: event._id }, { ...payload });
   }
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -247,7 +247,7 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
   if (eventPayload.shouldUpdateRepetition) {
     await EventsRepetitionHelper.updateRepetition(event, eventPayload, credentials);
   } else {
-    const miscUpdatedOnly = payload.misc && exports.isMiscOnlyUpdated(event, payload);
+    const miscUpdatedOnly = eventPayload.misc && exports.isMiscOnlyUpdated(event, eventPayload);
     const payload = exports.formatEditionPayload(event, eventPayload, isRepetition(event) && !miscUpdatedOnly);
     await Event.updateOne({ _id: event._id }, { ...payload });
   }

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -2,6 +2,7 @@ const Boom = require('@hapi/boom');
 const moment = require('moment');
 const pick = require('lodash/pick');
 const get = require('lodash/get');
+const has = require('lodash/get');
 const omit = require('lodash/omit');
 const isEqual = require('lodash/isEqual');
 const cloneDeep = require('lodash/cloneDeep');
@@ -36,7 +37,7 @@ momentRange.extendMoment(moment);
 const { language } = translate;
 
 exports.isRepetition = event =>
-  !!event.repetition && !!event.repetition.frequency && event.repetition.frequency !== NEVER;
+  !!has(event, 'repetition.frequency') && get(event, 'repetition.frequency') !== NEVER;
 
 exports.list = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
@@ -249,7 +250,8 @@ exports.updateEvent = async (event, eventPayload, credentials) => {
     await EventsRepetitionHelper.updateRepetition(event, eventPayload, credentials);
   } else {
     const miscUpdatedOnly = eventPayload.misc && exports.isMiscOnlyUpdated(event, eventPayload);
-    const payload = exports.formatEditionPayload(event, eventPayload, exports.isRepetition(event) && !miscUpdatedOnly);
+    const detachFromRepetition = exports.isRepetition(event) && !miscUpdatedOnly;
+    const payload = exports.formatEditionPayload(event, eventPayload, detachFromRepetition);
     await Event.updateOne({ _id: event._id }, { ...payload });
   }
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -2,7 +2,7 @@ const Boom = require('@hapi/boom');
 const moment = require('moment');
 const pick = require('lodash/pick');
 const get = require('lodash/get');
-const has = require('lodash/get');
+const has = require('lodash/has');
 const omit = require('lodash/omit');
 const isEqual = require('lodash/isEqual');
 const cloneDeep = require('lodash/cloneDeep');
@@ -36,8 +36,7 @@ momentRange.extendMoment(moment);
 
 const { language } = translate;
 
-exports.isRepetition = event =>
-  !!has(event, 'repetition.frequency') && get(event, 'repetition.frequency') !== NEVER;
+exports.isRepetition = event => has(event, 'repetition.frequency') && get(event, 'repetition.frequency') !== NEVER;
 
 exports.list = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -36,7 +36,7 @@ momentRange.extendMoment(moment);
 const { language } = translate;
 
 exports.isRepetition = event =>
-  event.repetition && event.repetition.frequency && event.repetition.frequency !== NEVER;
+  !!event.repetition && !!event.repetition.frequency && event.repetition.frequency !== NEVER;
 
 exports.list = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -153,11 +153,8 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
     let eventToSet = { ...eventPayload, startDate, endDate, _id: events[i]._id };
 
     const hasConflicts = await EventsValidationHelper.hasConflicts({ ...eventToSet, company: companyId });
-    let detachFromRepetition = false;
-    if (eventPayload.auxiliary && eventFromDb.type === INTERVENTION && hasConflicts) {
-      eventToSet = { ...omit(eventToSet, ['auxiliary']), sector: sectorId };
-      detachFromRepetition = true;
-    } else if (!eventPayload.auxiliary) {
+    const detachFromRepetition = !!eventPayload.auxiliary && eventFromDb.type === INTERVENTION && hasConflicts;
+    if (detachFromRepetition || !eventPayload.auxiliary) {
       eventToSet = { ...omit(eventToSet, 'auxiliary'), sector: sectorId };
     }
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -163,7 +163,7 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
     }
 
     const payload = EventsHelper.formatEditionPayload(events[i], eventToSet, detachFromRepetition);
-    promises.push(Event.updateOne({ _id: events[i]._id }, { ...payload }));
+    promises.push(Event.updateOne({ _id: events[i]._id }, payload));
   }
   await Promise.all([
     ...promises,

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -22,7 +22,6 @@ const EventHistoriesHelper = require('./eventHistories');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
-const Utils = require('./utils');
 
 momentRange.extendMoment(moment);
 

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -4,7 +4,7 @@ const Repetition = require('../models/Repetition');
 const EventsHelper = require('./events');
 
 exports.updateRepetitions = async (eventPayload, parentId) => {
-  const repetition = await Repetition.findOne({ parentId });
+  const repetition = await Repetition.findOne({ parentId }).lean();
   if (!repetition) return;
 
   const eventStartDate = moment(eventPayload.startDate);

--- a/src/helpers/repetitions.js
+++ b/src/helpers/repetitions.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const omit = require('lodash/omit');
 const Repetition = require('../models/Repetition');
+const EventsHelper = require('./events');
 
 exports.updateRepetitions = async (eventPayload, parentId) => {
   const repetition = await Repetition.findOne({ parentId });
@@ -15,7 +16,7 @@ exports.updateRepetitions = async (eventPayload, parentId) => {
     .hours(eventEndDate.hours())
     .minutes(eventEndDate.minutes()).toISOString();
 
-  const repetitionPayload = { $set: { ...omit(eventPayload, ['_id']), startDate, endDate } };
-  if (!eventPayload.auxiliary) repetitionPayload.$unset = { auxiliary: '' };
-  await Repetition.findOneAndUpdate({ parentId }, repetitionPayload);
+  const repetitionPayload = { ...omit(eventPayload, ['_id']), startDate, endDate };
+  const payload = EventsHelper.formatEditionPayload(repetition, repetitionPayload, false);
+  await Repetition.findOneAndUpdate({ parentId }, payload);
 };

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -108,6 +108,28 @@ describe('list', () => {
   });
 });
 
+describe('isRepetition', () => {
+  it('should return true if event is repetition with frequency not never', () => {
+    const res = EventHelper.isRepetition({ repetition: { frequency: 'every_week' } });
+    expect(res).toBe(true);
+  });
+
+  it('should return false if event is repetition with frequency never', () => {
+    const res = EventHelper.isRepetition({ repetition: { frequency: 'never' } });
+    expect(res).toBe(false);
+  });
+
+  it('should return false if event is repetition without frequency', () => {
+    const res = EventHelper.isRepetition({ repetition: { id: '123' } });
+    expect(res).toBe(false);
+  });
+
+  it('should return false if event is not a repetition', () => {
+    const res = EventHelper.isRepetition({ repetition: { id: '123' } });
+    expect(res).toBe(false);
+  });
+});
+
 describe('formatEditionPayload', () => {
   it('Case 1: event is detached from repetition', () => {
     const payload = { startDate: '2019-01-10T10:00:00', sector: new ObjectID(), misc: 'lalalal' };

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -301,7 +301,7 @@ describe('updateEvent', () => {
     sinon.assert.notCalled(updateRepetition);
   });
 
-  it('should update event when misc is updates among other fields', async () => {
+  it('should update event when misc is updated among other fields and event is a repetition', async () => {
     const companyId = new ObjectID();
     const credentials = { _id: new ObjectID(), company: { _id: companyId } };
     const eventId = new ObjectID();
@@ -336,7 +336,7 @@ describe('updateEvent', () => {
     sinon.assert.calledOnceWithExactly(formatEditionPayload, event, payload, true);
   });
 
-  it('should update event when misc is updates among other fields and event is not a repetition', async () => {
+  it('should update event when misc is updated among other fields and event is not a repetition', async () => {
     const companyId = new ObjectID();
     const credentials = { _id: new ObjectID(), company: { _id: companyId } };
     const eventId = new ObjectID();

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -37,7 +37,7 @@ describe('updateRepetitions', () => {
 
     expect(result).toBeUndefined();
     SinonMongoose.calledWithExactly(findOneRepetition, [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]);
-    sinon.assert.calledOnceWithExactly(findOneAndUpdateRepetition, { parentId }, { payload: 'payload' })
+    sinon.assert.calledOnceWithExactly(findOneAndUpdateRepetition, { parentId }, { payload: 'payload' });
     sinon.assert.calledOnceWithExactly(
       formatEditionPayloadStub,
       repetition,

--- a/tests/unit/helpers/repetitions.test.js
+++ b/tests/unit/helpers/repetitions.test.js
@@ -1,0 +1,60 @@
+const expect = require('expect');
+const sinon = require('sinon');
+const { ObjectID } = require('mongodb');
+const Repetition = require('../../../src/models/Repetition');
+const EventsHelper = require('../../../src/helpers/events');
+const RepetitionHelper = require('../../../src/helpers/repetitions');
+const SinonMongoose = require('../sinonMongoose');
+
+describe('updateRepetitions', () => {
+  let findOneRepetition;
+  let formatEditionPayloadStub;
+  let RepetitionMock;
+  beforeEach(() => {
+    findOneRepetition = sinon.stub(Repetition, 'findOne');
+    formatEditionPayloadStub = sinon.stub(EventsHelper, 'formatEditionPayload');
+    RepetitionMock = sinon.mock(Repetition);
+  });
+  afterEach(() => {
+    findOneRepetition.restore();
+    formatEditionPayloadStub.restore();
+    RepetitionMock.restore();
+  });
+
+  it('should update a repetition', async () => {
+    const parentId = new ObjectID();
+    const repetition = { startDate: '2021-01-01T09:10:00.000Z', endDate: '2021-01-01T11:10:00.000Z' };
+    const eventPayload = {
+      startDate: '2020-12-01T10:30:00.000Z',
+      endDate: '2021-12-01T11:30:00.000Z',
+      _id: new ObjectID(),
+      test: 's',
+    };
+    findOneRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['lean']));
+    formatEditionPayloadStub.returns({ payload: 'payload' });
+    RepetitionMock.expects('findOneAndUpdate').withExactArgs({ parentId }, { payload: 'payload' });
+
+    const result = await RepetitionHelper.updateRepetitions(eventPayload, parentId);
+
+    expect(result).toBeUndefined();
+    SinonMongoose.calledWithExactly(findOneRepetition, [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]);
+    sinon.assert.calledOnceWithExactly(
+      formatEditionPayloadStub,
+      repetition,
+      { test: 's', startDate: '2021-01-01T10:30:00.000Z', endDate: '2021-01-01T11:30:00.000Z' },
+      false
+    );
+  });
+
+  it('should do nothing if repetition does not exist', async () => {
+    const parentId = new ObjectID();
+    findOneRepetition.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    RepetitionMock.expects('findOneAndUpdate').never();
+
+    const result = await RepetitionHelper.updateRepetitions({}, parentId);
+
+    expect(result).toBeUndefined();
+    SinonMongoose.calledWithExactly(findOneRepetition, [{ query: 'find', args: [{ parentId }] }, { query: 'lean' }]);
+    sinon.assert.notCalled(formatEditionPayloadStub);
+  });
+});


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : client

- Périmetre roles : coach/auxiliaire

- Cas d'usage : 
Verifier que l'edition des evenements/repetitions fonctionne toujours
Essayer de lancer le script des repetitions avec postman pour un jour avec des repetitions qui ne fonctionnaient pas (ex: 15/01/2021), il ne faut pas avoir de repetition dans l'array d'erreurs
Lorsque l'on supprime l'adresse d'une repetition elle est bien supprimee, (et non laisse a {}), si on met a jour l'auxiliaire, le secteur disparait et inversement. 


Ce qui n'est pas fait dans cette pr: 
- mutualisation d'une fonction pour lors de la creation d'un evenement gerer le cas ou l'evenement est en conflit et ou on passe l'evenement en 'a affecter' (mutualisation entre events et eventRepetition)
- maj des tests unitaires de `createEvent` suite au changement de la fonction isRepetition. Comme la prochaine pr touchera a ces tests et qu'il y a plusieurs tests a revoir, j'ai prefere ne pas les mettre a jour dans cette pr. 