### PR TITLE
Com 1754

### DIFF
--- a/src/controllers/courseController.js
+++ b/src/controllers/courseController.js
@@ -62,7 +62,7 @@ const getById = async (req) => {
 
 const getFollowUp = async (req) => {
   try {
-    const followUp = await CoursesHelper.getCourseFollowUp(req.pre.course);
+    const followUp = await CoursesHelper.getCourseFollowUp(req.pre.course, req.query.company);
 
     return {
       message: translate[language].courseFound,

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -166,8 +166,9 @@ exports.formatActivity = (activity) => {
 
 exports.formatStep = step => ({ ...step, activities: step.activities.map(a => exports.formatActivity(a)) });
 
-exports.getCourseFollowUp = async (course) => {
+exports.getCourseFollowUp = async (course, company) => {
   const courseWithTrainees = await Course.findOne({ _id: course._id }).select('trainees').lean();
+  const traineeCompanyMatch = company ? { company } : {};
 
   const courseFollowUp = await Course.findOne({ _id: course._id })
     .select('subProgram')
@@ -191,7 +192,7 @@ exports.getCourseFollowUp = async (course) => {
         },
       ],
     })
-    .populate({ path: 'trainees', select: 'identity.firstname identity.lastname' })
+    .populate({ path: 'trainees', select: 'identity.firstname identity.lastname', match: traineeCompanyMatch })
     .populate({ path: 'slots', populate: { path: 'step', select: '_id' } })
     .lean();
 

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -109,6 +109,7 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
+          query: Joi.object({ company: Joi.objectId() }),
         },
         auth: { scope: ['courses:read'] },
         pre: [{ method: getCourse, assign: 'course' }, { method: authorizeGetCourse }],

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -37,6 +37,7 @@ const {
   authorizeAccessRuleDeletion,
   authorizeAndGetTrainee,
   authorizeGetCourse,
+  authorizeGetFollowUp,
 } = require('./preHandlers/courses');
 const { INTRA } = require('../helpers/constants');
 
@@ -112,7 +113,11 @@ exports.plugin = {
           query: Joi.object({ company: Joi.objectId() }),
         },
         auth: { scope: ['courses:read'] },
-        pre: [{ method: getCourse, assign: 'course' }, { method: authorizeGetCourse }],
+        pre: [
+          { method: getCourse, assign: 'course' },
+          { method: authorizeGetCourse },
+          { method: authorizeGetFollowUp },
+        ],
       },
       handler: getFollowUp,
     });

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -243,10 +243,10 @@ exports.authorizeAccessRuleDeletion = async (req) => {
 exports.authorizeGetFollowUp = async (req) => {
   const credentials = get(req, 'auth.credentials');
   const loggedUserVendorRole = get(credentials, 'role.vendor.name');
+  const companyQueryIsValid = !!req.query.company &&
+    UtilsHelper.areObjectIdsEquals(get(credentials, 'company._id'), req.query.company);
 
-  if (!loggedUserVendorRole && !UtilsHelper.areObjectIdsEquals(get(credentials, 'company._id'), req.query.company)) {
-    throw Boom.forbidden();
-  }
+  if (!loggedUserVendorRole && !companyQueryIsValid) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -239,3 +239,14 @@ exports.authorizeAccessRuleDeletion = async (req) => {
 
   return null;
 };
+
+exports.authorizeGetFollowUp = async (req) => {
+  const credentials = get(req, 'auth.credentials');
+  const loggedUserVendorRole = get(credentials, 'role.vendor.name');
+
+  if (!loggedUserVendorRole && !UtilsHelper.areObjectIdsEquals(get(credentials, 'company._id'), req.query.company)) {
+    throw Boom.forbidden();
+  }
+
+  return null;
+};

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -512,9 +512,9 @@ describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
     });
   });
 
-  describe('CLIENT_ADMIN', () => {
+  describe('COACH', () => {
     beforeEach(async () => {
-      authToken = await getToken('client_admin');
+      authToken = await getToken('coach');
     });
 
     it('should get course with follow up', async () => {
@@ -539,12 +539,21 @@ describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
   });
 
   describe('Other roles', () => {
+    it('should return 403 if user has no company and query has no company', async () => {
+      authToken = await getToken('auxiliary_without_company');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/courses/${coursesList[0]._id.toHexString()}/follow-up`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 200 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 200 },
     ];
     roles.forEach((role) => {

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -512,13 +512,38 @@ describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
     });
   });
 
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should get course with follow up', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/courses/${coursesList[0]._id.toHexString()}/follow-up?company=${authCompany._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 403 if user company is not query company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/courses/${coursesList[0]._id.toHexString()}/follow-up?company=${otherCompany._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
   describe('Other roles', () => {
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'auxiliary', expectedCode: 403 },
       { name: 'auxiliary_without_company', expectedCode: 403 },
       { name: 'coach', expectedCode: 200 },
-      { name: 'client_admin', expectedCode: 200 },
       { name: 'training_organisation_manager', expectedCode: 200 },
       { name: 'trainer', expectedCode: 200 },
     ];
@@ -528,7 +553,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/follow-up', () => {
 
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/${coursesList[0]._id.toHexString()}/follow-up`,
+          url: `/courses/${coursesList[0]._id.toHexString()}/follow-up?company=${authCompany._id.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -601,16 +601,16 @@ describe('formatStep', () => {
 });
 
 describe('getCourseFollowUp', () => {
-  let CourseMock;
+  let findOne;
   let formatStep;
   let getTraineeProgress;
   beforeEach(() => {
-    CourseMock = sinon.mock(Course);
+    findOne = sinon.stub(Course, 'findOne');
     formatStep = sinon.stub(CourseHelper, 'formatStep');
     getTraineeProgress = sinon.stub(CourseHelper, 'getTraineeProgress');
   });
   afterEach(() => {
-    CourseMock.restore();
+    findOne.restore();
     formatStep.restore();
     getTraineeProgress.restore();
   });
@@ -624,51 +624,50 @@ describe('getCourseFollowUp', () => {
     };
     const trainees = [1, 2, 3, 4, 5];
 
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: course._id })
-      .chain('select')
-      .withExactArgs('trainees')
-      .chain('lean')
-      .returns({ trainees });
-
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: course._id })
-      .chain('select')
-      .withExactArgs('subProgram')
-      .chain('populate')
-      .withExactArgs({
-        path: 'subProgram',
-        select: 'name steps program',
-        populate: [
-          { path: 'program', select: 'name' },
-          {
-            path: 'steps',
-            select: 'name activities type',
-            populate: {
-              path: 'activities',
-              select: 'name type',
-              populate: {
-                path: 'activityHistories',
-                match: { user: { $in: trainees } },
-                populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-              },
-            },
-          },
-        ],
-      })
-      .chain('populate')
-      .withExactArgs({ path: 'trainees', select: 'identity.firstname identity.lastname', match: {} })
-      .chain('populate')
-      .withExactArgs({ path: 'slots', populate: { path: 'step', select: '_id' } })
-      .chain('lean')
-      .returns(course);
+    findOne.returns(SinonMongoose.stubChainedQueries([{ trainees }, course], ['select', 'populate', 'lean']));
 
     formatStep.callsFake(s => s);
     getTraineeProgress.returns({ steps: { progress: 1 }, progress: 1 });
     const result = await CourseHelper.getCourseFollowUp(course);
 
     expect(result).toEqual(course);
-    CourseMock.verify();
+
+    SinonMongoose.calledWithExactly(findOne, [
+      { query: 'findOne', args: [{ _id: course._id }] },
+      { query: 'select', args: ['trainees'] },
+      { query: 'lean' },
+    ], 0);
+
+    SinonMongoose.calledWithExactly(findOne, [
+      { query: 'findOne', args: [{ _id: course._id }] },
+      { query: 'select', args: ['subProgram'] },
+      {
+        query: 'populate',
+        args: [{
+          path: 'subProgram',
+          select: 'name steps program',
+          populate: [
+            { path: 'program', select: 'name' },
+            {
+              path: 'steps',
+              select: 'name activities type',
+              populate: {
+                path: 'activities',
+                select: 'name type',
+                populate: {
+                  path: 'activityHistories',
+                  match: { user: { $in: trainees } },
+                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+                },
+              },
+            },
+          ],
+        }],
+      },
+      { query: 'populate', args: [{ path: 'trainees', select: 'identity.firstname identity.lastname', match: {} }] },
+      { query: 'populate', args: [{ path: 'slots', populate: { path: 'step', select: '_id' } }] },
+      { query: 'lean' },
+    ], 1);
   });
 
   it('should return course follow up with trainees from company', async () => {
@@ -681,55 +680,53 @@ describe('getCourseFollowUp', () => {
     const trainees = [1, 2, 3, 4, 5];
     const companyId = new ObjectID();
 
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: course._id })
-      .chain('select')
-      .withExactArgs('trainees')
-      .chain('lean')
-      .returns({ trainees });
-
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: course._id })
-      .chain('select')
-      .withExactArgs('subProgram')
-      .chain('populate')
-      .withExactArgs({
-        path: 'subProgram',
-        select: 'name steps program',
-        populate: [
-          { path: 'program', select: 'name' },
-          {
-            path: 'steps',
-            select: 'name activities type',
-            populate: {
-              path: 'activities',
-              select: 'name type',
-              populate: {
-                path: 'activityHistories',
-                match: { user: { $in: trainees } },
-                populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-              },
-            },
-          },
-        ],
-      })
-      .chain('populate')
-      .withExactArgs({
-        path: 'trainees',
-        select: 'identity.firstname identity.lastname',
-        match: { company: companyId },
-      })
-      .chain('populate')
-      .withExactArgs({ path: 'slots', populate: { path: 'step', select: '_id' } })
-      .chain('lean')
-      .returns(course);
+    findOne.returns(SinonMongoose.stubChainedQueries([{ trainees }, course], ['select', 'populate', 'lean']));
 
     formatStep.callsFake(s => s);
     getTraineeProgress.returns({ steps: { progress: 1 }, progress: 1 });
     const result = await CourseHelper.getCourseFollowUp(course, companyId);
 
     expect(result).toEqual(course);
-    CourseMock.verify();
+
+    SinonMongoose.calledWithExactly(findOne, [
+      { query: 'findOne', args: [{ _id: course._id }] },
+      { query: 'select', args: ['trainees'] },
+      { query: 'lean' },
+    ], 0);
+
+    SinonMongoose.calledWithExactly(findOne, [
+      { query: 'findOne', args: [{ _id: course._id }] },
+      { query: 'select', args: ['subProgram'] },
+      {
+        query: 'populate',
+        args: [{
+          path: 'subProgram',
+          select: 'name steps program',
+          populate: [
+            { path: 'program', select: 'name' },
+            {
+              path: 'steps',
+              select: 'name activities type',
+              populate: {
+                path: 'activities',
+                select: 'name type',
+                populate: {
+                  path: 'activityHistories',
+                  match: { user: { $in: trainees } },
+                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+                },
+              },
+            },
+          ],
+        }],
+      },
+      {
+        query: 'populate',
+        args: [{ path: 'trainees', select: 'identity.firstname identity.lastname', match: { company: companyId } }],
+      },
+      { query: 'populate', args: [{ path: 'slots', populate: { path: 'step', select: '_id' } }] },
+      { query: 'lean' },
+    ], 1);
   });
 });
 


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [x] Mon code est testé avec des tests d'intégration

- Périmetre interface : client

- Périmetre roles : coach / admin

- Cas d'usage :
Dans la page profile d'un apprenant, côté client, je peux maintenant cliquer sur une formation pour avoir accès à sa page profil, qui contient la liste des apprenants de cette formation. Je ne peux voir que les apprenants de mon entreprise.
