### PR TITLE
Create repetitions

### DIFF
--- a/src/jobs/eventRepetitions.js
+++ b/src/jobs/eventRepetitions.js
@@ -50,6 +50,7 @@ const createEventBasedOnRepetition = async (repetition, date) => {
 const eventRepetitions = {
   async method(server) {
     const date = get(server, 'query.date') || new Date();
+    const type = get(server, 'query.type') || '';
     const errors = [];
     const companies = await Company.find({ 'subscriptions.erp': true }).lean();
     const newSavedEvents = [];
@@ -64,11 +65,16 @@ const eventRepetitions = {
         continue;
       }
 
-      const orderedRepetitions = [ // order matters
-        ...repetitions.filter(rep => rep.type === INTERNAL_HOUR),
-        ...repetitions.filter(rep => rep.type === UNAVAILABILITY),
-        ...repetitions.filter(rep => rep.type === INTERVENTION),
-      ];
+      let orderedRepetitions;
+      if (type) {
+        orderedRepetitions = repetitions.filter(rep => rep.type === type);
+      } else {
+        orderedRepetitions = [ // order matters
+          ...repetitions.filter(rep => rep.type === INTERNAL_HOUR),
+          ...repetitions.filter(rep => rep.type === UNAVAILABILITY),
+          ...repetitions.filter(rep => rep.type === INTERVENTION),
+        ];
+      }
 
       for (const repetition of orderedRepetitions) {
         try {

--- a/src/jobs/eventRepetitions.js
+++ b/src/jobs/eventRepetitions.js
@@ -65,16 +65,13 @@ const eventRepetitions = {
         continue;
       }
 
-      let orderedRepetitions;
-      if (type) {
-        orderedRepetitions = repetitions.filter(rep => rep.type === type);
-      } else {
-        orderedRepetitions = [ // order matters
+      const orderedRepetitions = type
+        ? repetitions.filter(rep => rep.type === type)
+        : [ // order matters
           ...repetitions.filter(rep => rep.type === INTERNAL_HOUR),
           ...repetitions.filter(rep => rep.type === UNAVAILABILITY),
           ...repetitions.filter(rep => rep.type === INTERVENTION),
         ];
-      }
 
       for (const repetition of orderedRepetitions) {
         try {

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -33,6 +33,7 @@ exports.plugin = {
         validate: {
           query: Joi.object({
             date: Joi.date(),
+            type: Joi.string(),
           }),
         },
       },

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -2,8 +2,7 @@ const sinon = require('sinon');
 const expect = require('expect');
 const moment = require('moment');
 const { ObjectID } = require('mongodb');
-require('sinon-mongoose');
-
+const SinonMongoose = require('../sinonMongoose');
 const Repetition = require('../../../src/models/Repetition');
 const Company = require('../../../src/models/Company');
 const Event = require('../../../src/models/Event');
@@ -12,9 +11,9 @@ const EmailHelper = require('../../../src/helpers/email');
 const eventRepetitions = require('../../../src/jobs/eventRepetitions');
 
 describe('method', () => {
-  let EventMock;
-  let RepetitionMock;
-  let CompanyMock;
+  let create;
+  let findRepetition;
+  let findCompany;
   let formatEventBasedOnRepetitionStub;
   let EmailHelperStub;
   let date;
@@ -22,18 +21,18 @@ describe('method', () => {
   const server = { log: (tags, text) => `${tags}, ${text}` };
   let serverLogStub;
   beforeEach(() => {
-    RepetitionMock = sinon.mock(Repetition);
-    CompanyMock = sinon.mock(Company);
-    EventMock = sinon.mock(Event);
+    create = sinon.stub(Event, 'create');
+    findRepetition = sinon.stub(Repetition, 'find');
+    findCompany = sinon.stub(Company, 'find');
     formatEventBasedOnRepetitionStub = sinon.stub(EventsRepetitionHelper, 'formatEventBasedOnRepetition');
     EmailHelperStub = sinon.stub(EmailHelper, 'completeEventRepScriptEmail');
     date = sinon.useFakeTimers(fakeDate);
     serverLogStub = sinon.stub(server, 'log');
   });
   afterEach(() => {
-    EventMock.restore();
-    RepetitionMock.restore();
-    CompanyMock.restore();
+    create.restore();
+    findRepetition.restore();
+    findCompany.restore();
     formatEventBasedOnRepetitionStub.restore();
     EmailHelperStub.restore();
     date.restore();
@@ -63,16 +62,8 @@ describe('method', () => {
     it(`should create a J+90 event for ${freq.type} repetition object`, async () => {
       const companyId = new ObjectID();
 
-      CompanyMock.expects('find')
-        .withExactArgs({ 'subscriptions.erp': true })
-        .chain('lean')
-        .once()
-        .returns([{ _id: companyId }]);
-      RepetitionMock.expects('find')
-        .withExactArgs({ startDate: { $lt: fakeDate }, company: companyId })
-        .chain('lean')
-        .once()
-        .returns(repetition);
+      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['lean']));
+      findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
       const futureEvent = new Event({
         type: 'intervention',
@@ -89,18 +80,27 @@ describe('method', () => {
         },
       });
       formatEventBasedOnRepetitionStub.returns(futureEvent);
-      EventMock.expects('create')
-        .withArgs(futureEvent)
-        .once()
-        .returns(futureEvent);
+      create.returns(futureEvent);
 
       const result = await eventRepetitions.method(server);
 
       expect(result).toMatchObject({ results: [futureEvent], errors: [] });
       sinon.assert.calledWith(formatEventBasedOnRepetitionStub, repetition[0], new Date());
-      RepetitionMock.verify();
-      EventMock.verify();
-      CompanyMock.verify();
+      SinonMongoose.calledWithExactly(
+        findRepetition,
+        [
+          { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
+          { query: 'lean' },
+        ]
+      );
+      SinonMongoose.calledWithExactly(
+        findCompany,
+        [
+          { query: 'find', args: [{ 'subscriptions.erp': true }] },
+          { query: 'lean' },
+        ]
+      );
+      sinon.assert.calledOnceWithExactly(create, futureEvent);
     });
   });
 
@@ -129,17 +129,8 @@ describe('method', () => {
     ];
     const companyId = new ObjectID();
 
-    CompanyMock.expects('find')
-      .withExactArgs({ 'subscriptions.erp': true })
-      .chain('lean')
-      .once()
-      .returns([{ _id: companyId }]);
-
-    RepetitionMock.expects('find')
-      .withExactArgs({ startDate: { $lt: fakeDate }, company: companyId })
-      .chain('lean')
-      .once()
-      .returns(repetitions);
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions], ['lean']));
+    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
     const futureEvent = new Event({
       type: 'internal_hour',
@@ -153,18 +144,27 @@ describe('method', () => {
       },
     });
     formatEventBasedOnRepetitionStub.returns(futureEvent);
-    EventMock.expects('create')
-      .withArgs(futureEvent)
-      .once()
-      .returns(futureEvent);
+    create.returns(futureEvent);
 
     const result = await eventRepetitions.method({ ...server, query: { type: 'internal_hour' } });
 
     expect(result).toMatchObject({ results: [futureEvent], errors: [] });
     sinon.assert.calledWith(formatEventBasedOnRepetitionStub, repetitions[1], new Date());
-    RepetitionMock.verify();
-    EventMock.verify();
-    CompanyMock.verify();
+    SinonMongoose.calledWithExactly(
+      findRepetition,
+      [
+        { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      findCompany,
+      [
+        { query: 'find', args: [{ 'subscriptions.erp': true }] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.calledOnceWithExactly(create, futureEvent);
   });
 
   it('should log repetitions ids which failed to create J+90 event', async () => {
@@ -183,26 +183,29 @@ describe('method', () => {
     }];
 
     const companyId = new ObjectID();
-    CompanyMock.expects('find')
-      .withExactArgs({ 'subscriptions.erp': true })
-      .chain('lean')
-      .once()
-      .returns([{ _id: companyId }]);
 
-    RepetitionMock
-      .expects('find')
-      .withExactArgs({ startDate: { $lt: fakeDate }, company: companyId })
-      .chain('lean')
-      .once()
-      .returns(repetition);
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['lean']));
+    findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
     formatEventBasedOnRepetitionStub.returns(Promise.reject(error));
 
     const result = await eventRepetitions.method(server);
 
     expect(result).toMatchObject({ results: [], errors: [repetition[0]._id] });
-    RepetitionMock.verify();
-    CompanyMock.verify();
+    SinonMongoose.calledWithExactly(
+      findRepetition,
+      [
+        { query: 'find', args: [{ startDate: { $lt: fakeDate }, company: companyId }] },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      findCompany,
+      [
+        { query: 'find', args: [{ 'subscriptions.erp': true }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledWith(serverLogStub, ['error', 'cron', 'jobs'], error);
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [ ] J'ai bien fait les tests -np
  - C'est une ancienne route utilisée par le mobile -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante 

- Périmetre interface : aucune

- Périmetre roles : vendor_admin

- Cas d'usage : Je peux preciser un type de repetition a creer. 