### PR TITLE
COM-1933 - fix serial number in tax certificates

### DIFF
--- a/src/controllers/taxCertificateController.js
+++ b/src/controllers/taxCertificateController.js
@@ -7,7 +7,7 @@ const { language } = translate;
 const list = async (req) => {
   try {
     const { query, auth } = req;
-    const taxCertificates = await TaxCertificateHelper.generateTaxCertificatesList(query.customer, auth.credentials);
+    const taxCertificates = await TaxCertificateHelper.list(query.customer, auth.credentials);
 
     return {
       data: { taxCertificates },

--- a/src/helpers/taxCertificates.js
+++ b/src/helpers/taxCertificates.js
@@ -10,7 +10,7 @@ const TaxCertificate = require('../models/TaxCertificate');
 const EventRepository = require('../repositories/EventRepository');
 const PaymentRepository = require('../repositories/PaymentRepository');
 
-exports.generateTaxCertificatesList = async (customer, credentials) => {
+exports.list = async (customer, credentials) => {
   const companyId = get(credentials, 'company._id', null);
 
   return TaxCertificate.find({ customer, company: companyId }).lean();

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -652,7 +652,7 @@ exports.getTaxCertificateInterventions = async (taxCertificate, companyId) => {
     { $unwind: '$subscription' },
     {
       $project: {
-        auxiliary: { _id: 1, identity: 1, createdAt: 1 },
+        auxiliary: { _id: 1, identity: 1, createdAt: 1, serialNumber: 1 },
         month: '$_id.month',
         subscription: 1,
         duration: 1,

--- a/tests/unit/helpers/taxCertificates.test.js
+++ b/tests/unit/helpers/taxCertificates.test.js
@@ -14,7 +14,7 @@ const PaymentRepository = require('../../../src/repositories/PaymentRepository')
 
 require('sinon-mongoose');
 
-describe('generateTaxCertificatesList', () => {
+describe('list', () => {
   let TaxCertificateMock;
   beforeEach(() => {
     TaxCertificateMock = sinon.mock(TaxCertificate);
@@ -36,7 +36,7 @@ describe('generateTaxCertificatesList', () => {
       .once()
       .returns(taxCertificates);
 
-    const result = await TaxCertificateHelper.generateTaxCertificatesList(customer, { company: { _id: companyId } });
+    const result = await TaxCertificateHelper.list(customer, { company: { _id: companyId } });
 
     expect(result).toEqual(taxCertificates);
     TaxCertificateMock.verify();


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [ ] J'ai bien fait les tests - les tests sont deja la
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    -~~ [ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt~~
   ~~ créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    -~~ [ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

- Périmetre interface : Client

- Périmetre roles : Admin / aidant

- Cas d'usage : Ajout du numero de matricule quand on telecharge une attestation
