### PR TITLE
Com 1831 create

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -53,16 +53,15 @@ exports.list = async (query, credentials) => {
 };
 
 exports.detachAuxiliaryFromEvent = async (event, companyId) => {
-  const payload = { ...event };
-
-  const auxiliary = await User.findOne({ _id: payload.auxiliary })
+  const auxiliary = await User.findOne({ _id: event.auxiliary })
     .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
     .lean({ autopopulate: true, virtuals: true });
-  delete payload.auxiliary;
-  payload.sector = auxiliary.sector;
-  payload.repetition.frequency = NEVER;
 
-  return payload;
+  return {
+    ...omit(event, 'auxiliary'),
+    sector: auxiliary.sector,
+    repetition: { frequency: NEVER },
+  };
 };
 
 exports.createEvent = async (payload, credentials) => {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -60,7 +60,7 @@ exports.detachAuxiliaryFromEvent = async (event, companyId) => {
   return {
     ...omit(event, 'auxiliary'),
     sector: auxiliary.sector,
-    repetition: { frequency: NEVER },
+    repetition: { ...event.repetition, frequency: NEVER },
   };
 };
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -52,45 +52,53 @@ exports.list = async (query, credentials) => {
   return exports.populateEvents(await EventRepository.getEventList(eventsQuery, companyId));
 };
 
+exports.detachAuxiliaryFromEvent = async (event, companyId) => {
+  const payload = { ...event };
+
+  const auxiliary = await User.findOne({ _id: payload.auxiliary })
+    .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
+    .lean({ autopopulate: true, virtuals: true });
+  delete payload.auxiliary;
+  payload.sector = auxiliary.sector;
+  payload.repetition.frequency = NEVER;
+
+  return payload;
+};
+
 exports.createEvent = async (payload, credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  let event = { ...cloneDeep(payload), company: companyId };
-  if (!await EventsValidationHelper.isCreationAllowed(event, credentials)) throw Boom.badData();
+  let eventPayload = { ...cloneDeep(payload), company: companyId };
+  if (!await EventsValidationHelper.isCreationAllowed(eventPayload, credentials)) throw Boom.badData();
 
   await EventHistoriesHelper.createEventHistoryOnCreate(payload, credentials);
 
-  const isRepeatedEvent = exports.isRepetition(event);
-  const hasConflicts = await EventsValidationHelper.hasConflicts(event);
-  if (event.type === INTERVENTION && event.auxiliary && isRepeatedEvent && hasConflicts) {
-    const auxiliary = await User.findOne({ _id: event.auxiliary })
-      .populate({ path: 'sector', select: '_id sector', match: { company: get(credentials, 'company._id', null) } })
-      .lean({ autopopulate: true, virtuals: true });
-    delete event.auxiliary;
-    event.sector = auxiliary.sector;
-    event.repetition.frequency = NEVER;
+  const isRepeatedEvent = exports.isRepetition(eventPayload);
+  const hasConflicts = await EventsValidationHelper.hasConflicts(eventPayload);
+  if (eventPayload.type === INTERVENTION && eventPayload.auxiliary && isRepeatedEvent && hasConflicts) {
+    eventPayload = exports.detachAuxiliaryFromEvent(eventPayload, companyId);
   }
 
-  event = await Event.create(event);
-  event = await EventRepository.getEvent(event._id, credentials);
+  const event = await Event.create(eventPayload);
+  const populatedEvent = await EventRepository.getEvent(event._id, credentials);
   if (payload.type === ABSENCE) {
-    const { startDate, endDate } = event;
+    const { startDate, endDate } = populatedEvent;
     const dates = { startDate, endDate };
-    const auxiliary = await User.findOne({ _id: event.auxiliary })
-      .populate({ path: 'sector', select: '_id sector', match: { company: get(credentials, 'company._id', null) } })
+    const auxiliary = await User.findOne({ _id: populatedEvent.auxiliary })
+      .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
       .lean({ autopopulate: true, virtuals: true });
-    await exports.deleteConflictInternalHoursAndUnavailabilities(event, auxiliary, credentials);
+    await exports.deleteConflictInternalHoursAndUnavailabilities(populatedEvent, auxiliary, credentials);
     await exports.unassignConflictInterventions(dates, auxiliary, credentials);
   }
 
   if (isRepeatedEvent) {
     await EventsRepetitionHelper.createRepetitions(
-      event,
-      { ...payload, company: companyId, repetition: { ...payload.repetition, parentId: event._id } },
+      populatedEvent,
+      { ...payload, company: companyId, repetition: { ...payload.repetition, parentId: populatedEvent._id } },
       credentials
     );
   }
 
-  return exports.populateEventSubscription(event);
+  return exports.populateEventSubscription(populatedEvent);
 };
 
 exports.deleteConflictInternalHoursAndUnavailabilities = async (event, auxiliary, credentials) => {

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -219,5 +219,5 @@ exports.formatEventBasedOnRepetition = async (repetition, date) => {
     newEvent = await EventsHelper.detachAuxiliaryFromEvent(newEvent, repetition.company);
   }
 
-  return new Event(newEvent);
+  return newEvent;
 };

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -205,7 +205,7 @@ exports.formatEventBasedOnRepetition = async (repetition, date) => {
     'address',
     'company',
   ];
-  const newEvent = {
+  let newEvent = {
     ...pick(cloneDeep(repetition), pickedFields),
     startDate: newEventStartDate,
     endDate: newEventEndDate,
@@ -216,12 +216,7 @@ exports.formatEventBasedOnRepetition = async (repetition, date) => {
   if ([INTERNAL_HOUR, UNAVAILABILITY].includes(newEvent.type) && hasConflicts) return null;
 
   if (newEvent.type === INTERVENTION && newEvent.auxiliary && hasConflicts) {
-    delete newEvent.auxiliary;
-    newEvent.repetition.frequency = NEVER;
-    const user = await User.findOne({ _id: repetition.auxiliary })
-      .populate({ path: 'sector', select: '_id sector', match: { company: repetition.company } })
-      .lean({ autopopulate: true, virtuals: true });
-    newEvent.sector = user.sector;
+    newEvent = await EventsHelper.detachAuxiliaryFromEvent(newEvent, repetition.company);
   }
 
   return new Event(newEvent);

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1266,7 +1266,7 @@ describe('createEvent', () => {
     sinon.assert.notCalled(detachAuxiliaryFromEvent);
   });
 
-  it('should detach auxiliary as event is a repeted intervention with conflicts', async () => {
+  it('should detach auxiliary as event is a repeated intervention with conflicts', async () => {
     const newEvent = { type: INTERVENTION, auxiliary: new ObjectID(), repetition: { frequency: 'every_week' } };
     const detachedEvent = { _id: new ObjectID(), type: INTERVENTION, repetition: { frequency: 'never' } };
 


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : client

- Périmetre roles : auxiliaire/coach

- Cas d'usage : mutualisation d'une fonction pour detacher un evenement d'une auxiliaire lors de sa creation en cas de conflit
J'ai aussi renommer `event` dans la methode de creation d'evenement pour avoir des constantes plus claires. 
