### PR TITLE
Com 1854

### DIFF
--- a/tests/unit/helpers/surcharges.test.js
+++ b/tests/unit/helpers/surcharges.test.js
@@ -14,6 +14,7 @@ describe('list', () => {
   afterEach(() => {
     find.restore();
   });
+
   it('should return a list of every surcharges from company', async () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
@@ -21,10 +22,10 @@ describe('list', () => {
     find.returns(SinonMongoose.stubChainedQueries([[{ company: companyId, name: 'Coucou' }]], ['lean']));
 
     const result = await SurchargesHelper.list(credentials);
-    expect(result).toMatchObject([{ company: companyId, name: 'Coucou' }]);
+    expect(result).toEqual([{ company: companyId, name: 'Coucou' }]);
 
     SinonMongoose.calledWithExactly(find, [
-      { query: 'findOne', args: [{ company: companyId }] },
+      { query: 'find', args: [{ company: companyId }] },
       { query: 'lean' },
     ]);
   });

--- a/tests/unit/helpers/surcharges.test.js
+++ b/tests/unit/helpers/surcharges.test.js
@@ -4,30 +4,29 @@ const moment = require('moment');
 const { ObjectID } = require('mongodb');
 const Surcharge = require('../../../src/models/Surcharge');
 const SurchargesHelper = require('../../../src/helpers/surcharges');
-require('sinon-mongoose');
+const SinonMongoose = require('../sinonMongoose');
 
 describe('list', () => {
-  let SurchargeMock;
+  let find;
   beforeEach(() => {
-    SurchargeMock = sinon.mock(Surcharge);
+    find = sinon.stub(Surcharge, 'find');
   });
   afterEach(() => {
-    SurchargeMock.restore();
+    find.restore();
   });
   it('should return a list of every surcharges from company', async () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
 
-    SurchargeMock.expects('find')
-      .withExactArgs({ company: companyId })
-      .chain('lean')
-      .once()
-      .returns([{ company: companyId, name: 'Coucou' }]);
+    find.returns(SinonMongoose.stubChainedQueries([[{ company: companyId, name: 'Coucou' }]], ['lean']));
 
     const result = await SurchargesHelper.list(credentials);
+    expect(result).toMatchObject([{ company: companyId, name: 'Coucou' }]);
 
-    SurchargeMock.verify();
-    expect(result).toEqual([{ company: companyId, name: 'Coucou' }]);
+    SinonMongoose.calledWithExactly(find, [
+      { query: 'findOne', args: [{ company: companyId }] },
+      { query: 'lean' },
+    ]);
   });
 });
 


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : -np

- Périmetre roles : -np

- Cas d'usage : migration des test sinon-mongoose
surcharges : list
users : 
  - formatQueryForUsersList
  - getUsersList
  - getUsersListWithSectorHistories
  - getUser
  - userExists
  - removeHelper
  - updateUser
  - createDriveFolder