### PR TITLE
COM-1949 - cannot create version before previous version startDate

### DIFF
--- a/src/controllers/contractController.js
+++ b/src/controllers/contractController.js
@@ -66,7 +66,7 @@ const exportDpae = async (req, h) => {
 
 const createContractVersion = async (req) => {
   try {
-    const contract = await ContractHelper.createVersion(req.params._id, req.payload);
+    const contract = await ContractHelper.createVersion(req.params._id, req.payload, req.auth.credentials);
     if (!contract) return Boom.notFound(translate[language].contractNotFound);
 
     return { message: translate[language].contractVersionAdded, data: { contract } };

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -373,4 +373,4 @@ exports.uploadFile = async (params, payload) => {
 
 exports.auxiliaryHasActiveContractOnDay = (contracts, day) =>
   contracts.some(contract => moment(contract.startDate).isSameOrBefore(day, 'd') &&
-  (!contract.endDate || moment(contract.endDate).isSameOrAfter(day, 'd')));
+    (!contract.endDate || moment(contract.endDate).isSameOrAfter(day, 'd')));

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -186,7 +186,8 @@ exports.createVersion = async (contractId, versionPayload, credentials) => {
 };
 
 exports.canUpdateVersion = async (contract, versionPayload, versionIndex, companyId) => {
-  if (contract.endDate) return false;
+  const lastVersionIndex = contract.versions.length - 1;
+  if (contract.endDate || versionIndex < lastVersionIndex) return false;
   if (versionIndex !== 0) {
     return new Date(contract.versions[versionIndex - 1].startDate) < new Date(versionPayload.startDate);
   }

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -154,8 +154,15 @@ exports.endContract = async (contractId, contractToEnd, credentials) => {
   return updatedContract;
 };
 
-exports.createVersion = async (contractId, versionPayload) => {
+exports.canCreateVersion = async (contract, versionPayload, companyId) =>
+  exports.canUpdateVersion(contract, versionPayload, contract.versions.length, companyId);
+
+exports.createVersion = async (contractId, versionPayload, credentials) => {
+  const companyId = get(credentials, 'company._id', null);
   const contract = await Contract.findOne({ _id: contractId }).lean();
+
+  const canCreate = await exports.canCreateVersion(contract, versionPayload, companyId);
+  if (!canCreate) throw Boom.badData();
 
   const versionToAdd = { ...versionPayload };
   if (versionPayload.signature) {
@@ -366,4 +373,4 @@ exports.uploadFile = async (params, payload) => {
 
 exports.auxiliaryHasActiveContractOnDay = (contracts, day) =>
   contracts.some(contract => moment(contract.startDate).isSameOrBefore(day, 'd') &&
-    (!contract.endDate || moment(contract.endDate).isSameOrAfter(day, 'd')));
+  (!contract.endDate || moment(contract.endDate).isSameOrAfter(day, 'd')));

--- a/src/helpers/gDriveStorage.js
+++ b/src/helpers/gDriveStorage.js
@@ -27,11 +27,7 @@ exports.createFolder = async (identity, parentFolderId) => {
 
 exports.createFolderForCompany = async (companyName) => {
   const parentFolderId = process.env.GOOGLE_DRIVE_COMPANY_FOLDER_ID;
-  const folder = await Gdrive.add({
-    name: companyName,
-    parentFolderId,
-    folder: true,
-  });
+  const folder = await Gdrive.add({ name: companyName, parentFolderId, folder: true });
 
   if (!folder) throw Boom.failedDependency('Google drive folder creation failed.');
 

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -612,6 +612,18 @@ describe('PUT contract/:id/versions/:versionId', () => {
     expect(moment(payload.startDate).isSame(sectorHistories[0].startDate, 'day')).toBeTruthy();
   });
 
+  it('should return 422 if not last version updated', async () => {
+    const payload = { startDate: '2020-02-01' };
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/contracts/${contractsList[7]._id}/versions/${contractsList[7].versions[0]._id}`,
+      headers: { Cookie: `alenvi_token=${authToken}` },
+      payload,
+    });
+
+    expect(response.statusCode).toBe(422);
+  });
+
   it('should return a 403 if contract is not from the same company', async () => {
     const payload = { startDate: '2020-02-01' };
     const response = await app.inject({

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -264,7 +264,7 @@ const contractsList = [
     endDate: null,
     company: authCompany._id,
     user: getUser('auxiliary')._id,
-    startDate: '2020-08-02T00:00:00',
+    startDate: '2018-08-02T00:00:00',
     _id: new ObjectID(),
     versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() }],
   },
@@ -317,6 +317,18 @@ const contractsList = [
     _id: new ObjectID(),
     company: authCompany._id,
     versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() }],
+  },
+  {
+    serialNumber: 'xbcbdsvknsdk',
+    endDate: null,
+    company: authCompany._id,
+    user: getUser('auxiliary')._id,
+    startDate: '2017-10-12T00:00:00',
+    _id: new ObjectID(),
+    versions: [
+      { grossHourlyRate: 10.12, startDate: '2017-10-12T00:00:00', weeklyHours: 23, _id: new ObjectID() },
+      { grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() },
+    ],
   },
 ];
 

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -191,16 +191,8 @@ const contractUsers = [{
 }];
 
 const sectorHistories = [
-  {
-    auxiliary: contractUsers[0]._id,
-    sector: sector._id,
-    company: authCompany._id,
-  },
-  {
-    auxiliary: contractUsers[1]._id,
-    sector: sector._id,
-    company: authCompany._id,
-  },
+  { auxiliary: contractUsers[0]._id, sector: sector._id, company: authCompany._id },
+  { auxiliary: contractUsers[1]._id, sector: sector._id, company: authCompany._id },
   {
     auxiliary: contractUsers[2]._id,
     sector: sector._id,
@@ -222,12 +214,7 @@ const sectorHistories = [
     startDate: '2017-01-01',
     endDate: '2017-11-30',
   },
-  {
-    auxiliary: contractUsers[3]._id,
-    sector: sector._id,
-    company: authCompany._id,
-    startDate: '2018-09-03',
-  },
+  { auxiliary: contractUsers[3]._id, sector: sector._id, company: authCompany._id, startDate: '2018-09-03' },
 ];
 
 const otherContract = {
@@ -301,16 +288,16 @@ const contractsList = [
   {
     serialNumber: 'cacnxnkzlas',
     user: contractUsers[2]._id,
-    startDate: '2017-08-02T17:12:55.144Z',
-    endDate: '2017-09-02T17:12:55.144Z',
-    endNotificationDate: '2017-09-02T17:12:55.144Z',
+    startDate: '2017-08-02T00:00:00',
+    endDate: '2017-09-02T23:59:59',
+    endNotificationDate: '2017-09-02T17:12:55',
     endReason: 'mutation',
     _id: new ObjectID(),
     company: authCompany._id,
     versions: [{
-      endDate: '2017-09-02T17:12:55.144Z',
+      endDate: '2017-09-02T17:12:55',
       grossHourlyRate: 10.12,
-      startDate: '2017-08-02T17:12:55.144Z',
+      startDate: '2017-08-02T00:00:00',
       weeklyHours: 15,
       _id: new ObjectID(),
     }],
@@ -318,18 +305,18 @@ const contractsList = [
   {
     serialNumber: 'sldfnasdlknfkds',
     user: contractUsers[3]._id,
-    startDate: '2018-08-02T17:12:55.144Z',
+    startDate: '2018-08-02T00:00:00',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T17:12:55.144Z', weeklyHours: 15, _id: new ObjectID() }],
+    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() }],
   },
   {
     serialNumber: 'lqwjrewjqpjefek',
     user: getUser('auxiliary_without_company')._id,
-    startDate: '2018-08-02T17:12:55.144Z',
+    startDate: '2018-08-02T00:00:00',
     _id: new ObjectID(),
     company: authCompany._id,
-    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T17:12:55.144Z', weeklyHours: 15, _id: new ObjectID() }],
+    versions: [{ grossHourlyRate: 10.12, startDate: '2018-08-02T00:00:00', weeklyHours: 15, _id: new ObjectID() }],
   },
 ];
 

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -537,17 +537,23 @@ describe('endContract', () => {
 
 describe('createVersion', () => {
   let generateSignatureRequest;
-  let ContractMock;
+  let findOneContract;
+  let updateOneContract;
+  let findOneAndUpdateContract;
   let canCreateVersion;
   beforeEach(() => {
     generateSignatureRequest = sinon.stub(ESignHelper, 'generateSignatureRequest');
-    ContractMock = sinon.mock(Contract);
+    findOneContract = sinon.stub(Contract, 'findOne');
+    updateOneContract = sinon.stub(Contract, 'updateOne');
+    findOneAndUpdateContract = sinon.stub(Contract, 'findOneAndUpdate');
     canCreateVersion = sinon.stub(ContractHelper, 'canCreateVersion');
   });
   afterEach(() => {
     generateSignatureRequest.restore();
-    ContractMock.restore();
     canCreateVersion.restore();
+    findOneContract.restore();
+    updateOneContract.restore();
+    findOneAndUpdateContract.restore();
   });
 
   it('should create version and update previous one', async () => {
@@ -560,28 +566,25 @@ describe('createVersion', () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
 
-    ContractMock.expects('findOne')
-      .withExactArgs({ _id: contract._id.toHexString() })
-      .chain('lean')
-      .once()
-      .returns(contract);
-    ContractMock.expects('updateOne')
-      .withExactArgs(
-        { _id: contract._id.toHexString() },
-        {
-          $set: { [`versions.${1}.endDate`]: moment('2019-09-13T00:00:00').subtract(1, 'd').endOf('d').toISOString() },
-        }
-      )
-      .once();
-    ContractMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: contract._id.toHexString() }, { $push: { versions: newVersion } })
-      .chain('lean')
-      .once();
+    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     canCreateVersion.returns(true);
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
 
-    ContractMock.verify();
+    SinonMongoose.calledWithExactly(
+      findOneContract,
+      [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
+    );
+    sinon.assert.calledOnceWithExactly(
+      updateOneContract,
+      { _id: contract._id.toHexString() },
+      { $set: { [`versions.${1}.endDate`]: moment('2019-09-13T00:00:00').subtract(1, 'd').endOf('d').toISOString() } }
+    );
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdateContract,
+      [{ query: 'findOneAndUpdate', args: [{ _id: contract._id.toHexString() }, { $push: { versions: newVersion } }] }]
+    );
     sinon.assert.notCalled(generateSignatureRequest);
     sinon.assert.calledOnceWithExactly(canCreateVersion, contract, newVersion, companyId);
   });
@@ -594,26 +597,28 @@ describe('createVersion', () => {
 
     generateSignatureRequest.returns({ data: { document_hash: '1234567890' } });
     canCreateVersion.returns(true);
-    ContractMock.expects('findOne')
-      .withExactArgs({ _id: contract._id.toHexString() })
-      .chain('lean')
-      .once()
-      .returns(contract);
-    ContractMock.expects('updateOne').never();
-    ContractMock.expects('findOneAndUpdate')
-      .withExactArgs(
-        { _id: contract._id.toHexString() },
-        { $push: { versions: { ...newVersion, signature: { eversignId: '1234567890' } } } }
-      )
-      .chain('lean')
-      .once()
-      .returns(contract);
+    findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+    findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
 
-    ContractMock.verify();
+    SinonMongoose.calledWithExactly(
+      findOneContract,
+      [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
+    );
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdateContract,
+      [{
+        query: 'findOneAndUpdate',
+        args: [
+          { _id: contract._id.toHexString() },
+          { $push: { versions: { ...newVersion, signature: { eversignId: '1234567890' } } } },
+        ],
+      }]
+    );
     sinon.assert.calledOnceWithExactly(generateSignatureRequest, { templateId: '1234567890' });
     sinon.assert.calledOnceWithExactly(canCreateVersion, contract, newVersion, companyId);
+    sinon.assert.notCalled(updateOneContract);
   });
 
   it('should throw on signature generation error', async () => {
@@ -623,13 +628,7 @@ describe('createVersion', () => {
     const credentials = { company: { _id: companyId } };
 
     try {
-      ContractMock.expects('findOne')
-        .withExactArgs({ _id: contract._id.toHexString() })
-        .chain('lean')
-        .once()
-        .returns(contract);
-      ContractMock.expects('findOneAndUpdate').never();
-      ContractMock.expects('updateOne').never();
+      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
       generateSignatureRequest.returns({ data: { error: { type: '1234567890' } } });
       canCreateVersion.returns(true);
 
@@ -637,9 +636,14 @@ describe('createVersion', () => {
     } catch (e) {
       expect(e.output.statusCode).toEqual(400);
     } finally {
+      SinonMongoose.calledWithExactly(
+        findOneContract,
+        [{ query: 'findOne', args: [{ _id: contract._id.toHexString() }] }]
+      );
       sinon.assert.calledOnceWithExactly(canCreateVersion, contract, newVersion, companyId);
       sinon.assert.calledWithExactly(generateSignatureRequest, { templateId: '1234567890' });
-      ContractMock.verify();
+      sinon.assert.notCalled(updateOneContract);
+      sinon.assert.notCalled(findOneAndUpdateContract);
     }
   });
 
@@ -650,13 +654,7 @@ describe('createVersion', () => {
     const credentials = { company: { _id: companyId } };
 
     try {
-      ContractMock.expects('findOne')
-        .withExactArgs({ _id: contract._id.toHexString() })
-        .chain('lean')
-        .once()
-        .returns(contract);
-      ContractMock.expects('findOneAndUpdate').never();
-      ContractMock.expects('updateOne').never();
+      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
       canCreateVersion.returns(false);
 
       await ContractHelper.createVersion(contract._id.toHexString(), newVersion, credentials);
@@ -665,7 +663,8 @@ describe('createVersion', () => {
     } finally {
       sinon.assert.calledOnceWithExactly(canCreateVersion, contract, newVersion, companyId);
       sinon.assert.notCalled(generateSignatureRequest);
-      ContractMock.verify();
+      sinon.assert.notCalled(updateOneContract);
+      sinon.assert.notCalled(findOneAndUpdateContract);
     }
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - ~~J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - ~~[ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent~~

- ~~[ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):~~
  - ~~[ ] Affichage des pages explorer/mes formations/About/CourseProfile~~
  - ~~[ ] Inscription a une formation e-learning~~
  - ~~[ ] Possibilité de faire une activité~~

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - ~~J'ai ajoute un champ possible :~~
    - ~~[ ] J'ai géré le cas ou on ne l'envoie pas~~
  - ~~J'ai rendu obligatoire un champs :~~
    - ~~[ ] Il est toujours envoyé par le mobile (même par les anciennes versions)~~
  - ~~J'ai retiré un champ possible :~~
    - ~~[ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas~~

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - ~~[ ] J'ai précisé sur le slite de MES et MEP les modifications faites~~


- Périmetre interface : Client

- Périmetre roles : Coach

- Cas d'usage : Quand je cree une version de contrat, elle ets forcement posterieur a la date de debut de la version precedente
