### PR TITLE
COM-1878 - Allow duplicate name for team of different structure

### DIFF
--- a/src/helpers/sectors.js
+++ b/src/helpers/sectors.js
@@ -8,10 +8,11 @@ const { language } = translate;
 exports.list = async credentials => Sector.find({ company: get(credentials, 'company._id') }).lean();
 
 exports.create = async (payload, credentials) => {
-  const existingSector = await Sector.countDocuments({ name: payload.name });
+  const company = get(credentials, 'company._id');
+  const existingSector = await Sector.countDocuments({ name: payload.name, company });
   if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
 
-  const sector = await Sector.create({ ...payload, company: get(credentials, 'company._id') });
+  const sector = await Sector.create({ ...payload, company });
 
   return sector.toObject();
 };

--- a/src/helpers/sectors.js
+++ b/src/helpers/sectors.js
@@ -7,8 +7,11 @@ const { language } = translate;
 
 exports.list = async credentials => Sector.find({ company: get(credentials, 'company._id') }).lean();
 
-exports.create = async (payload, credentials) => Sector.create({ ...payload, company: get(credentials, 'company._id') })
-  .toObject();
+exports.create = async (payload, credentials) => {
+  const sector = await Sector.create({ ...payload, company: get(credentials, 'company._id') });
+
+  return sector.toObject();
+};
 
 exports.update = async (sectorId, payload, credentials) => {
   const existingSector = await Sector.countDocuments({ name: payload.name, company: get(credentials, 'company._id') });

--- a/src/helpers/sectors.js
+++ b/src/helpers/sectors.js
@@ -7,15 +7,8 @@ const { language } = translate;
 
 exports.list = async credentials => Sector.find({ company: get(credentials, 'company._id') }).lean();
 
-exports.create = async (payload, credentials) => {
-  const company = get(credentials, 'company._id');
-  const existingSector = await Sector.countDocuments({ name: payload.name, company });
-  if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
-
-  const sector = await Sector.create({ ...payload, company });
-
-  return sector.toObject();
-};
+exports.create = async (payload, credentials) => Sector.create({ ...payload, company: get(credentials, 'company._id') })
+  .toObject();
 
 exports.update = async (sectorId, payload, credentials) => {
   const existingSector = await Sector.countDocuments({ name: payload.name, company: get(credentials, 'company._id') });

--- a/src/helpers/sectors.js
+++ b/src/helpers/sectors.js
@@ -1,9 +1,5 @@
 const get = require('lodash/get');
-const Boom = require('@hapi/boom');
 const Sector = require('../models/Sector');
-const translate = require('./translate');
-
-const { language } = translate;
 
 exports.list = async credentials => Sector.find({ company: get(credentials, 'company._id') }).lean();
 
@@ -13,11 +9,8 @@ exports.create = async (payload, credentials) => {
   return sector.toObject();
 };
 
-exports.update = async (sectorId, payload, credentials) => {
-  const existingSector = await Sector.countDocuments({ name: payload.name, company: get(credentials, 'company._id') });
-  if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
-
-  return Sector.findOneAndUpdate({ _id: sectorId }, { $set: payload }, { new: true }).lean();
-};
+exports.update = async (sectorId, payload) => Sector
+  .findOneAndUpdate({ _id: sectorId }, { $set: payload }, { new: true })
+  .lean();
 
 exports.remove = async sectorId => Sector.deleteOne({ _id: sectorId });

--- a/src/routes/preHandlers/sectors.js
+++ b/src/routes/preHandlers/sectors.js
@@ -3,6 +3,7 @@ const Boom = require('@hapi/boom');
 const Sector = require('../../models/Sector');
 const SectorHistory = require('../../models/SectorHistory');
 const translate = require('../../helpers/translate');
+const { areObjectIdsEquals } = require('../../helpers/utils');
 
 const { language } = translate;
 
@@ -33,7 +34,7 @@ exports.authorizeSectorCreation = async (req) => {
 exports.authorizeSectorUpdate = async (req) => {
   const { credentials } = req.auth;
   const sector = req.pre.sector || req.payload;
-  if (sector.company.toHexString() !== credentials.company._id.toHexString()) throw Boom.forbidden();
+  if (!areObjectIdsEquals(sector.company, credentials.company._id)) throw Boom.forbidden();
 
   const existingSector = await Sector.countDocuments({ name: req.payload.name, company: sector.company });
   if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
@@ -44,7 +45,7 @@ exports.authorizeSectorUpdate = async (req) => {
 exports.authorizeSectorDeletion = async (req) => {
   const { credentials } = req.auth;
   const { sector } = req.pre;
-  if (sector.company.toHexString() !== credentials.company._id.toHexString()) throw Boom.forbidden();
+  if (!areObjectIdsEquals(sector.company, credentials.company._id)) throw Boom.forbidden();
 
   const historiesCount = await SectorHistory.countDocuments({ sector: sector._id });
   if (historiesCount) throw Boom.forbidden();

--- a/src/routes/preHandlers/sectors.js
+++ b/src/routes/preHandlers/sectors.js
@@ -30,10 +30,13 @@ exports.authorizeSectorCreation = async (req) => {
   return null;
 };
 
-exports.authorizeSectorUpdate = (req) => {
+exports.authorizeSectorUpdate = async (req) => {
   const { credentials } = req.auth;
   const sector = req.pre.sector || req.payload;
   if (sector.company.toHexString() !== credentials.company._id.toHexString()) throw Boom.forbidden();
+
+  const existingSector = await Sector.countDocuments({ name: req.payload.name, company: sector.company });
+  if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
 
   return null;
 };

--- a/src/routes/preHandlers/sectors.js
+++ b/src/routes/preHandlers/sectors.js
@@ -1,3 +1,4 @@
+const get = require('lodash/get');
 const Boom = require('@hapi/boom');
 const Sector = require('../../models/Sector');
 const SectorHistory = require('../../models/SectorHistory');
@@ -16,6 +17,17 @@ exports.getSector = async (req) => {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
   }
+};
+
+exports.authorizeSectorCreation = async (req) => {
+  const { credentials } = req.auth;
+  const existingSector = await Sector.countDocuments({
+    name: req.payload.name,
+    company: get(credentials, 'company._id'),
+  });
+  if (existingSector) throw Boom.conflict(translate[language].sectorAlreadyExists);
+
+  return null;
 };
 
 exports.authorizeSectorUpdate = (req) => {

--- a/src/routes/sectors.js
+++ b/src/routes/sectors.js
@@ -2,7 +2,12 @@
 
 const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
-const { authorizeSectorUpdate, authorizeSectorDeletion, getSector } = require('./preHandlers/sectors');
+const {
+  authorizeSectorUpdate,
+  authorizeSectorDeletion,
+  getSector,
+  authorizeSectorCreation,
+} = require('./preHandlers/sectors');
 const {
   create,
   update,
@@ -21,6 +26,7 @@ exports.plugin = {
         validate: {
           payload: Joi.object().keys({ name: Joi.string().required() }),
         },
+        pre: [{ method: authorizeSectorCreation }],
       },
       handler: create,
     });

--- a/tests/integration/sectors.test.js
+++ b/tests/integration/sectors.test.js
@@ -184,7 +184,7 @@ describe('PUT /sectors/:id', () => {
       expect(response.statusCode).toBe(409);
     });
 
-    it('should create company even if sector name already exists in other company', async () => {
+    it('should update company even if sector name already exists in other company', async () => {
       const sector = sectorsList[1];
       authToken = await getTokenByCredentials(userFromOtherCompany.local);
       const payload = { name: sectorsList[2].name };

--- a/tests/integration/sectors.test.js
+++ b/tests/integration/sectors.test.js
@@ -171,9 +171,9 @@ describe('PUT /sectors/:id', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return a 409 error if sector name already exists', async () => {
+    it('should return a 409 error if sector name already exists in company', async () => {
       const sector = sectorsList[0];
-      const payload = { name: sectorsList[1].name };
+      const payload = { name: sectorsList[2].name };
       const response = await app.inject({
         method: 'PUT',
         url: `/sectors/${sector._id.toHexString()}`,
@@ -182,6 +182,20 @@ describe('PUT /sectors/:id', () => {
       });
 
       expect(response.statusCode).toBe(409);
+    });
+
+    it('should create company even if sector name already exists in other company', async () => {
+      const sector = sectorsList[1];
+      authToken = await getTokenByCredentials(userFromOtherCompany.local);
+      const payload = { name: sectorsList[2].name };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/sectors/${sector._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
     });
   });
 

--- a/tests/integration/seed/sectorsSeed.js
+++ b/tests/integration/seed/sectorsSeed.js
@@ -1,7 +1,11 @@
 const { ObjectID } = require('mongodb');
+const { v4: uuidv4 } = require('uuid');
 const Sector = require('../../../src/models/Sector');
 const SectorHistory = require('../../../src/models/SectorHistory');
+const User = require('../../../src/models/User');
 const { populateDBForAuthentication, authCompany, otherCompany } = require('./authenticationSeed');
+const { WEBAPP } = require('../../../src/helpers/constants');
+const { rolesList } = require('./authenticationSeed');
 
 const sectorsList = [
   { _id: new ObjectID(), name: 'Test', company: authCompany._id },
@@ -33,13 +37,28 @@ const historyList = [
   },
 ];
 
+const userFromOtherCompany = {
+  _id: new ObjectID(),
+  identity: { firstname: 'Test7', lastname: 'Test7' },
+  local: { email: 'test@othercompany.io', password: '123456!eR' },
+  inactivityDate: null,
+  employee_id: 123456789,
+  refreshToken: uuidv4(),
+  role: { client: rolesList[1]._id },
+  contracts: [new ObjectID()],
+  company: otherCompany._id,
+  origin: WEBAPP,
+};
+
 const populateDB = async () => {
   await Sector.deleteMany({});
   await SectorHistory.deleteMany({});
+  await User.deleteMany({});
 
   await populateDBForAuthentication();
   await Sector.insertMany(sectorsList);
   await SectorHistory.insertMany(historyList);
+  await User.create(userFromOtherCompany);
 };
 
-module.exports = { sectorsList, populateDB };
+module.exports = { sectorsList, populateDB, userFromOtherCompany };

--- a/tests/unit/helpers/sectors.test.js
+++ b/tests/unit/helpers/sectors.test.js
@@ -57,14 +57,11 @@ describe('list', () => {
 });
 
 describe('update', () => {
-  let countDocuments;
   let findOneAndUpdate;
   beforeEach(() => {
-    countDocuments = sinon.stub(Sector, 'countDocuments');
     findOneAndUpdate = sinon.stub(Sector, 'findOneAndUpdate');
   });
   afterEach(() => {
-    countDocuments.restore();
     findOneAndUpdate.restore();
   });
 
@@ -74,34 +71,14 @@ describe('update', () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
 
-    countDocuments.returns(0);
     findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await SectorsHelper.update(sectorId, payload, credentials);
 
-    sinon.assert.calledOnceWithExactly(countDocuments, { name: 'Tutu', company: companyId });
     SinonMongoose.calledWithExactly(findOneAndUpdate, [
       { query: 'findOneAndUpdate', args: [{ _id: sectorId }, { $set: payload }, { new: true }] },
       { query: 'lean' },
     ]);
-  });
-
-  it('should not update sector as name already exists', async () => {
-    const payload = { name: 'Tutu' };
-    const sectorId = new ObjectID();
-    const companyId = new ObjectID();
-    const credentials = { company: { _id: companyId } };
-
-    countDocuments.returns(3);
-
-    try {
-      await SectorsHelper.update(sectorId, payload, credentials);
-    } catch (e) {
-      expect(e.output.statusCode).toEqual(409);
-    }
-
-    sinon.assert.calledOnceWithExactly(countDocuments, { name: 'Tutu', company: companyId });
-    sinon.assert.notCalled(findOneAndUpdate);
   });
 });
 

--- a/tests/unit/helpers/sectors.test.js
+++ b/tests/unit/helpers/sectors.test.js
@@ -6,14 +6,11 @@ const SectorsHelper = require('../../../src/helpers/sectors');
 const SinonMongoose = require('../sinonMongoose');
 
 describe('create', () => {
-  let countDocuments;
   let create;
   beforeEach(() => {
-    countDocuments = sinon.stub(Sector, 'countDocuments');
     create = sinon.stub(Sector, 'create');
   });
   afterEach(() => {
-    countDocuments.restore();
     create.restore();
   });
 
@@ -22,37 +19,16 @@ describe('create', () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
 
-    countDocuments.returns(0);
-    create.returns(
-      SinonMongoose.stubChainedQueries([{ name: 'toto', company: companyId }], ['toObject'])
-    );
+    create.returns(SinonMongoose.stubChainedQueries([{ name: 'toto', company: companyId }], ['toObject']));
 
     const result = await SectorsHelper.create(payload, credentials);
 
     expect(result).toMatchObject({ name: 'toto', company: companyId });
 
-    sinon.assert.calledOnceWithExactly(countDocuments, { name: 'toto', company: companyId });
     SinonMongoose.calledWithExactly(create, [
       { query: 'create', args: [{ name: 'toto', company: companyId }] },
       { query: 'toObject' },
     ]);
-  });
-
-  it('should not create a new sector as name already exists', async () => {
-    const payload = { name: 'toto' };
-    const companyId = new ObjectID();
-    const credentials = { company: { _id: companyId } };
-
-    countDocuments.returns(2);
-
-    try {
-      await SectorsHelper.create(payload, credentials);
-    } catch (e) {
-      expect(e.output.statusCode).toEqual(409);
-    }
-
-    sinon.assert.calledOnceWithExactly(countDocuments, { name: 'toto', company: companyId });
-    sinon.assert.notCalled(create);
   });
 });
 
@@ -143,6 +119,6 @@ describe('remove', () => {
 
     await SectorsHelper.remove(sectorId);
 
-    sinon.assert.calledWithExactly(deleteOne, { _id: sectorId });
+    sinon.assert.calledOnceWithExactly(deleteOne, { _id: sectorId });
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - ~~Ce n'est pas une ancienne route utilisée par le mobile~~
      - ~~[ ] J'ai bien fait les tests~~
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    - ~~[ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Je peux créer une équipe (Config RH > Equipe) ayant le même nom qu'une autre équipe mais d'une autre structure. (Par exemple j'ai pu créer une équipe Lotus dans ma société Kenny Company). Je ne peux pas créer 2 équipes ayant le même nom au sein d'une même structure.
Refacto sinon-mongoose en boyscoot
