### PR TITLE
Com 1947

### DIFF
--- a/src/helpers/draftPay.js
+++ b/src/helpers/draftPay.js
@@ -298,7 +298,7 @@ exports.getHoursFromDailyAbsence = (absence, contract, query = absence) => {
 };
 
 exports.getPayFromAbsences = (absences, contract, query) => absences.reduce((acc, abs) => {
-  if (abs.absenceNature !== DAILY) return moment(abs.endDate).diff(abs.startDate, 'm') / 60;
+  if (abs.absenceNature !== DAILY) return acc + moment(abs.endDate).diff(abs.startDate, 'm') / 60;
 
   return acc + exports.getHoursFromDailyAbsence(abs, contract, query);
 }, 0);

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1303,11 +1303,11 @@ describe('getPayFromAbsences', () => {
       versions: [{ weeklyHours: 12 }],
     };
 
-    getHoursFromDailyAbsence.returns(6);
+    getHoursFromDailyAbsence.returns(2);
 
     const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
 
-    expect(result).toBe(12);
+    expect(result).toBe(4);
     sinon.assert.calledWithExactly(getHoursFromDailyAbsence.getCall(0), absences[0], contract, query);
     sinon.assert.calledWithExactly(getHoursFromDailyAbsence.getCall(1), absences[1], contract, query);
   });
@@ -1321,13 +1321,35 @@ describe('getPayFromAbsences', () => {
     const contract = {
       startDate: '2019-02-18T07:00:00',
       endDate: '2019-07-18T22:00:00',
-      versions: [{ weeklyHours: 12 }, { weeklyHours: 24 }],
+      versions: [{ weeklyHours: 12 }],
     };
 
     const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
 
     expect(result).toBe(4);
     sinon.assert.notCalled(getHoursFromDailyAbsence);
+  });
+
+  it('should return paid hours from daily and hourly absences', () => {
+    const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
+    const absences = [
+      { absenceNature: 'daily', startDate: '2019-05-01T07:00:00', endDate: '2019-05-01T22:00:00' },
+      { absenceNature: 'daily', startDate: '2019-05-18T07:00:00', endDate: '2019-05-18T22:00:00' },
+      { absenceNature: 'hourly', startDate: '2019-05-19T10:00:00', endDate: '2019-05-19T13:00:00' },
+    ];
+    const contract = {
+      startDate: '2019-02-18T07:00:00',
+      endDate: '2019-07-18T22:00:00',
+      versions: [{ weeklyHours: 12 }],
+    };
+
+    getHoursFromDailyAbsence.returns(2);
+
+    const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
+
+    expect(result).toBe(7);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence.getCall(0), absences[0], contract, query);
+    sinon.assert.calledWithExactly(getHoursFromDailyAbsence.getCall(1), absences[1], contract, query);
   });
 });
 

--- a/tests/unit/helpers/draftPay.test.js
+++ b/tests/unit/helpers/draftPay.test.js
@@ -1291,25 +1291,6 @@ describe('getPayFromAbsences', () => {
     expect(result).toBe(0);
   });
 
-  it('should call getHoursFromDailyAbsence', () => {
-    const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
-    const absences = [
-      { absenceNature: 'daily', startDate: '2019-05-18T07:00:00', endDate: '2019-05-18T22:00:00' },
-    ];
-    const contract = {
-      startDate: '2019-02-18T07:00:00',
-      endDate: '2019-07-18T22:00:00',
-      versions: [{ weeklyHours: 12 }],
-    };
-
-    getHoursFromDailyAbsence.returns(6);
-
-    const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
-
-    expect(result).toBe(6);
-    sinon.assert.calledOnceWithExactly(getHoursFromDailyAbsence, absences[0], contract, query);
-  });
-
   it('should call getHoursFromDailyAbsence for every daily absence', () => {
     const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
     const absences = [
@@ -1331,10 +1312,11 @@ describe('getPayFromAbsences', () => {
     sinon.assert.calledWithExactly(getHoursFromDailyAbsence.getCall(1), absences[1], contract, query);
   });
 
-  it('should return paid hours from hourly absence', () => {
+  it('should return paid hours from hourly absences', () => {
     const query = { startDate: '2019-05-01T07:00:00', endDate: '2019-05-31T07:00:00' };
     const absences = [
       { absenceNature: 'hourly', startDate: '2019-05-18T10:00:00', endDate: '2019-05-18T12:00:00' },
+      { absenceNature: 'hourly', startDate: '2019-06-18T10:00:00', endDate: '2019-06-18T12:00:00' },
     ];
     const contract = {
       startDate: '2019-02-18T07:00:00',
@@ -1344,7 +1326,7 @@ describe('getPayFromAbsences', () => {
 
     const result = DraftPayHelper.getPayFromAbsences(absences, contract, query);
 
-    expect(result).toBe(2);
+    expect(result).toBe(4);
     sinon.assert.notCalled(getHoursFromDailyAbsence);
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - ~~Ce n'est pas une ancienne route utilisée par le mobile~~
      - ~~[ ] J'ai bien fait les tests~~
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    - ~~[ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~


- Périmetre interface : client

- Périmetre roles : admin / aux

- Cas d'usage : 
Reproduire le bug :
Sur dev
- Ajouter une absence horaire à une auxiliaire, puis regarder le récapitulatif des heures (en cliquant sur son avatar dans le planning). Vous devriez avoir `x h - y h (absences)`, (x et  y dépendent de l'auxiliaire et de votre absence)
- Si vous ajouter une nouvel absence horaire, cela n'aura aucun impact sur ce compteur d'heure. (toujours `x h - y h (absences)`)
Sur ma branche
- On voit désormais la deuxième absence prise en compte
