### PR TITLE
COM-1949 - fix update contract startdate

### DIFF
--- a/src/controllers/contractController.js
+++ b/src/controllers/contractController.js
@@ -81,7 +81,8 @@ const updateContractVersion = async (req) => {
     const contract = await ContractHelper.updateVersion(
       req.params._id,
       req.params.versionId,
-      req.payload, req.auth.credentials
+      req.payload,
+      req.auth.credentials
     );
     if (!contract) return Boom.notFound(translate[language].contractNotFound);
 

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -192,6 +192,8 @@ exports.canUpdateVersion = async (contract, versionToUpdate, versionIndex, compa
   const eventsQuery = { auxiliary: user, endDate: startDate, company: companyId };
   if (userContracts.length > 1) {
     const pastContracts = userContracts.filter(c => new Date(c.startDate) < new Date(contract.startDate));
+    if (new Date(pastContracts[0].endDate) >= new Date(versionToUpdate.startDate)) return false;
+
     eventsQuery.startDate = pastContracts[0].endDate;
   }
   const eventsCount = await EventRepository.countAuxiliaryEventsBetweenDates(eventsQuery);

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -178,21 +178,21 @@ exports.createVersion = async (contractId, versionPayload) => {
   return Contract.findOneAndUpdate({ _id: contractId }, { $push: { versions: versionToAdd } }).lean();
 };
 
-exports.canUpdateVersion = async (contract, versionToUpdate, versionIndex, companyId) => {
+exports.canUpdateVersion = async (contract, versionPayload, versionIndex, companyId) => {
   if (contract.endDate) return false;
   if (versionIndex !== 0) {
-    return new Date(contract.versions[versionIndex - 1].startDate) < new Date(versionToUpdate.startDate);
+    return new Date(contract.versions[versionIndex - 1].startDate) < new Date(versionPayload.startDate);
   }
 
   const { user } = contract;
-  const { startDate } = versionToUpdate;
+  const { startDate } = versionPayload;
   const userContracts = await Contract.find({ user: contract.user, company: companyId })
     .sort({ startDate: -1 })
     .lean();
   const eventsQuery = { auxiliary: user, endDate: startDate, company: companyId };
   if (userContracts.length > 1) {
     const pastContracts = userContracts.filter(c => new Date(c.startDate) < new Date(contract.startDate));
-    if (new Date(pastContracts[0].endDate) >= new Date(versionToUpdate.startDate)) return false;
+    if (new Date(pastContracts[0].endDate) >= new Date(versionPayload.startDate)) return false;
 
     eventsQuery.startDate = pastContracts[0].endDate;
   }
@@ -235,19 +235,19 @@ exports.formatVersionEditionPayload = async (oldVersion, newVersion, versionInde
   return payload;
 };
 
-exports.updateVersion = async (contractId, versionId, versionToUpdate, credentials) => {
+exports.updateVersion = async (contractId, versionId, versionPayload, credentials) => {
   const contract = await Contract.findOne({ _id: contractId }).lean();
   const companyId = get(credentials, 'company._id', null);
   const index = contract.versions.findIndex(ver => ver._id.toHexString() === versionId);
 
-  const canUpdate = await exports.canUpdateVersion(contract, versionToUpdate, index, companyId);
+  const canUpdate = await exports.canUpdateVersion(contract, versionPayload, index, companyId);
   if (!canUpdate) throw Boom.badData();
 
-  if (index === 0 && versionToUpdate.startDate) {
-    await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, versionToUpdate, companyId);
+  if (index === 0 && versionPayload.startDate) {
+    await SectorHistoryHelper.updateHistoryOnContractUpdate(contractId, versionPayload, companyId);
   }
 
-  const payload = await exports.formatVersionEditionPayload(contract.versions[index], versionToUpdate, index);
+  const payload = await exports.formatVersionEditionPayload(contract.versions[index], versionPayload, index);
 
   if (payload.$unset && Object.keys(payload.$unset).length > 0) {
     await Contract.updateOne({ _id: contractId }, { $unset: payload.$unset });

--- a/src/helpers/subPrograms.js
+++ b/src/helpers/subPrograms.js
@@ -37,6 +37,7 @@ exports.listELearningDraft = async () => {
     .populate({ path: 'program', select: '_id name description image' })
     .populate({ path: 'steps', select: 'type' })
     .lean({ virtuals: true });
+
   return subPrograms.filter(sp => sp.steps.length && sp.isStrictlyELearning);
 };
 

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -461,7 +461,7 @@ describe('PUT contract/:id/versions/:versionId', () => {
   });
 
   it('should update a contract startDate and update corresponding sectorhistory', async () => {
-    const payload = { startDate: '2018-11-28' };
+    const payload = { startDate: '2020-11-28T00:00:00' };
     const response = await app.inject({
       method: 'PUT',
       url: `/contracts/${contractsList[2]._id}/versions/${contractsList[2].versions[0]._id}`,
@@ -520,7 +520,7 @@ describe('PUT contract/:id/versions/:versionId', () => {
   });
 
   const roles = [
-    { name: 'client_admin', expectedCode: 200 },
+    { name: 'coach', expectedCode: 200 },
     { name: 'auxiliary', expectedCode: 403 },
     { name: 'helper', expectedCode: 403 },
     { name: 'auxiliary_without_company', expectedCode: 403 },

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -360,7 +360,7 @@ const exportTypes = [
     populate: populateSectorHistories,
     expectedRows: [
       '\ufeff"Equipe";"Id Auxiliaire";"Nom";"Prénom";"Date d\'arrivée dans l\'équipe";"Date de départ de l\'équipe"',
-      `"Test";${userList[2]._id};"Test";"Auxiliary";"10/12/2018";`,
+      `"Test";${userList[2]._id};"Test";"Auxiliary";"10/12/2020";`,
       `"Test";${userList[4]._id};"Test";"PlanningReferent";"10/12/2018";`,
       `"Etoile";${auxiliaryList[0]._id};"Uiui";"Lulu";"10/12/2018";`,
     ],

--- a/tests/integration/seed/authenticationSeed.js
+++ b/tests/integration/seed/authenticationSeed.js
@@ -39,7 +39,7 @@ const sectorHistories = [
     auxiliary: userList[2]._id,
     sector: sector._id,
     company: authCompany._id,
-    startDate: '2018-12-10',
+    startDate: '2020-12-10',
   },
   {
     auxiliary: userList[4]._id,

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -231,22 +231,12 @@ const sectorHistories = [
 ];
 
 const otherContract = {
-  createdAt: '2018-12-04T16:34:04.144Z',
   serialNumber: 'wfjefajsdklvcmkdmck',
   user: otherContractUser._id,
   startDate: '2018-12-03T23:00:00.000Z',
   _id: otherContractUser.contracts[0],
   company: otherCompany._id,
-  versions: [
-    {
-      createdAt: '2018-12-04T16:34:04.144Z',
-      endDate: null,
-      grossHourlyRate: 10.28,
-      startDate: '2018-12-03T23:00:00.000Z',
-      weeklyHours: 9,
-      _id: new ObjectID(),
-    },
-  ],
+  versions: [{ grossHourlyRate: 10.28, startDate: '2018-12-03T23:00:00.000Z', weeklyHours: 9, _id: new ObjectID() }],
 };
 
 const userFromOtherCompany = {
@@ -264,24 +254,14 @@ const userFromOtherCompany = {
 
 const contractsList = [
   {
-    createdAt: '2018-12-04T16:34:04.144Z',
     serialNumber: 'mnbvcxzaserfghjiu',
     user: contractUsers[0]._id,
     startDate: '2018-12-03T23:00:00.000Z',
     _id: contractUsers[0].contracts[0],
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2018-12-04T16:34:04.144Z',
-        grossHourlyRate: 10.28,
-        startDate: '2018-12-03T23:00:00.000Z',
-        weeklyHours: 9,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{ grossHourlyRate: 10.28, startDate: '2018-12-03T23:00:00.000Z', weeklyHours: 9, _id: new ObjectID() }],
   },
   {
-    createdAt: '2018-12-04T16:34:04.144Z',
     serialNumber: 'sdfgtresddbgr',
     user: contractUsers[1]._id,
     startDate: '2018-12-03T23:00:00.000Z',
@@ -290,58 +270,35 @@ const contractsList = [
     endReason: 'mutation',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2018-12-04T16:34:04.144Z',
-        grossHourlyRate: 10.28,
-        startDate: '2018-12-03T23:00:00.000Z',
-        weeklyHours: 9,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{ grossHourlyRate: 10.28, startDate: '2018-12-03T23:00:00.000Z', weeklyHours: 9, _id: new ObjectID() }],
   },
   {
-    createdAt: '2018-08-02T17:12:55.144Z',
     serialNumber: 'qwdfgbnhygfc',
     endDate: null,
     company: authCompany._id,
     user: getUser('auxiliary')._id,
-    startDate: '2018-08-02T17:12:55.144Z',
+    startDate: '2020-08-02T00:00:00',
     _id: new ObjectID(),
-    versions: [
-      {
-        createdAt: '2018-08-02T17:12:55.144Z',
-        endDate: null,
-        grossHourlyRate: 10.12,
-        startDate: '2018-08-02T17:12:55.144Z',
-        weeklyHours: 15,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() }],
   },
   {
-    createdAt: '2018-08-02T17:12:55.144Z',
     serialNumber: 'cvfdjsbjknvkaskdj',
     user: getUser('auxiliary')._id,
-    startDate: '2018-08-02T17:12:55.144Z',
-    endDate: '2018-09-02T17:12:55.144Z',
+    startDate: '2018-08-02T00:00:00',
+    endDate: '2018-09-02T23:59:59',
     endNotificationDate: '2018-02-03T23:00:00.000Z',
     endReason: 'mutation',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2018-08-02T17:12:55.144Z',
-        endDate: '2018-09-02T17:12:55.144Z',
-        grossHourlyRate: 10.12,
-        startDate: '2018-08-02T17:12:55.144Z',
-        weeklyHours: 15,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{
+      endDate: '2018-09-02T23:59:59',
+      grossHourlyRate: 10.12,
+      startDate: '2018-08-02T00:00:00',
+      weeklyHours: 15,
+      _id: new ObjectID(),
+    }],
   },
   {
-    createdAt: '2017-08-02T17:12:55.144Z',
     serialNumber: 'cacnxnkzlas',
     user: contractUsers[2]._id,
     startDate: '2017-08-02T17:12:55.144Z',
@@ -350,50 +307,29 @@ const contractsList = [
     endReason: 'mutation',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2017-08-02T17:12:55.144Z',
-        endDate: '2017-09-02T17:12:55.144Z',
-        grossHourlyRate: 10.12,
-        startDate: '2017-08-02T17:12:55.144Z',
-        weeklyHours: 15,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{
+      endDate: '2017-09-02T17:12:55.144Z',
+      grossHourlyRate: 10.12,
+      startDate: '2017-08-02T17:12:55.144Z',
+      weeklyHours: 15,
+      _id: new ObjectID(),
+    }],
   },
   {
-    createdAt: '2018-08-02T17:12:55.144Z',
     serialNumber: 'sldfnasdlknfkds',
     user: contractUsers[3]._id,
     startDate: '2018-08-02T17:12:55.144Z',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2018-08-02T17:12:55.144Z',
-        grossHourlyRate: 10.12,
-        startDate: '2018-08-02T17:12:55.144Z',
-        weeklyHours: 15,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T17:12:55.144Z', weeklyHours: 15, _id: new ObjectID() }],
   },
   {
-    createdAt: '2018-08-02T17:12:55.144Z',
     serialNumber: 'lqwjrewjqpjefek',
     user: getUser('auxiliary_without_company')._id,
     startDate: '2018-08-02T17:12:55.144Z',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [
-      {
-        createdAt: '2018-08-02T17:12:55.144Z',
-        grossHourlyRate: 10.12,
-        startDate: '2018-08-02T17:12:55.144Z',
-        weeklyHours: 15,
-        _id: new ObjectID(),
-      },
-    ],
+    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T17:12:55.144Z', weeklyHours: 15, _id: new ObjectID() }],
   },
 ];
 
@@ -406,7 +342,6 @@ const contractEvents = [
     startDate: '2019-08-08T14:00:18.653Z',
     endDate: '2019-08-08T16:00:18.653Z',
     auxiliary: contractUsers[0]._id,
-    createdAt: '2019-01-05T15:24:18.653Z',
     internalHour: { _id: new ObjectID(), name: 'Formation' },
   },
   {
@@ -419,7 +354,6 @@ const contractEvents = [
     startDate: '2019-01-19T14:00:18.653Z',
     endDate: '2019-01-19T17:00:18.653Z',
     auxiliary: contractUsers[0]._id,
-    createdAt: '2019-01-11T08:38:18.653Z',
   },
   {
     _id: new ObjectID(),
@@ -431,7 +365,6 @@ const contractEvents = [
     startDate: '2019-07-06T14:00:18.653Z',
     endDate: '2019-07-10T17:00:18.653Z',
     auxiliary: contractUsers[0]._id,
-    createdAt: '2019-01-11T08:38:18.653Z',
   },
   {
     _id: new ObjectID(),
@@ -442,7 +375,6 @@ const contractEvents = [
     endDate: '2019-01-16T11:30:21.653Z',
     auxiliary: contractUsers[0]._id,
     customer: customer._id,
-    createdAt: '2019-01-15T11:33:14.343Z',
     subscription: customer.subscriptions[0]._id,
     address: {
       fullAddress: '37 rue de ponthieu 75008 Paris',
@@ -461,7 +393,6 @@ const contractEvents = [
     endDate: '2019-01-17T16:30:19.543Z',
     auxiliary: contractUsers[0]._id,
     customer: customer._id,
-    createdAt: '2019-01-16T14:30:19.543Z',
     subscription: customer.subscriptions[0]._id,
     address: {
       fullAddress: '37 rue de ponthieu 75008 Paris',

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -663,7 +663,23 @@ describe('canUpdateVersion', () => {
 
   it('should return false if contract not ended and start date is before previous version startDate', async () => {
     const versionToUpdate = { startDate: '2020-01-03T00:00:00' };
-    const contract = { _id: new ObjectID(), versions: [versionToUpdate, { startDate: '2020-09-03T00:00:00' }] };
+    const contract = {
+      _id: new ObjectID(),
+      versions: [versionToUpdate, { startDate: '2019-09-03T00:00:00', endDate: '2019-12-03T00:00:00' }],
+    };
+    const result = await ContractHelper.canUpdateVersion(contract, versionToUpdate, 1, '1234567890');
+
+    expect(result).toBeFalsy();
+    sinon.assert.notCalled(countAuxiliaryEventsBetweenDates);
+    sinon.assert.notCalled(findContract);
+  });
+
+  it('should return false if  start date is before previous contract startDate', async () => {
+    const versionToUpdate = { startDate: '2018-01-03T00:00:00' };
+    const contract = {
+      _id: new ObjectID(),
+      versions: [versionToUpdate, { startDate: '2019-09-03T00:00:00', endDate: '2019-12-03T00:00:00' }],
+    };
     const result = await ContractHelper.canUpdateVersion(contract, versionToUpdate, 1, '1234567890');
 
     expect(result).toBeFalsy();


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [ ] J'ai bien fait les tests -> ils sont déjà faits
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - ~~[ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme~~
  - ~~Je n'ai pas fait de breaking change :~~
    - ~~[ ] Je n'ai pas changé les droits de la route~~
    - ~~[ ] Je n'ai pas changé les droits dans le fichier rights.js~~
    - ~~[ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile~~
    - ~~[ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles~~
    - ~~Justification des breaking changes s'il y en a:~~
  - ~~J'ai supprimé une route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas~~
  - ~~J'ai renommé une route :~~
    - ~~[ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)~~
  - ~~J'ai ajoute un champ possible dans la route :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible dans la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour~~

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~


- Périmetre interface : Client

- Périmetre roles : Admin / Coach

- Cas d'usage : 3 bugs sont corrigés dans cette PR
1. Je ne peux pas modifier la date d'une version avec une date antérieure a la date de début de la version précédente
2. Si c'est le 2eme contrat de l'auxiliaire, je peux modifier sa date de début s'il n'y a pas d'evenement entre la date de fin du dernier contrat et la nouvelle date de debut
3. Je ne peux pas modifier la date de debut d'un contrat a une date anterieur a la date de debut du contrat d'avant
