### PR TITLE
Com 1784

### DIFF
--- a/tests/unit/helpers/internalHours.test.js
+++ b/tests/unit/helpers/internalHours.test.js
@@ -3,8 +3,7 @@ const expect = require('expect');
 const sinon = require('sinon');
 const InternalHour = require('../../../src/models/InternalHour');
 const InternalHoursHelper = require('../../../src/helpers/internalHours');
-
-require('sinon-mongoose');
+const SinonMongoose = require('../sinonMongoose');
 
 describe('create', () => {
   let createStub;
@@ -27,27 +26,27 @@ describe('create', () => {
 });
 
 describe('list', () => {
-  let InternalHourMock;
+  let find;
   beforeEach(() => {
-    InternalHourMock = sinon.mock(InternalHour);
+    find = sinon.stub(InternalHour, 'find');
   });
   afterEach(() => {
-    InternalHourMock.restore();
+    find.restore();
   });
 
   it('should return an array of every internal hour of user company', async () => {
     const credentials = { company: { _id: new ObjectID() } };
     const internalHours = [{ _id: new ObjectID(), name: 'skusku' }];
 
-    InternalHourMock.expects('find')
-      .withExactArgs({ company: credentials.company._id })
-      .chain('lean')
-      .returns(internalHours);
+    find.returns(SinonMongoose.stubChainedQueries([internalHours], ['lean']));
 
     const result = await InternalHoursHelper.list(credentials);
 
     expect(result).toEqual(internalHours);
-    InternalHourMock.verify();
+    SinonMongoose.calledWithExactly(
+      find,
+      [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
+    );
   });
 });
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -8,8 +8,6 @@ const ProgramHelper = require('../../../src/helpers/programs');
 const GCloudStorageHelper = require('../../../src/helpers/gCloudStorage');
 const SinonMongoose = require('../sinonMongoose');
 
-require('sinon-mongoose');
-
 describe('createProgram', () => {
   let create;
   beforeEach(() => {
@@ -185,36 +183,23 @@ describe('getProgram', () => {
 });
 
 describe('update', () => {
-  let ProgramMock;
+  let programUpdateOne;
   beforeEach(() => {
-    ProgramMock = sinon.mock(Program);
+    programUpdateOne = sinon.stub(Program, 'updateOne');
   });
   afterEach(() => {
-    ProgramMock.restore();
+    programUpdateOne.restore();
   });
 
   it('should update name', async () => {
     const programId = new ObjectID();
     const payload = { name: 'toto' };
 
-    ProgramMock.expects('updateOne')
-      .withExactArgs({ _id: programId }, { $set: payload })
-      .returns({ _id: programId, name: 'toto' });
+    programUpdateOne.returns({ _id: programId, name: 'toto' });
 
-    const result = await ProgramHelper.updateProgram(programId, payload);
-    expect(result).toMatchObject({ _id: programId, name: 'toto' });
-  });
+    await ProgramHelper.updateProgram(programId, payload);
 
-  it('should update image', async () => {
-    const programId = new ObjectID();
-    const payload = { image: { publicId: new ObjectID(), link: new ObjectID() } };
-
-    ProgramMock.expects('updateOne')
-      .withExactArgs({ _id: programId }, { $set: payload })
-      .returns({ _id: programId, ...payload });
-
-    const result = await ProgramHelper.updateProgram(programId, payload);
-    expect(result).toMatchObject({ _id: programId, ...payload });
+    programUpdateOne.calledOnceWithExactly({ _id: programId }, { $set: payload });
   });
 });
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -6,6 +6,7 @@ const Program = require('../../../src/models/Program');
 const Course = require('../../../src/models/Course');
 const ProgramHelper = require('../../../src/helpers/programs');
 const GCloudStorageHelper = require('../../../src/helpers/gCloudStorage');
+const SinonMongoose = require('../sinonMongoose');
 
 require('sinon-mongoose');
 
@@ -27,27 +28,29 @@ describe('createProgram', () => {
 });
 
 describe('list', () => {
-  let ProgramMock;
+  let find;
   beforeEach(() => {
-    ProgramMock = sinon.mock(Program);
+    find = sinon.stub(Program, 'find');
   });
   afterEach(() => {
-    ProgramMock.restore();
+    find.restore();
   });
 
   it('should return programs', async () => {
     const programsList = [{ name: 'name' }, { name: 'program' }];
 
-    ProgramMock.expects('find')
-      .withExactArgs({})
-      .chain('populate')
-      .withExactArgs({ path: 'subPrograms', select: 'name' })
-      .chain('lean')
-      .once()
-      .returns(programsList);
+    find.returns(SinonMongoose.stubChainedQueries([programsList]));
 
     const result = await ProgramHelper.list();
     expect(result).toMatchObject(programsList);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{}] },
+        { query: 'populate', args: [{ path: 'subPrograms', select: 'name' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -74,7 +74,7 @@ describe('listELearning', () => {
     programFind.returns(SinonMongoose.stubChainedQueries([programsList]));
 
     const result = await ProgramHelper.listELearning(credentials);
-    expect(result).toMatchObject(programsList);
+    expect(result).toMatchObject([{ name: 'name' }, { name: 'program' }]);
 
     SinonMongoose.calledWithExactly(
       courseFind,


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration - np

- Périmetre interface : np

- Périmetre roles : np

- Cas d'usage : sinon mongoose pour les test unitaires programmes et heures internes
