### PR TITLE
Com 1920

### DIFF
--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -37,19 +37,19 @@ exports.authorizeEventGet = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
 
   if (req.query.customer) {
-    const customerIds = UtilsHelper.formatIdsArray(req.query.customer);
+    const customerIds = [...new Set(UtilsHelper.formatIdsArray(req.query.customer))];
     const customerCount = await Customer.countDocuments({ _id: { $in: customerIds }, company: companyId });
     if (customerCount !== customerIds.length) throw Boom.forbidden();
   }
 
   if (req.query.auxiliary) {
-    const auxiliariesIds = UtilsHelper.formatIdsArray(req.query.auxiliary);
+    const auxiliariesIds = [...new Set(UtilsHelper.formatIdsArray(req.query.auxiliary))];
     const auxiliariesCount = await User.countDocuments({ _id: { $in: auxiliariesIds }, company: companyId });
     if (auxiliariesCount !== auxiliariesIds.length) throw Boom.forbidden();
   }
 
   if (req.query.sector) {
-    const sectorsIds = UtilsHelper.formatIdsArray(req.query.sector);
+    const sectorsIds = [...new Set(UtilsHelper.formatIdsArray(req.query.sector))];
     const sectorCount = await Sector.countDocuments({ _id: { $in: sectorsIds }, company: companyId });
     if (sectorCount !== sectorsIds.length) throw Boom.forbidden();
   }

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -105,6 +105,36 @@ describe('EVENTS ROUTES', () => {
         });
       });
 
+      it('should return a 200 if same id send twice - sectors', async () => {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/events?sector=${sectors[0]._id}&sector=${sectors[0]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toEqual(200);
+      });
+
+      it('should return a 200 if same id send twice - auxiliaries', async () => {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/events?auxiliary=${auxiliaries[0]._id}&auxiliary=${auxiliaries[0]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toEqual(200);
+      });
+
+      it('should return a 200 if same id send twice - customers', async () => {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/events?customer=${customerAuxiliary._id}&customer=${customerAuxiliary._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toEqual(200);
+      });
+
       it('should return a 403 if customer is not from the same company', async () => {
         const response = await app.inject({
           method: 'GET',


### PR DESCRIPTION
- [ ] Mon code est testé unitairement -np
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- Périmetre interface : client

- Périmetre roles : aidant/auxiliaire/coach

- Cas d'usage : Lorsqu'une auxiliaire appartient a deux secteur sur une meme semaine, je peux afficher le planning.

