### PR TITLE
Com 1884

### DIFF
--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -483,29 +483,27 @@ describe('createHistory', () => {
 });
 
 describe('updateEndDate', () => {
-  let SectorHistoryMock;
+  let updateOne;
 
   beforeEach(() => {
-    SectorHistoryMock = sinon.mock(SectorHistory);
+    updateOne = sinon.stub(SectorHistory, 'updateOne');
   });
 
   afterEach(() => {
-    SectorHistoryMock.restore();
+    updateOne.restore();
   });
 
   it('should update sector history', async () => {
     const auxiliary = new ObjectID();
     const endDate = '2020-01-01';
-    SectorHistoryMock
-      .expects('updateOne')
-      .withExactArgs(
-        { auxiliary, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
-        { $set: { endDate: moment(endDate).endOf('day').toDate() } }
-      );
 
     await SectorHistoryHelper.updateEndDate(auxiliary, endDate);
 
-    SectorHistoryMock.verify();
+    sinon.assert.calledOnceWithExactly(
+      updateOne,
+      { auxiliary, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
+      { $set: { endDate: moment(endDate).endOf('day').toDate() } }
+    );
   });
 });
 

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -7,8 +7,6 @@ const SectorHistory = require('../../../src/models/SectorHistory');
 const Contract = require('../../../src/models/Contract');
 const SectorHistoryHelper = require('../../../src/helpers/sectorHistories');
 
-require('sinon-mongoose');
-
 describe('updateHistoryOnSectorUpdate', () => {
   const auxiliaryId = new ObjectID();
   const sector = new ObjectID();

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -39,13 +39,16 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toBeUndefined();
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        {
+          query: 'findOne',
+          args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledWithExactly(
       createHistoryStub,
       { _id: auxiliaryId, sector: sector.toHexString() },
@@ -62,13 +65,16 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual(null);
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        {
+          query: 'findOne',
+          args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.notCalled(createHistoryStub);
   });
 
@@ -82,22 +88,29 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
-    SinonMongoose.calledWithExactly(find, [
-      {
-        query: 'find',
-        args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        {
+          query: 'findOne',
+          args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        {
+          query: 'find',
+          args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
-      updateOne, { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
+      updateOne,
+      { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
       { $set: { sector: sector.toHexString() } }
     );
     sinon.assert.notCalled(createHistoryStub);
@@ -113,23 +126,30 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
-    SinonMongoose.calledWithExactly(find, [
-      {
-        query: 'find',
-        args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'sort', args: [{ startDate: -1 }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        {
+          query: 'findOne',
+          args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        {
+          query: 'find',
+          args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'sort', args: [{ startDate: -1 }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
-      updateOne, { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
+      updateOne,
+      { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
       { $set: { sector: sector.toHexString() } }
     );
     sinon.assert.notCalled(createHistoryStub);
@@ -145,23 +165,30 @@ describe('updateHistoryOnSectorUpdate', () => {
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
     expect(result).toEqual({ sector });
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'lean' },
-    ]);
-    SinonMongoose.calledWithExactly(find, [
-      {
-        query: 'find',
-        args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'sort', args: [{ startDate: -1 }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        {
+          query: 'findOne',
+          args: [{ auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        {
+          query: 'find',
+          args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'sort', args: [{ startDate: -1 }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
-      updateOne, { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
+      updateOne,
+      { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
       { $set: { sector: sector.toHexString() } }
     );
     sinon.assert.notCalled(createHistoryStub);
@@ -194,14 +221,16 @@ describe('updateHistoryOnSectorUpdate', () => {
       },
       { query: 'lean' },
     ]);
-    SinonMongoose.calledWithExactly(find, [
-      {
-        query: 'find',
-        args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
-      },
-      { query: 'sort', args: [{ startDate: -1 }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find, [
+        {
+          query: 'find',
+          args: [{ user: auxiliaryId, company: companyId, $or: [{ endDate: { $exists: false } }, { endDate: null }] }],
+        },
+        { query: 'sort', args: [{ startDate: -1 }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
@@ -240,19 +269,19 @@ describe('createHistoryOnContractCreation', () => {
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
-    sinon.assert.notCalled(createHistoryStub);
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }],
-      },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: existingHistory._id },
       { $set: { startDate: moment(newContract.startDate).startOf('day').toDate(), sector: user.sector } }
     );
+    sinon.assert.notCalled(createHistoryStub);
   });
 
   it('should create sector history if does not exist without start date', async () => {
@@ -262,19 +291,19 @@ describe('createHistoryOnContractCreation', () => {
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       createHistoryStub,
       { _id: auxiliaryId, sector },
       companyId,
       moment(newContract.startDate).startOf('day').toDate()
     );
-    SinonMongoose.calledWithExactly(findOne, [
-      {
-        query: 'findOne',
-        args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }],
-      },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ startDate: { $exists: false }, auxiliary: auxiliaryId }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.notCalled(updateOne);
   });
 });
@@ -282,74 +311,77 @@ describe('createHistoryOnContractCreation', () => {
 describe('updateHistoryOnContractUpdate', () => {
   const auxiliaryId = new ObjectID();
   const contractId = new ObjectID();
-  const newContract = { startDate: moment('2020-01-30') };
+  const newContract = { startDate: moment('2025-01-30') };
   const companyId = new ObjectID();
 
-  let ContractMock;
-  let SectorHistoryMock;
+  let findOne;
+  let updateOne;
+  let remove;
+  let find;
 
   beforeEach(() => {
-    ContractMock = sinon.mock(Contract);
-    SectorHistoryMock = sinon.mock(SectorHistory);
+    findOne = sinon.stub(Contract, 'findOne');
+    updateOne = sinon.stub(SectorHistory, 'updateOne');
+    remove = sinon.stub(SectorHistory, 'remove');
+    find = sinon.stub(SectorHistory, 'find');
   });
 
   afterEach(() => {
-    ContractMock.verify();
-    SectorHistoryMock.verify();
+    findOne.restore();
+    updateOne.restore();
+    remove.restore();
+    find.restore();
   });
 
   it('should update sector history if contract has not started yet', async () => {
-    ContractMock
-      .expects('findOne')
-      .withExactArgs({ _id: contractId, company: companyId })
-      .chain('lean')
-      .returns({ user: auxiliaryId, startDate: '2020-02-26' });
-
-    SectorHistoryMock
-      .expects('updateOne')
-      .withExactArgs(
-        { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
-        { $set: { startDate: moment(newContract.startDate).startOf('day').toDate() } }
-      )
-      .returns();
+    findOne.returns(SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: '2025-02-26' }], ['lean']));
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
+
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ _id: contractId, company: companyId }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      updateOne,
+      { auxiliary: auxiliaryId, $or: [{ endDate: { $exists: false } }, { endDate: null }] },
+      { $set: { startDate: moment(newContract.startDate).startOf('day').toDate() } }
+    );
   });
 
   it('should update and remove sector history if contract has started', async () => {
-    ContractMock
-      .expects('findOne')
-      .withExactArgs({ _id: contractId, company: companyId })
-      .chain('lean')
-      .returns({ user: auxiliaryId, startDate: '2019-01-01' });
-
-    SectorHistoryMock
-      .expects('remove')
-      .withExactArgs({
-        auxiliary: auxiliaryId,
-        endDate: { $gte: '2019-01-01', $lte: newContract.startDate },
-      })
-      .returns();
-
     const sectorHistory = [{ _id: new ObjectID() }];
-    SectorHistoryMock
-      .expects('find')
-      .withExactArgs({ company: companyId, auxiliary: auxiliaryId, startDate: { $gte: moment('2019-01-01').toDate() } })
-      .chain('sort')
-      .withExactArgs({ startDate: 1 })
-      .chain('limit')
-      .withExactArgs(1)
-      .chain('lean')
-      .returns(sectorHistory);
 
-    SectorHistoryMock
-      .expects('updateOne')
-      .withExactArgs(
-        { _id: sectorHistory[0]._id },
-        { $set: { startDate: moment(newContract.startDate).startOf('day').toDate() } }
-      );
+    findOne.returns(SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: '2019-01-01' }], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['sort', 'limit', 'lean']));
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
+
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ _id: contractId, company: companyId }] }, { query: 'lean' }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      remove,
+      { auxiliary: auxiliaryId, endDate: { $gte: '2019-01-01', $lte: newContract.startDate } }
+    );
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        {
+          query: 'find',
+          args: [{ company: companyId, auxiliary: auxiliaryId, startDate: { $gte: moment('2019-01-01').toDate() } }],
+        },
+        { query: 'sort', args: [{ startDate: 1 }] },
+        { query: 'limit', args: [1] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.calledOnceWithExactly(
+      updateOne,
+      { _id: sectorHistory[0]._id },
+      { $set: { startDate: moment(newContract.startDate).startOf('day').toDate() } }
+    );
   });
 });
 

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -32,7 +32,7 @@ describe('updateHistoryOnSectorUpdate', () => {
   });
 
   it('should create sector history if no previous one', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     const result = await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
 
@@ -285,7 +285,7 @@ describe('createHistoryOnContractCreation', () => {
   it('should create sector history if does not exist without start date', async () => {
     const user = { _id: auxiliaryId, sector };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
@@ -309,7 +309,7 @@ describe('createHistoryOnContractCreation', () => {
 describe('updateHistoryOnContractUpdate', () => {
   const auxiliaryId = new ObjectID();
   const contractId = new ObjectID();
-  const newContract = { startDate: moment('2025-01-30') };
+  const newContract = { startDate: moment().add(1, 'month') };
   const companyId = new ObjectID();
 
   let findOne;
@@ -332,7 +332,9 @@ describe('updateHistoryOnContractUpdate', () => {
   });
 
   it('should update sector history if contract has not started yet', async () => {
-    findOne.returns(SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: '2025-02-26' }], ['lean']));
+    findOne.returns(
+      SinonMongoose.stubChainedQueries([{ user: auxiliaryId, startDate: moment().add(2, 'month') }], ['lean'])
+    );
 
     await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, newContract, companyId);
 

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -437,52 +437,48 @@ describe('createHistory', () => {
   const sector = new ObjectID();
   const companyId = new ObjectID();
 
-  let SectorHistoryMock;
+  let create;
 
   beforeEach(() => {
-    SectorHistoryMock = sinon.mock(SectorHistory);
+    create = sinon.stub(SectorHistory, 'create');
   });
 
   afterEach(() => {
-    SectorHistoryMock.verify();
+    create.restore();
   });
 
   it('should create SectorHistory without startDate', async () => {
-    const payloadSectorHistory = { auxiliary: auxiliaryId, sector, company: companyId };
-    const sectorHistory = new SectorHistory({ auxiliary: auxiliaryId, sector, company: companyId });
-    const sectorHistoryMock = sinon.mock(sectorHistory);
+    const sectorHistory = { auxiliary: auxiliaryId, sector, company: companyId };
 
-    SectorHistoryMock
-      .expects('create')
-      .withExactArgs(payloadSectorHistory)
-      .returns(sectorHistory);
-    sectorHistoryMock.expects('toObject').once().returns(payloadSectorHistory);
+    create.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['toObject']));
 
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId);
 
-    expect(result).toEqual(payloadSectorHistory);
-    sectorHistoryMock.verify();
+    expect(result).toEqual(sectorHistory);
+    SinonMongoose.calledWithExactly(
+      create,
+      [
+        { query: 'create', args: [{ auxiliary: auxiliaryId, sector, company: companyId }] },
+        { query: 'toObject' },
+      ]
+    );
   });
 
   it('should create SectorHistory with startDate', async () => {
-    const payloadSectorHistory = {
-      auxiliary: auxiliaryId,
-      sector,
-      company: companyId,
-      startDate: '2020-01-01',
-    };
-    const sectorHistory = new SectorHistory(payloadSectorHistory);
-    const sectorHistoryMock = sinon.mock(sectorHistory);
-    SectorHistoryMock
-      .expects('create')
-      .withExactArgs(payloadSectorHistory)
-      .returns(sectorHistory);
-    sectorHistoryMock.expects('toObject').once().returns(payloadSectorHistory);
+    const sectorHistory = { auxiliary: auxiliaryId, sector, company: companyId, startDate: '2020-01-01' };
+
+    create.returns(SinonMongoose.stubChainedQueries([sectorHistory], ['toObject']));
 
     const result = await SectorHistoryHelper.createHistory({ _id: auxiliaryId, sector }, companyId, '2020-01-01');
 
-    expect(result).toEqual(payloadSectorHistory);
-    sectorHistoryMock.verify();
+    expect(result).toEqual(sectorHistory);
+    SinonMongoose.calledWithExactly(
+      create,
+      [
+        { query: 'create', args: [{ auxiliary: auxiliaryId, sector, company: companyId, startDate: '2020-01-01' }] },
+        { query: 'toObject' },
+      ]
+    );
   });
 });
 


### PR DESCRIPTION
- ~~[ ] Mon code est testé unitairement~~
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - ~~Ce n'est pas une ancienne route utilisée par le mobile~~
      - ~~[ ] J'ai bien fait les tests~~
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    - ~~[ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

Sinon Mongoose pour les fichiers sectorHistories et quotes. J'ai coché les cases sur le slite et j'ai supprimé sinon-mongoose
