### PR TITLE
Com 1853

### DIFF
--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -14,35 +14,32 @@ const {
   ORDER_THE_SEQUENCE,
   TRANSITION,
 } = require('../../../src/helpers/constants');
-require('sinon-mongoose');
 
 describe('addCard', () => {
-  let CardMock;
-  let ActivityMock;
+  let cardCreate;
+  let activityUpdateOne;
   const activity = { _id: new ObjectID(), name: 'faire du jetski' };
   const newCard = { template: 'transition' };
 
   beforeEach(() => {
-    CardMock = sinon.mock(Card);
-    ActivityMock = sinon.mock(Activity);
+    cardCreate = sinon.stub(Card, 'create');
+    activityUpdateOne = sinon.stub(Activity, 'updateOne');
   });
 
   afterEach(() => {
-    CardMock.restore();
-    ActivityMock.restore();
+    cardCreate.restore();
+    activityUpdateOne.restore();
   });
 
   it('should create an transition card', async () => {
     const cardId = new ObjectID();
 
-    CardMock.expects('create').withExactArgs(newCard).returns({ _id: cardId });
-
-    ActivityMock.expects('updateOne').withExactArgs({ _id: activity._id }, { $push: { cards: cardId } });
+    cardCreate.returns({ _id: cardId });
 
     await CardHelper.addCard(activity._id, newCard);
 
-    CardMock.verify();
-    ActivityMock.verify();
+    sinon.assert.calledWithExactly(cardCreate, newCard);
+    sinon.assert.calledWith(activityUpdateOne, { _id: activity._id }, { $push: { cards: cardId } });
   });
 });
 

--- a/tests/unit/helpers/cards.test.js
+++ b/tests/unit/helpers/cards.test.js
@@ -39,7 +39,7 @@ describe('addCard', () => {
     await CardHelper.addCard(activity._id, newCard);
 
     sinon.assert.calledWithExactly(cardCreate, newCard);
-    sinon.assert.calledWith(activityUpdateOne, { _id: activity._id }, { $push: { cards: cardId } });
+    sinon.assert.calledWithExactly(activityUpdateOne, { _id: activity._id }, { $push: { cards: cardId } });
   });
 });
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -51,28 +51,23 @@ describe('createCourse', () => {
 
 describe('list', () => {
   let findCourseAndPopulate;
-  let CourseMock;
   const authCompany = new ObjectID();
 
   beforeEach(() => {
     findCourseAndPopulate = sinon.stub(CourseRepository, 'findCourseAndPopulate');
-    CourseMock = sinon.mock(Course);
   });
   afterEach(() => {
     findCourseAndPopulate.restore();
-    CourseMock.restore();
   });
 
   it('should return courses', async () => {
     const coursesList = [{ misc: 'name' }, { misc: 'program' }];
 
     findCourseAndPopulate.returns(coursesList);
-    CourseMock.expects('findOne').never();
 
     const result = await CourseHelper.list({ trainer: '1234567890abcdef12345678', format: 'blended' });
     expect(result).toMatchObject(coursesList);
     sinon.assert.calledWithExactly(findCourseAndPopulate, { trainer: '1234567890abcdef12345678', format: 'blended' });
-    CourseMock.verify();
   });
 
   it('should return company courses', async () => {
@@ -102,8 +97,6 @@ describe('list', () => {
       .onSecondCall()
       .returns([returnedList[1]]);
 
-    CourseMock.expects('findOne').never();
-
     const result = await CourseHelper.list({
       company: authCompany.toHexString(),
       trainer: '1234567890abcdef12345678',
@@ -119,7 +112,6 @@ describe('list', () => {
       { trainer: '1234567890abcdef12345678', type: 'inter_b2b', format: 'blended' },
       true
     );
-    CourseMock.verify();
   });
 
   it('should return company eLearning courses', async () => {

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -10,7 +10,6 @@ const moment = require('moment');
 const Course = require('../../../src/models/Course');
 const Activity = require('../../../src/models/Activity');
 const CourseSmsHistory = require('../../../src/models/CourseSmsHistory');
-const Role = require('../../../src/models/Role');
 const Drive = require('../../../src/models/Google/Drive');
 const CourseHelper = require('../../../src/helpers/courses');
 const SmsHelper = require('../../../src/helpers/sms');
@@ -1485,18 +1484,18 @@ describe('formatInterCourseForPdf', () => {
 });
 
 describe('generateAttendanceSheets', () => {
-  let CourseMock;
+  let courseFindOne;
   let formatInterCourseForPdf;
   let formatIntraCourseForPdf;
   let generatePdf;
   beforeEach(() => {
-    CourseMock = sinon.mock(Course);
+    courseFindOne = sinon.stub(Course, 'findOne');
     formatInterCourseForPdf = sinon.stub(CourseHelper, 'formatInterCourseForPdf');
     formatIntraCourseForPdf = sinon.stub(CourseHelper, 'formatIntraCourseForPdf');
     generatePdf = sinon.stub(PdfHelper, 'generatePdf');
   });
   afterEach(() => {
-    CourseMock.restore();
+    courseFindOne.restore();
     formatInterCourseForPdf.restore();
     formatIntraCourseForPdf.restore();
     generatePdf.restore();
@@ -1505,26 +1504,26 @@ describe('generateAttendanceSheets', () => {
   it('should download attendance sheet for inter b2b course', async () => {
     const courseId = new ObjectID();
     const course = { misc: 'des infos en plus', type: 'inter_b2b' };
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: courseId })
-      .chain('populate')
-      .withExactArgs('company')
-      .chain('populate')
-      .withExactArgs('slots')
-      .chain('populate')
-      .withExactArgs({ path: 'trainees', populate: { path: 'company', select: 'name' } })
-      .chain('populate')
-      .withExactArgs('trainer')
-      .chain('populate')
-      .withExactArgs({ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } })
-      .chain('lean')
-      .once()
-      .returns(course);
+
+    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
+
     formatInterCourseForPdf.returns({ name: 'la formation - des infos en plus' });
     generatePdf.returns('pdf');
 
     await CourseHelper.generateAttendanceSheets(courseId);
 
+    SinonMongoose.calledWithExactly(courseFindOne, [
+      { query: 'findOne', args: [{ _id: courseId }] },
+      { query: 'populate', args: ['company'] },
+      { query: 'populate', args: ['slots'] },
+      { query: 'populate', args: [{ path: 'trainees', populate: { path: 'company', select: 'name' } }] },
+      { query: 'populate', args: ['trainer'] },
+      {
+        query: 'populate',
+        args: [{ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } }],
+      },
+      { query: 'lean' },
+    ]);
     sinon.assert.calledOnceWithExactly(formatInterCourseForPdf, course);
     sinon.assert.notCalled(formatIntraCourseForPdf);
     sinon.assert.calledOnceWithExactly(
@@ -1537,26 +1536,26 @@ describe('generateAttendanceSheets', () => {
   it('should download attendance sheet for intra course', async () => {
     const courseId = new ObjectID();
     const course = { misc: 'des infos en plus', type: 'intra' };
-    CourseMock.expects('findOne')
-      .withExactArgs({ _id: courseId })
-      .chain('populate')
-      .withExactArgs('company')
-      .chain('populate')
-      .withExactArgs('slots')
-      .chain('populate')
-      .withExactArgs({ path: 'trainees', populate: { path: 'company', select: 'name' } })
-      .chain('populate')
-      .withExactArgs('trainer')
-      .chain('populate')
-      .withExactArgs({ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } })
-      .chain('lean')
-      .once()
-      .returns(course);
+
+    courseFindOne.returns(SinonMongoose.stubChainedQueries([course]));
+
     formatIntraCourseForPdf.returns({ name: 'la formation - des infos en plus' });
     generatePdf.returns('pdf');
 
     await CourseHelper.generateAttendanceSheets(courseId);
 
+    SinonMongoose.calledWithExactly(courseFindOne, [
+      { query: 'findOne', args: [{ _id: courseId }] },
+      { query: 'populate', args: ['company'] },
+      { query: 'populate', args: ['slots'] },
+      { query: 'populate', args: [{ path: 'trainees', populate: { path: 'company', select: 'name' } }] },
+      { query: 'populate', args: ['trainer'] },
+      {
+        query: 'populate',
+        args: [{ path: 'subProgram', select: 'program', populate: { path: 'program', select: 'name' } }],
+      },
+      { query: 'lean' },
+    ]);
     sinon.assert.calledOnceWithExactly(formatIntraCourseForPdf, course);
     sinon.assert.notCalled(formatInterCourseForPdf);
     sinon.assert.calledOnceWithExactly(

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -25,8 +25,6 @@ const CourseHistoriesHelper = require('../../../src/helpers/courseHistories');
 const { E_LEARNING, ON_SITE, WEBAPP } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 
-require('sinon-mongoose');
-
 describe('createCourse', () => {
   let save;
   beforeEach(() => {

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -341,11 +341,7 @@ describe('listUserCourses', () => {
     SinonMongoose.calledWithExactly(courseFind, [
       {
         query: 'find',
-        args: [{
-          trainees: trainee._id,
-          $or: [{ accessRules: [] }, { accessRules: trainee.company }],
-        },
-        { format: 1 }],
+        args: [{ trainees: trainee._id, $or: [{ accessRules: [] }, { accessRules: trainee.company }] }, { format: 1 }],
       },
       {
         query: 'populate',
@@ -967,24 +963,27 @@ describe('getTraineeCourse', () => {
 });
 
 describe('updateCourse', () => {
-  let CourseMock;
+  let courseFindOneAndUpdate;
   beforeEach(() => {
-    CourseMock = sinon.mock(Course, 'CourseMock');
+    courseFindOneAndUpdate = sinon.stub(Course, 'findOneAndUpdate');
   });
   afterEach(() => {
-    CourseMock.restore();
+    courseFindOneAndUpdate.restore();
   });
 
   it('should update an intra course', async () => {
     const courseId = new ObjectID();
     const payload = { misc: 'groupe 4' };
-    CourseMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: courseId }, { $set: payload })
-      .chain('lean')
-      .returns(payload);
+
+    courseFindOneAndUpdate.returns(SinonMongoose.stubChainedQueries([payload], ['lean']));
 
     const result = await CourseHelper.updateCourse(courseId, payload);
     expect(result.misc).toEqual(payload.misc);
+
+    SinonMongoose.calledWithExactly(courseFindOneAndUpdate, [
+      { query: 'findOneAndUpdate', args: [{ _id: courseId }, { $set: payload }] },
+      { query: 'lean' },
+    ]);
   });
 });
 


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- [ ] Mon code est testé avec des tests d'intégration -np

- Périmetre interface : -np

- Périmetre roles : -np

- Cas d'usage : migration des test sinon-mongoose

cards 
- addCard

courses

- list

- listUserCourses

- updateCourse

- sendSMS

- getSMSHistory

- addCourseTrainee

- generateAttendanceSheets

- generateCompletionCertificate

- generateConvocationPdf


