### PR TITLE
Com 1883

### DIFF
--- a/src/helpers/payments.js
+++ b/src/helpers/payments.js
@@ -111,10 +111,9 @@ exports.createPayment = async (payload, credentials) => {
   const { company } = credentials;
   const number = await exports.getPaymentNumber(payload, company._id);
   const payment = await Payment.create(exports.formatPayment(payload, company, number));
-  number.seq += 1;
   await PaymentNumber.updateOne(
     { prefix: number.prefix, nature: payload.nature, company: company._id },
-    { $set: { seq: number.seq } }
+    { $set: { seq: number.seq + 1 } }
   );
   return payment;
 };

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -305,29 +305,35 @@ describe('formatCreditNote', () => {
 });
 
 describe('getCreditNoteNumber', () => {
-  let CreditNoteNumberMock;
+  let findOneAndUpdate;
   beforeEach(() => {
-    CreditNoteNumberMock = sinon.mock(CreditNoteNumber);
+    findOneAndUpdate = sinon.stub(CreditNoteNumber, 'findOneAndUpdate');
   });
   afterEach(() => {
-    CreditNoteNumberMock.restore();
+    findOneAndUpdate.restore();
   });
 
   it('should get credit note number', async () => {
     const payload = { date: '2019-09-19T00:00:00' };
     const company = { _id: new ObjectID() };
 
-    CreditNoteNumberMock.expects('findOneAndUpdate')
-      .withExactArgs(
-        { prefix: '0919', company: company._id },
-        {},
-        { new: true, upsert: true, setDefaultsOnInsert: true }
-      )
-      .chain('lean')
-      .once();
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await CreditNoteHelper.getCreditNoteNumber(payload, company._id);
-    CreditNoteNumberMock.verify();
+
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        {
+          query: 'find',
+          args: [
+            { prefix: '0919', company: company._id },
+            {},
+            { new: true, upsert: true, setDefaultsOnInsert: true }],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -49,10 +49,11 @@ describe('getCreditNotes', () => {
       $lte: moment(payload.endDate).endOf('day').toISOString(),
       $gte: moment(payload.startDate).startOf('day').toISOString(),
     };
+
     getDateQueryStub.returns(dateQuery);
-    const query = { date: dateQuery, customer: customerId, company: companyId };
+
     CreditNoteMock.expects('find')
-      .withExactArgs(query)
+      .withExactArgs({ date: dateQuery, customer: customerId, company: companyId })
       .chain('populate')
       .withExactArgs({
         path: 'customer',
@@ -66,18 +67,19 @@ describe('getCreditNotes', () => {
     populateSubscriptionsServicesStub.returns({ _id: customerId, firstname: 'toto' });
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
+
     expect(result).toEqual([{ customer: { _id: customerId, firstname: 'toto' } }]);
-    sinon.assert.calledWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
-    sinon.assert.calledWithExactly(populateSubscriptionsServicesStub, { _id: customerId });
+    sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
+    sinon.assert.calledOnceWithExactly(populateSubscriptionsServicesStub, { _id: customerId });
   });
 
   it('should not call getDateQuery if no date in payload', async () => {
     const payload = {
       customer: customerId,
     };
-    const query = { customer: customerId, company: companyId };
+
     CreditNoteMock.expects('find')
-      .withExactArgs(query)
+      .withExactArgs({ customer: customerId, company: companyId })
       .chain('populate')
       .withExactArgs({
         path: 'customer',
@@ -91,9 +93,10 @@ describe('getCreditNotes', () => {
     populateSubscriptionsServicesStub.returns({ _id: customerId, firstname: 'toto' });
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
+
     expect(result).toEqual([{ customer: { _id: customerId, firstname: 'toto' } }]);
     sinon.assert.notCalled(getDateQueryStub);
-    sinon.assert.calledWithExactly(populateSubscriptionsServicesStub, { _id: customerId });
+    sinon.assert.calledOnceWithExactly(populateSubscriptionsServicesStub, { _id: customerId });
   });
 
   it('should not call populateSubscriptionsService if no creditNotes', async () => {
@@ -106,10 +109,10 @@ describe('getCreditNotes', () => {
       $lte: moment(payload.endDate).endOf('day').toISOString(),
       $gte: moment(payload.startDate).startOf('day').toISOString(),
     };
+
     getDateQueryStub.returns(dateQuery);
-    const query = { date: dateQuery, customer: customerId, company: companyId };
     CreditNoteMock.expects('find')
-      .withExactArgs(query)
+      .withExactArgs({ date: dateQuery, customer: customerId, company: companyId })
       .chain('populate')
       .withExactArgs({
         path: 'customer',
@@ -122,8 +125,9 @@ describe('getCreditNotes', () => {
       .returns([]);
 
     const result = await CreditNoteHelper.getCreditNotes(payload, credentials);
+
     expect(result).toEqual([]);
-    sinon.assert.calledWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
+    sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: payload.startDate, endDate: payload.endDate });
     sinon.assert.notCalled(populateSubscriptionsServicesStub);
   });
 });
@@ -161,16 +165,9 @@ describe('updateEventAndFundingHistory', () => {
     const credentials = { company: { _id: new ObjectID() } };
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
-    sinon.assert.calledWithExactly(
-      findOneAndUpdate,
-      { fundingId, month: '01/2019' },
-      { $inc: { careHours: -3 } }
-    );
-    sinon.assert.calledWithExactly(
-      updateOne,
-      { fundingId },
-      { $inc: { careHours: -3 } }
-    );
+
+    sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: -3 } });
+    sinon.assert.calledOnceWithExactly(updateOne, { fundingId }, { $inc: { careHours: -3 } });
   });
 
   it('should increment history for hourly and monthly funding', async () => {
@@ -188,11 +185,8 @@ describe('updateEventAndFundingHistory', () => {
     const credentials = { company: { _id: new ObjectID() } };
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
-    sinon.assert.calledWithExactly(
-      findOneAndUpdate,
-      { fundingId, month: '01/2019' },
-      { $inc: { careHours: -3 } }
-    );
+
+    sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: -3 } });
     sinon.assert.notCalled(updateOne);
   });
 
@@ -211,16 +205,9 @@ describe('updateEventAndFundingHistory', () => {
     const credentials = { company: { _id: new ObjectID() } };
 
     await CreditNoteHelper.updateEventAndFundingHistory([], true, credentials);
-    sinon.assert.calledWithExactly(
-      findOneAndUpdate,
-      { fundingId, month: '01/2019' },
-      { $inc: { careHours: 3 } }
-    );
-    sinon.assert.calledWithExactly(
-      updateOne,
-      { fundingId },
-      { $inc: { careHours: 3 } }
-    );
+
+    sinon.assert.calledOnceWithExactly(findOneAndUpdate, { fundingId, month: '01/2019' }, { $inc: { careHours: 3 } });
+    sinon.assert.calledOnceWithExactly(updateOne, { fundingId }, { $inc: { careHours: 3 } });
   });
 
   it('should increment history for fixed and once funding', async () => {
@@ -237,11 +224,8 @@ describe('updateEventAndFundingHistory', () => {
     const credentials = { company: { _id: new ObjectID() } };
 
     await CreditNoteHelper.updateEventAndFundingHistory([], false, credentials);
-    sinon.assert.calledWithExactly(
-      updateOne,
-      { fundingId },
-      { $inc: { amountTTC: -666 } }
-    );
+
+    sinon.assert.calledOnceWithExactly(updateOne, { fundingId }, { $inc: { amountTTC: -666 } });
   });
 });
 
@@ -272,7 +256,7 @@ describe('formatCreditNote', () => {
     formatCreditNoteNumber.returns('number');
 
     await CreditNoteHelper.formatCreditNote(payload, companyPrefix, prefix, seq);
-    sinon.assert.calledWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
+    sinon.assert.calledOnceWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
     sinon.assert.notCalled(getFixedNumber);
   });
   it('should format credit note for customer', async () => {
@@ -284,8 +268,8 @@ describe('formatCreditNote', () => {
     getFixedNumber.returnsArg(0);
 
     const creditNote = await CreditNoteHelper.formatCreditNote(payload, companyPrefix, prefix, seq);
-    sinon.assert.calledWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
-    sinon.assert.calledWithExactly(getFixedNumber, 98, 2);
+    sinon.assert.calledOnceWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
+    sinon.assert.calledOnceWithExactly(getFixedNumber, 98, 2);
     expect(creditNote.number).toEqual('number');
     expect(creditNote.inclTaxesCustomer).toEqual(98);
   });
@@ -298,8 +282,8 @@ describe('formatCreditNote', () => {
     getFixedNumber.returnsArg(0);
 
     const creditNote = await CreditNoteHelper.formatCreditNote(payload, companyPrefix, prefix, seq);
-    sinon.assert.calledWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
-    sinon.assert.calledWithExactly(getFixedNumber, 98, 2);
+    sinon.assert.calledOnceWithExactly(formatCreditNoteNumber, companyPrefix, prefix, seq);
+    sinon.assert.calledOnceWithExactly(getFixedNumber, 98, 2);
     expect(creditNote.number).toEqual('number');
     expect(creditNote.inclTaxesTpp).toEqual(98);
   });
@@ -370,7 +354,7 @@ describe('createCreditNotes', () => {
 
     await CreditNoteHelper.createCreditNotes(payload, credentials);
 
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       formatCreditNote,
       {
         date: '2019-07-30T00:00:00',
@@ -383,11 +367,17 @@ describe('createCreditNotes', () => {
       prefix,
       1
     );
-    sinon.assert.calledWithExactly(insertManyCreditNote, [{ inclTaxesCustomer: 1234 }]);
-    sinon.assert.calledWithExactly(createBillSlips, [{ inclTaxesCustomer: 1234 }], payload.date, credentials.company);
+    sinon.assert.calledOnceWithExactly(insertManyCreditNote, [{ inclTaxesCustomer: 1234 }]);
+    sinon.assert.calledOnceWithExactly(
+      createBillSlips,
+      [{ inclTaxesCustomer: 1234 }], payload.date, credentials.company
+    );
     sinon.assert.notCalled(updateEventAndFundingHistory);
-    sinon.assert.calledWithExactly(getCreditNoteNumber, payload, credentials.company._id);
-    sinon.assert.calledWithExactly(updateOneNumber, { prefix, company: credentials.company._id }, { $set: { seq: 2 } });
+    sinon.assert.calledOnceWithExactly(getCreditNoteNumber, payload, credentials.company._id);
+    sinon.assert.calledOnceWithExactly(
+      updateOneNumber,
+      { prefix, company: credentials.company._id }, { $set: { seq: 2 } }
+    );
   });
 
   it('should create one credit note (for tpp)', async () => {
@@ -402,7 +392,7 @@ describe('createCreditNotes', () => {
 
     await CreditNoteHelper.createCreditNotes(payload, credentials);
 
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       formatCreditNote,
       {
         date: '2019-07-30T00:00:00',
@@ -417,11 +407,14 @@ describe('createCreditNotes', () => {
       prefix,
       1
     );
-    sinon.assert.calledWithExactly(insertManyCreditNote, [{ inclTaxesTpp: 1234 }]);
-    sinon.assert.calledWithExactly(createBillSlips, [{ inclTaxesTpp: 1234 }], payload.date, credentials.company);
-    sinon.assert.calledWithExactly(updateEventAndFundingHistory, [{ _id: 'asdfghjkl' }], false, credentials);
-    sinon.assert.calledWithExactly(getCreditNoteNumber, payload, credentials.company._id);
-    sinon.assert.calledWithExactly(updateOneNumber, { prefix, company: credentials.company._id }, { $set: { seq: 2 } });
+    sinon.assert.calledOnceWithExactly(insertManyCreditNote, [{ inclTaxesTpp: 1234 }]);
+    sinon.assert.calledOnceWithExactly(createBillSlips, [{ inclTaxesTpp: 1234 }], payload.date, credentials.company);
+    sinon.assert.calledOnceWithExactly(updateEventAndFundingHistory, [{ _id: 'asdfghjkl' }], false, credentials);
+    sinon.assert.calledOnceWithExactly(getCreditNoteNumber, payload, credentials.company._id);
+    sinon.assert.calledOnceWithExactly(
+      updateOneNumber,
+      { prefix, company: credentials.company._id }, { $set: { seq: 2 } }
+    );
   });
 
   it('should create two credit notes (for customer and tpp)', async () => {
@@ -464,7 +457,7 @@ describe('createCreditNotes', () => {
       prefix,
       2
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       insertManyCreditNote,
       [
         { _id: '0987', linkedCreditNote: '1234', inclTaxesTpp: 1234 },
@@ -472,7 +465,7 @@ describe('createCreditNotes', () => {
       ]
     );
     sinon.assert.notCalled(updateEventAndFundingHistory);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       createBillSlips,
       [
         { _id: '0987', linkedCreditNote: '1234', inclTaxesTpp: 1234 },
@@ -481,8 +474,11 @@ describe('createCreditNotes', () => {
       payload.date,
       credentials.company
     );
-    sinon.assert.calledWithExactly(getCreditNoteNumber, payload, credentials.company._id);
-    sinon.assert.calledWithExactly(updateOneNumber, { prefix, company: credentials.company._id }, { $set: { seq: 3 } });
+    sinon.assert.calledOnceWithExactly(getCreditNoteNumber, payload, credentials.company._id);
+    sinon.assert.calledOnceWithExactly(
+      updateOneNumber,
+      { prefix, company: credentials.company._id }, { $set: { seq: 3 } }
+    );
   });
 });
 
@@ -545,18 +541,8 @@ describe('updateCreditNotes', () => {
     const result = await CreditNoteHelper.updateCreditNotes(creditNote, payload, credentials);
 
     expect(result).toMatchObject(updatedCreditNote);
-    sinon.assert.calledWithExactly(
-      updateEventAndFundingHistory,
-      creditNote.events,
-      true,
-      credentials
-    );
-    sinon.assert.calledWithExactly(
-      findByIdAndUpdate,
-      creditNote._id,
-      { $set: payload },
-      { new: true }
-    );
+    sinon.assert.calledOnceWithExactly(updateEventAndFundingHistory, creditNote.events, true, credentials);
+    sinon.assert.calledOnceWithExactly(findByIdAndUpdate, creditNote._id, { $set: payload }, { new: true });
   });
 
   it('should update a customer credit note and its tpp linked credit note', async () => {
@@ -577,6 +563,7 @@ describe('updateCreditNotes', () => {
     findByIdAndUpdate.returns(updatedCreditNote);
 
     const result = await CreditNoteHelper.updateCreditNotes(creditNoteWithLink, payload, credentials);
+
     expect(result).toMatchObject(updatedCreditNote);
     sinon.assert.calledWithExactly(
       updateEventAndFundingHistory.firstCall,
@@ -584,19 +571,14 @@ describe('updateCreditNotes', () => {
       true,
       credentials
     );
-    sinon.assert.calledWithExactly(
-      updateEventAndFundingHistory.secondCall,
-      payload.events,
-      false,
-      credentials
-    );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledWithExactly(updateEventAndFundingHistory.secondCall, payload.events, false, credentials);
+    sinon.assert.calledOnceWithExactly(
       findByIdAndUpdate,
       creditNote._id,
       { $set: { ...payload, inclTaxesTpp: 0, exclTaxesTpp: 0 } },
       { new: true }
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: creditNoteWithLink.linkedCreditNote },
       { $set: { ...payload, inclTaxesCustomer: 0, exclTaxesCustomer: 0 } },
@@ -629,19 +611,14 @@ describe('updateCreditNotes', () => {
       true,
       credentials
     );
-    sinon.assert.calledWithExactly(
-      updateEventAndFundingHistory.secondCall,
-      payload.events,
-      false,
-      credentials
-    );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledWithExactly(updateEventAndFundingHistory.secondCall, payload.events, false, credentials);
+    sinon.assert.calledOnceWithExactly(
       findByIdAndUpdate,
       creditNote._id,
       { $set: { ...payload, inclTaxesCustomer: 0, exclTaxesCustomer: 0 } },
       { new: true }
     );
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: creditNoteWithLink.linkedCreditNote },
       { $set: { ...payload, inclTaxesTpp: 0, exclTaxesTpp: 0 } },
@@ -738,7 +715,7 @@ describe('formatPDF', () => {
     const result = CreditNoteHelper.formatPDF(creditNote, company);
 
     expect(result).toEqual(expectedResult);
-    sinon.assert.calledWithExactly(formatEventSurchargesForPdf, [{ percentage: 30 }]);
+    sinon.assert.calledOnceWithExactly(formatEventSurchargesForPdf, [{ percentage: 30 }]);
   });
 
   it('should format correct credit note PDF with events for tpp', () => {
@@ -893,14 +870,14 @@ describe('removeCreditNote', () => {
 
   it('should delete a credit note', async () => {
     await CreditNoteHelper.removeCreditNote(creditNote, credentials, params);
-    sinon.assert.calledWithExactly(updateEventAndFundingHistoryStub, creditNote.events, true, credentials);
-    sinon.assert.calledWithExactly(deleteOneStub, { _id: params._id });
+    sinon.assert.calledOnceWithExactly(updateEventAndFundingHistoryStub, creditNote.events, true, credentials);
+    sinon.assert.calledOnceWithExactly(deleteOneStub, { _id: params._id });
   });
 
   it('should delete the linked creditNote if it has one', async () => {
     creditNote.linkedCreditNote = new ObjectID();
     await CreditNoteHelper.removeCreditNote(creditNote, credentials, params);
-    sinon.assert.calledWithExactly(updateEventAndFundingHistoryStub, creditNote.events, true, credentials);
+    sinon.assert.calledOnceWithExactly(updateEventAndFundingHistoryStub, creditNote.events, true, credentials);
     expect(deleteOneStub.getCall(0).calledWithExactly(deleteOneStub, { _id: params._id }));
     expect(deleteOneStub.getCall(1).calledWithExactly(deleteOneStub, { _id: creditNote.linkedCreditNote }));
   });
@@ -964,8 +941,8 @@ describe('generateCreditNotePdf', () => {
     const result = await CreditNoteHelper.generateCreditNotePdf(params, credentials);
 
     expect(result).toEqual({ pdf: { title: 'creditNote' }, creditNoteNumber: creditNote.number });
-    sinon.assert.calledWithExactly(formatPDFStub, creditNote, company);
-    sinon.assert.calledWithExactly(generatePdfStub, data, './src/data/creditNote.html');
+    sinon.assert.calledOnceWithExactly(formatPDFStub, creditNote, company);
+    sinon.assert.calledOnceWithExactly(generatePdfStub, data, './src/data/creditNote.html');
     CreditNoteModel.verify();
     CompanyModel.verify();
   });

--- a/tests/unit/helpers/creditNotes.test.js
+++ b/tests/unit/helpers/creditNotes.test.js
@@ -19,8 +19,6 @@ const SinonMongoose = require('../sinonMongoose');
 
 const { language } = translate;
 
-require('sinon-mongoose');
-
 describe('getCreditNotes', () => {
   let getDateQueryStub;
   let find;
@@ -329,7 +327,8 @@ describe('getCreditNoteNumber', () => {
           args: [
             { prefix: '0919', company: company._id },
             {},
-            { new: true, upsert: true, setDefaultsOnInsert: true }],
+            { new: true, upsert: true, setDefaultsOnInsert: true },
+          ],
         },
         { query: 'lean' },
       ]
@@ -927,10 +926,6 @@ describe('generateCreditNotePdf', () => {
   });
 
   it('should generate a pdf', async () => {
-    const creditNote = { origin: COMPANI, number: '12345' };
-    const company = { _id: credentials.company._id };
-    const data = { name: 'creditNotePdf' };
-
     creditNoteFindOne.returns(SinonMongoose.stubChainedQueries([{ origin: COMPANI, number: '12345' }]));
     companyNoteFindOne.returns(SinonMongoose.stubChainedQueries([{ _id: credentials.company._id }], ['lean']));
     formatPDFStub.returns({ name: 'creditNotePdf' });
@@ -938,7 +933,7 @@ describe('generateCreditNotePdf', () => {
 
     const result = await CreditNoteHelper.generateCreditNotePdf(params, credentials);
 
-    expect(result).toEqual({ pdf: { title: 'creditNote' }, creditNoteNumber: creditNote.number });
+    expect(result).toEqual({ pdf: { title: 'creditNote' }, creditNoteNumber: '12345' });
     SinonMongoose.calledWithExactly(
       creditNoteFindOne,
       [
@@ -960,8 +955,12 @@ describe('generateCreditNotePdf', () => {
       companyNoteFindOne,
       [{ query: 'find', args: [{ _id: credentials.company._id }] }, { query: 'lean' }]
     );
-    sinon.assert.calledOnceWithExactly(formatPDFStub, creditNote, company);
-    sinon.assert.calledOnceWithExactly(generatePdfStub, data, './src/data/creditNote.html');
+    sinon.assert.calledOnceWithExactly(
+      formatPDFStub,
+      { origin: COMPANI, number: '12345' },
+      { _id: credentials.company._id }
+    );
+    sinon.assert.calledOnceWithExactly(generatePdfStub, { name: 'creditNotePdf' }, './src/data/creditNote.html');
   });
 
   it('should return a 404 if creditnote is not found', async () => {

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -372,23 +372,38 @@ describe('formatPayment', () => {
 });
 
 describe('getPaymentNumber', () => {
+  let findOneAndUpdate;
+
+  beforeEach(() => {
+    findOneAndUpdate = sinon.stub(PaymentNumber, 'findOneAndUpdate');
+  });
+
+  afterEach(() => {
+    findOneAndUpdate.restore();
+  });
+
   it('should get payment number', async () => {
     const payment = { nature: 'payment', date: new Date('2019-12-01') };
     const companyId = new ObjectID();
-    const PaymentNumberMock = sinon.mock(PaymentNumber);
 
-    PaymentNumberMock
-      .expects('findOneAndUpdate')
-      .withExactArgs(
-        { nature: payment.nature, company: companyId, prefix: '1219' },
-        {},
-        { new: true, upsert: true, setDefaultsOnInsert: true }
-      )
-      .chain('lean');
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await PaymentsHelper.getPaymentNumber(payment, companyId);
 
-    PaymentNumberMock.verify();
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        {
+          query: 'find',
+          args: [
+            { nature: payment.nature, company: companyId, prefix: '1219' },
+            {},
+            { new: true, upsert: true, setDefaultsOnInsert: true },
+          ],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -330,10 +330,10 @@ describe('createPayment', () => {
     const result = await PaymentsHelper.createPayment(payment, credentials);
 
     expect(result).toEqual(formattedPayment);
-    sinon.assert.calledWithExactly(getPaymentNumberStub, payment, credentials.company._id);
-    sinon.assert.calledWithExactly(formatPaymentStub, payment, credentials.company, number);
-    sinon.assert.calledWithExactly(create, formattedPayment);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(getPaymentNumberStub, payment, credentials.company._id);
+    sinon.assert.calledOnceWithExactly(formatPaymentStub, payment, credentials.company, number);
+    sinon.assert.calledOnceWithExactly(create, formattedPayment);
+    sinon.assert.calledOnceWithExactly(
       updateOne,
       { prefix: number.prefix, nature: number.nature, company: companyId },
       { $set: { seq: number.seq + 1 } }

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -12,8 +12,6 @@ const Payment = require('../../../src/models/Payment');
 const xmlHelper = require('../../../src/helpers/xml');
 const SinonMongoose = require('../sinonMongoose');
 
-require('sinon-mongoose');
-
 describe('getPayments', () => {
   let getDateQueryStub;
   let find;

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -203,10 +203,8 @@ describe('generateXML', () => {
 
     await PaymentsHelper.generateXML([], [], company);
 
-    sinon.assert.calledOnce(createDocumentStub);
-    sinon.assert.calledWithExactly(createDocumentStub);
-    sinon.assert.calledOnce(generateSEPAHeaderStub);
-    sinon.assert.calledWithExactly(generateSEPAHeaderStub, { ...generateSEPAHeaderArgument, txNumber: 0, sum: 0 });
+    sinon.assert.calledOnceWithExactly(createDocumentStub);
+    sinon.assert.calledOnceWithExactly(generateSEPAHeaderStub, { ...generateSEPAHeaderArgument, txNumber: 0, sum: 0 });
     sinon.assert.calledOnce(generateSEPAXmlStub);
     sinon.assert.notCalled(generatePaymentInfoStub);
     sinon.assert.notCalled(addTransactionInfoStub);
@@ -221,15 +219,13 @@ describe('generateXML', () => {
 
     await PaymentsHelper.generateXML(firstPayments, [], company);
 
-    sinon.assert.calledOnce(createDocumentStub);
-    sinon.assert.calledWithExactly(createDocumentStub);
-    sinon.assert.calledOnce(generateSEPAHeaderStub);
-    sinon.assert.calledWithExactly(generateSEPAHeaderStub, { ...generateSEPAHeaderArgument, txNumber: 1, sum: 190 });
-
-    sinon.assert.calledOnce(generatePaymentInfoStub);
-    sinon.assert.calledWithExactly(generatePaymentInfoStub, generateFirstPaymentsInfoArgument);
-    sinon.assert.calledOnce(addTransactionInfoStub);
-    sinon.assert.calledWithExactly(addTransactionInfoStub, firstPaymentsInfo, firstPayments);
+    sinon.assert.calledOnceWithExactly(createDocumentStub);
+    sinon.assert.calledOnceWithExactly(
+      generateSEPAHeaderStub,
+      { ...generateSEPAHeaderArgument, txNumber: 1, sum: 190 }
+    );
+    sinon.assert.calledOnceWithExactly(generatePaymentInfoStub, generateFirstPaymentsInfoArgument);
+    sinon.assert.calledOnceWithExactly(addTransactionInfoStub, firstPaymentsInfo, firstPayments);
     sinon.assert.calledOnce(generateSEPAXmlStub);
   });
 
@@ -242,16 +238,13 @@ describe('generateXML', () => {
 
     await PaymentsHelper.generateXML([], recurPayments, company);
 
-    sinon.assert.calledOnce(createDocumentStub);
-    sinon.assert.calledWithExactly(createDocumentStub);
-    sinon.assert.calledOnce(generateSEPAHeaderStub);
-    sinon.assert.calledWithExactly(generateSEPAHeaderStub, { ...generateSEPAHeaderArgument, txNumber: 1, sum: 120 });
-
-    sinon.assert.calledOnce(generatePaymentInfoStub);
-    sinon.assert.calledWithExactly(generatePaymentInfoStub, generateRecurPaymentsInfoArgument);
-    sinon.assert.calledOnce(addTransactionInfoStub);
-    sinon.assert.calledWithExactly(addTransactionInfoStub, recurPaymentsInfo, recurPayments);
-
+    sinon.assert.calledOnceWithExactly(createDocumentStub);
+    sinon.assert.calledOnceWithExactly(
+      generateSEPAHeaderStub,
+      { ...generateSEPAHeaderArgument, txNumber: 1, sum: 120 }
+    );
+    sinon.assert.calledOnceWithExactly(generatePaymentInfoStub, generateRecurPaymentsInfoArgument);
+    sinon.assert.calledOnceWithExactly(addTransactionInfoStub, recurPaymentsInfo, recurPayments);
     sinon.assert.calledOnce(generateSEPAXmlStub);
   });
 
@@ -267,10 +260,8 @@ describe('generateXML', () => {
 
     await PaymentsHelper.generateXML(firstPayments, recurPayments, company);
 
-    sinon.assert.calledOnce(createDocumentStub);
-    sinon.assert.calledWithExactly(createDocumentStub);
-    sinon.assert.calledOnce(generateSEPAHeaderStub);
-    sinon.assert.calledWithExactly(generateSEPAHeaderStub, generateSEPAHeaderArgument);
+    sinon.assert.calledOnceWithExactly(createDocumentStub);
+    sinon.assert.calledOnceWithExactly(generateSEPAHeaderStub, generateSEPAHeaderArgument);
 
     sinon.assert.calledTwice(generatePaymentInfoStub);
     sinon.assert.calledWithExactly(generatePaymentInfoStub, generateFirstPaymentsInfoArgument);
@@ -360,7 +351,7 @@ describe('formatPayment', () => {
     expect(result.number).toBe('REG-190410100001');
     expect(ObjectID.isValid(result._id)).toBe(true);
     expect(result.company).toBe(companyId);
-    sinon.assert.calledWithExactly(
+    sinon.assert.calledOnceWithExactly(
       formatPaymentNumberStub,
       company.prefixNumber,
       number.prefix,
@@ -516,8 +507,7 @@ describe('savePayments', () => {
     sinon.assert.calledTwice(countDocuments);
     sinon.assert.calledOnceWithExactly(insertMany, payload);
     sinon.assert.calledTwice(formatPaymentStub);
-    sinon.assert.calledWithExactly(generateXMLStub, [payload[0]], [payload[1]], credentials.company);
-    sinon.assert.calledOnce(generateXMLStub);
+    sinon.assert.calledOnceWithExactly(generateXMLStub, [payload[0]], [payload[1]], credentials.company);
     sinon.assert.calledWithExactly(
       getPaymentNumberStub.getCall(0),
       { nature: 'payment', date: sinon.match.date },

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -10,40 +10,42 @@ const { PAYMENT, REFUND } = require('../../../src/helpers/constants');
 const PaymentNumber = require('../../../src/models/PaymentNumber');
 const Payment = require('../../../src/models/Payment');
 const xmlHelper = require('../../../src/helpers/xml');
+const SinonMongoose = require('../sinonMongoose');
 
 require('sinon-mongoose');
 
 describe('getPayments', () => {
   let getDateQueryStub;
-  let PaymentModel;
+  let find;
   beforeEach(() => {
     getDateQueryStub = sinon.stub(UtilsHelper, 'getDateQuery');
-    PaymentModel = sinon.mock(Payment);
+    find = sinon.stub(Payment, 'find');
   });
 
   afterEach(() => {
     getDateQueryStub.restore();
-    PaymentModel.restore();
+    find.restore();
   });
 
   it('should return all payments ', async () => {
     const credentials = { company: { _id: new ObjectID() } };
     const query = {};
     const payment = { _id: new ObjectID() };
-    PaymentModel
-      .expects('find')
-      .withExactArgs({ company: credentials.company._id })
-      .chain('populate')
-      .withExactArgs({ path: 'thirdPartyPayer', select: '_id name' })
-      .chain('populate')
-      .withExactArgs({ path: 'customer', select: '_id identity' })
-      .chain('lean')
-      .returns([payment]);
+    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
     expect(result).toEqual([payment]);
     sinon.assert.notCalled(getDateQueryStub);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ company: credentials.company._id }] },
+        { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
+        { query: 'populate', args: [{ path: 'customer', select: '_id identity' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should call getDateQuery if startDate is defined ', async () => {
@@ -52,21 +54,21 @@ describe('getPayments', () => {
     const payment = { _id: new ObjectID() };
 
     getDateQueryStub.returns({ $lte: '2019-11-01' });
-
-    PaymentModel
-      .expects('find')
-      .withExactArgs({ company: credentials.company._id, date: { $lte: '2019-11-01' } })
-      .chain('populate')
-      .withExactArgs({ path: 'thirdPartyPayer', select: '_id name' })
-      .chain('populate')
-      .withExactArgs({ path: 'customer', select: '_id identity' })
-      .chain('lean')
-      .returns([payment]);
+    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
     expect(result).toEqual([payment]);
-    sinon.assert.calledWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
+    sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ company: credentials.company._id, date: { $lte: '2019-11-01' } }] },
+        { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
+        { query: 'populate', args: [{ path: 'customer', select: '_id identity' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should call getDateQuery if endDate is defined ', async () => {
@@ -75,21 +77,21 @@ describe('getPayments', () => {
     const payment = { _id: new ObjectID() };
 
     getDateQueryStub.returns({ $gte: '2019-11-01' });
-
-    PaymentModel
-      .expects('find')
-      .withExactArgs({ company: credentials.company._id, date: { $gte: '2019-11-01' } })
-      .chain('populate')
-      .withExactArgs({ path: 'thirdPartyPayer', select: '_id name' })
-      .chain('populate')
-      .withExactArgs({ path: 'customer', select: '_id identity' })
-      .chain('lean')
-      .returns([payment]);
+    find.returns(SinonMongoose.stubChainedQueries([[payment]]));
 
     const result = await PaymentsHelper.getPayments(query, credentials);
 
     expect(result).toEqual([payment]);
-    sinon.assert.calledWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
+    sinon.assert.calledOnceWithExactly(getDateQueryStub, { startDate: query.startDate, endDate: query.endDate });
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ company: credentials.company._id, date: { $gte: '2019-11-01' } }] },
+        { query: 'populate', args: [{ path: 'thirdPartyPayer', select: '_id name' }] },
+        { query: 'populate', args: [{ path: 'customer', select: '_id identity' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 


### PR DESCRIPTION
- ~~[ ] Mon code est testé unitairement~~
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - ~~Ce n'est pas une ancienne route utilisée par le mobile~~
      - ~~[ ] J'ai bien fait les tests~~
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    - ~~[ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

Sinon Mongoose pour les fichiers payments et creditNotes. J'ai coché les cases sur le slite et j'ai supprimé sinon-mongoose