### PR TITLE
Com 1956

### DIFF
--- a/src/controllers/programController.js
+++ b/src/controllers/programController.js
@@ -128,6 +128,17 @@ const removeCategory = async (req) => {
   }
 };
 
+const addTester = async (req) => {
+  try {
+    await ProgramHelper.addTester(req.params._id, req.payload);
+
+    return { message: translate[language].testerAdded };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
 module.exports = {
   list,
   listELearning,
@@ -139,4 +150,5 @@ module.exports = {
   deleteImage,
   addCategory,
   removeCategory,
+  addTester,
 };

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -2,8 +2,10 @@ const flat = require('flat');
 const { get } = require('lodash');
 const Course = require('../models/Course');
 const Program = require('../models/Program');
+const User = require('../models/User');
 const GCloudStorageHelper = require('./gCloudStorage');
-const { STRICTLY_E_LEARNING } = require('./constants');
+const UsersHelper = require('./users');
+const { STRICTLY_E_LEARNING, WEBAPP } = require('./constants');
 
 exports.createProgram = async payload => Program.create(payload);
 
@@ -81,3 +83,11 @@ exports.addCategory = async (programId, payload) =>
 
 exports.removeCategory = async (programId, categoryId) =>
   Program.updateOne({ _id: programId }, { $pull: { categories: categoryId } });
+
+exports.addTester = async (programId, payload) => {
+  const user = await User.findOne({ 'local.email': payload.local.email }).lean();
+  const addedTester = user || await UsersHelper.createUser({ ...payload, origin: WEBAPP });
+
+  return Program.findOneAndUpdate({ _id: programId }, { $addToSet: { testers: addedTester._id } }, { new: true })
+    .lean();
+};

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -48,7 +48,8 @@ exports.getProgram = async (programId) => {
       path: 'subPrograms',
       populate: { path: 'steps', populate: [{ path: 'activities ', populate: 'cards' }, { path: 'courseSlotsCount' }] },
     })
-    .populate({ path: 'categories' })
+    .populate({ path: 'testers', select: 'identity.firstname identity.lastname local.email contact.phone' })
+    .populate('categories')
     .lean({ virtuals: true });
 
   return {

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -224,6 +224,7 @@ module.exports = {
     programFound: 'Program found.',
     programUpdated: 'Program updated.',
     testerAdded: 'Tester added to program.',
+    testerConflict: 'Tester already added to program.',
     /* Categories */
     categoriesFound: 'Categories found.',
     categoriesNotFound: 'Categories not found.',
@@ -505,6 +506,7 @@ module.exports = {
     programFound: 'Programme trouvé.',
     programUpdated: 'Programme mis à jour.',
     testerAdded: 'Testeur ajouté au programme.',
+    testerConflict: 'Testeur déjà ajouté au programme.',
     /* Categories */
     categoriesFound: 'Catégories trouvées.',
     categoriesNotFound: 'Catégories non trouvées.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -223,6 +223,7 @@ module.exports = {
     programCreated: 'Program created.',
     programFound: 'Program found.',
     programUpdated: 'Program updated.',
+    testerAdded: 'Tester added to program.',
     /* Categories */
     categoriesFound: 'Categories found.',
     categoriesNotFound: 'Categories not found.',
@@ -503,6 +504,7 @@ module.exports = {
     programCreated: 'Programme créé.',
     programFound: 'Programme trouvé.',
     programUpdated: 'Programme mis à jour.',
+    testerAdded: 'Testeur ajouté au programme.',
     /* Categories */
     categoriesFound: 'Catégories trouvées.',
     categoriesNotFound: 'Catégories non trouvées.',

--- a/src/models/Program.js
+++ b/src/models/Program.js
@@ -10,6 +10,7 @@ const ProgramSchema = mongoose.Schema({
     publicId: String,
     link: { type: String, trim: true },
   },
+  testers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
 }, { timestamps: true });
 
 module.exports = mongoose.model('Program', ProgramSchema);

--- a/src/routes/preHandlers/programs.js
+++ b/src/routes/preHandlers/programs.js
@@ -3,7 +3,6 @@ const get = require('lodash/get');
 const Program = require('../../models/Program');
 const Category = require('../../models/Category');
 const User = require('../../models/User');
-const Utils = require('../../helpers/utils');
 const translate = require('../../helpers/translate');
 
 const { language } = translate;

--- a/src/routes/preHandlers/programs.js
+++ b/src/routes/preHandlers/programs.js
@@ -38,10 +38,8 @@ exports.authorizeTesterAddition = async (req) => {
   if (!user && !(get(payload, 'identity.lastname') && get(payload, 'contact.phone'))) throw Boom.badRequest();
 
   if (user) {
-    const program = await Program.findOne({ _id: req.params._id }).lean();
-    if (program.testers.some(tester => Utils.areObjectIdsEquals(tester._id, user._id))) {
-      throw Boom.conflict(translate[language].testerConflict);
-    }
+    const program = await Program.countDocuments({ _id: req.params._id, testers: user._id });
+    if (program) throw Boom.conflict(translate[language].testerConflict);
   }
 
   return null;

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -175,7 +175,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object({
-            identity: Joi.object().keys({ firstname: Joi.string(), lastname: Joi.string() }),
+            identity: Joi.object().keys({ firstname: Joi.string().allow(''), lastname: Joi.string() }),
             local: Joi.object().keys({ email: Joi.string().email().required() }).required(),
             contact: Joi.object().keys({ phone: phoneNumberValidation }),
           }),

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -2,7 +2,12 @@
 
 const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
-const { checkProgramExists, getProgramImagePublicId, checkCategoryExists } = require('./preHandlers/programs');
+const {
+  checkProgramExists,
+  getProgramImagePublicId,
+  checkCategoryExists,
+  authorizeTesterAddition,
+} = require('./preHandlers/programs');
 const {
   list,
   listELearning,
@@ -181,7 +186,7 @@ exports.plugin = {
           }),
         },
         auth: { scope: ['programs:edit'] },
-        pre: [{ method: checkProgramExists }],
+        pre: [{ method: checkProgramExists }, { method: authorizeTesterAddition }],
       },
       handler: addTester,
     });

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -14,8 +14,9 @@ const {
   deleteImage,
   addCategory,
   removeCategory,
+  addTester,
 } = require('../controllers/programController');
-const { formDataPayload } = require('./validations/utils');
+const { formDataPayload, phoneNumberValidation } = require('./validations/utils');
 
 exports.plugin = {
   name: 'routes-programs',
@@ -165,6 +166,24 @@ exports.plugin = {
         auth: { scope: ['programs:edit'] },
         pre: [{ method: getProgramImagePublicId, assign: 'publicId' }],
       },
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/{_id}/tester',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+          payload: Joi.object({
+            identity: Joi.object().keys({ firstname: Joi.string(), lastname: Joi.string() }),
+            local: Joi.object().keys({ email: Joi.string().email().required() }).required(),
+            contact: Joi.object().keys({ phone: phoneNumberValidation }),
+          }),
+        },
+        auth: { scope: ['programs:edit'] },
+        pre: [{ method: checkProgramExists }],
+      },
+      handler: addTester,
     });
   },
 };

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -175,7 +175,7 @@ exports.plugin = {
 
     server.route({
       method: 'POST',
-      path: '/{_id}/tester',
+      path: '/{_id}/testers',
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -23,771 +23,771 @@ describe('NODE ENV', () => {
   });
 });
 
-describe('PROGRAMS ROUTES - POST /programs', () => {
-  let authToken;
-  beforeEach(populateDB);
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should create program', async () => {
-      const categoryId = categoriesList[0]._id;
-      const response = await app.inject({
-        method: 'POST',
-        url: '/programs',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { name: 'program', categories: [categoryId] },
-      });
-
-      expect(response.statusCode).toBe(200);
-    });
-
-    it('should return 404 if wrong category id', async () => {
-      const response = await app.inject({
-        method: 'POST',
-        url: '/programs',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { name: 'program', categories: [new ObjectID()] },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const categoryId = categoriesList[0]._id;
-        const response = await app.inject({
-          method: 'POST',
-          url: '/programs',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-          payload: { name: 'program', categories: [categoryId] },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - GET /programs', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should get all programs', async () => {
-      const programsNumber = programsList.length;
-      const response = await app.inject({
-        method: 'GET',
-        url: '/programs',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.result.data.programs.length).toEqual(programsNumber);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const response = await app.inject({
-          method: 'GET',
-          url: '/programs',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - GET /programs/e-learning', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should get all programs', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/programs/e-learning',
-        headers: { 'x-access-token': authToken },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.result.data.programs.length).toEqual(1);
-      const coursesIds = response.result.data.programs[0].subPrograms[0].courses.map(c => c._id);
-
-      const courses = await Course.find({ _id: { $in: coursesIds } }).lean();
-      expect(courses.every(c => c.format === 'strictly_e_learning')).toBeTruthy();
-    });
-
-    it('should return 401 if user is not connected', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/programs/e-learning',
-        headers: { 'x-access-token': '' },
-      });
-
-      expect(response.statusCode).toBe(401);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 200 },
-      { name: 'auxiliary', expectedCode: 200 },
-      { name: 'auxiliary_without_company', expectedCode: 200 },
-      { name: 'coach', expectedCode: 200 },
-      { name: 'client_admin', expectedCode: 200 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 200 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const response = await app.inject({
-          method: 'GET',
-          url: '/programs/e-learning',
-          headers: { 'x-access-token': authToken },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should get program', async () => {
-      const programId = programsList[0]._id;
-      const response = await app.inject({
-        method: 'GET',
-        url: `/programs/${programId.toHexString()}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.result.data.program).toMatchObject({
-        _id: programId,
-        name: 'program',
-        subPrograms: [{
-          name: 'c\'est un sous-programme',
-          steps: [{
-            type: 'on_site',
-            name: 'encore une étape',
-            areActivitiesValid: true,
-            activities: [{
-              name: 'c\'est une activité',
-              type: 'sharing_experience',
-              areCardsValid: true,
-            }],
-          }],
-        }],
-      });
-    });
-
-    it('should return 404 if program does not exists', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/programs/${new ObjectID()}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should get program with non valid activities and non valid steps', async () => {
-      const programId = programsList[2]._id;
-      const response = await app.inject({
-        method: 'GET',
-        url: `/programs/${programId.toHexString()}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.result.data.program).toMatchObject({
-        _id: programId,
-        name: 'non valid program',
-        subPrograms: [{
-          name: 'c\'est un sous-programme',
-          steps: [{
-            type: 'on_site',
-            name: 'encore une étape',
-            areActivitiesValid: false,
-            activities: [{ areCardsValid: false }],
-          }],
-        }],
-      });
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const programId = programsList[0]._id;
-        const response = await app.inject({
-          method: 'GET',
-          url: `/programs/${programId.toHexString()}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - PUT /programs/{_id}', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should update program', async () => {
-      const programId = programsList[0]._id;
-      const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
-
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/programs/${programId.toHexString()}`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      const programUpdated = await Program.findById(programId);
-
-      expect(response.statusCode).toBe(200);
-      expect(programUpdated._id).toEqual(programId);
-      expect(programUpdated.name).toEqual('new name');
-      expect(programUpdated.description).toEqual('On apprend des trucs\nc\'est chouette');
-    });
-
-    it('should return 404 if program does not exist', async () => {
-      const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/programs/${new ObjectID()}`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return 400 if payload is empty', async () => {
-      const programId = programsList[0]._id;
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/programs/${programId.toHexString()}`,
-        payload: {},
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
-    const falsyParams = ['name', 'description', 'learningGoals'];
-    falsyParams.forEach((param) => {
-      it(`should return a 400 if ${param} is equal to '' `, async () => {
-        const programId = programsList[0]._id;
-        const payload = { name: 'new name', description: 'Trop top', learningGoals: 'Truc chouette' };
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/programs/${programId.toHexString()}`,
-          payload: { ...payload, [param]: '' },
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(400);
-      });
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const programId = programsList[0]._id;
-        const response = await app.inject({
-          method: 'PUT',
-          payload: { learningGoals: 'On apprend des trucs\nc\'est chouette' },
-          url: `/programs/${programId.toHexString()}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - POST /programs/{_id}/subprogram', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-  const payload = { name: 'new subProgram' };
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should create subProgram', async () => {
-      const programId = programsList[0]._id;
-      const subProgramLengthBefore = programsList[0].subPrograms.length;
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${programId.toHexString()}/subprograms`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      const programUpdated = await Program.findById(programId);
-
-      expect(response.statusCode).toBe(200);
-      expect(programUpdated._id).toEqual(programId);
-      expect(programUpdated.subPrograms.length).toEqual(subProgramLengthBefore + 1);
-    });
-
-    it('should return 404 if program does not exist', async () => {
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${new ObjectID()}/subprograms`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return a 400 if missing name', async () => {
-      const programId = programsList[0]._id;
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${programId.toHexString()}/subprograms`,
-        payload: omit(payload, 'name'),
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
-    it('should return a 400 if program does not exist', async () => {
-      const invalidId = new ObjectID();
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${invalidId}/subprograms`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const programId = programsList[0]._id;
-        const response = await app.inject({
-          method: 'POST',
-          payload,
-          url: `/programs/${programId.toHexString()}/subprograms`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - POST /programs/:id/upload', () => {
-  let authToken;
-  let uploadProgramMediaStub;
-  const program = programsList[0];
-  beforeEach(() => {
-    uploadProgramMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
-  });
-  afterEach(() => {
-    uploadProgramMediaStub.restore();
-  });
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(populateDB);
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should add a program image', async () => {
-      uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
-
-      const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${program._id}/upload`,
-        payload: await GetStream(form),
-        headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-      });
-
-      const programUpdated = await Program.findById(program._id, { name: 1, image: 1 }).lean();
-
-      expect(response.statusCode).toBe(200);
-      expect(programUpdated).toMatchObject({
-        ...pick(program, ['_id', 'name']),
-        image: { publicId: 'abcdefgh', link: 'https://alenvi.io' },
-      });
-      sinon.assert.calledOnceWithExactly(uploadProgramMediaStub, { fileName: 'program_image_test', file: 'true' });
-    });
-
-    it('should return 404 if program does not exist', async () => {
-      const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${new ObjectID()}/upload`,
-        payload: await GetStream(form),
-        headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    const wrongParams = ['file', 'fileName'];
-    wrongParams.forEach((param) => {
-      it(`should return a 400 error if missing '${param}' parameter`, async () => {
-        const invalidForm = generateFormData(omit({ fileName: 'program_image_test', file: 'true' }, param));
-        const response = await app.inject({
-          method: 'POST',
-          url: `/programs/${program._id}/upload`,
-          payload: await GetStream(invalidForm),
-          headers: { ...invalidForm.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(400);
-      });
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-        authToken = await getToken(role.name);
-        uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
-
-        const response = await app.inject({
-          method: 'POST',
-          url: `/programs/${program._id}/upload`,
-          payload: await GetStream(form),
-          headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
-  let authToken;
-  let deleteProgramMediaStub;
-  beforeEach(() => {
-    deleteProgramMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
-  });
-  afterEach(() => {
-    deleteProgramMediaStub.restore();
-  });
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(populateDB);
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should delete a program media', async () => {
-      const program = programsList[0];
-      const imageExistsBeforeUpdate = await Program
-        .countDocuments({ _id: program._id, 'image.publicId': { $exists: true } });
-
-      const response = await app.inject({
-        method: 'DELETE',
-        url: `/programs/${program._id}/upload`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'au revoir');
-
-      const isPictureDeleted = await Program.countDocuments({ _id: program._id, 'image.publicId': { $exists: false } });
-      expect(imageExistsBeforeUpdate).toBeTruthy();
-      expect(isPictureDeleted).toBeTruthy();
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const program = programsList[0];
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/programs/${program._id}/upload`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - POST /programs/{_id}/categories', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-  const programId = programsList[0]._id;
-  const payload = { categoryId: categoriesList[1]._id };
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should add category', async () => {
-      const categoryLengthBefore = programsList[0].categories.length;
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${programId.toHexString()}/categories`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      const programUpdated = await Program.findById(programId);
-
-      expect(response.statusCode).toBe(200);
-      expect(programUpdated._id).toEqual(programId);
-      expect(programUpdated.categories.length).toEqual(categoryLengthBefore + 1);
-    });
-
-    it('should return 404 if program does not exist', async () => {
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${new ObjectID()}/categories`,
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return a 404 if category does not exist', async () => {
-      const response = await app.inject({
-        method: 'POST',
-        url: `/programs/${programId.toHexString()}/categories`,
-        payload: { categoryId: new ObjectID() },
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const response = await app.inject({
-          method: 'POST',
-          payload,
-          url: `/programs/${programId.toHexString()}/categories`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
-
-describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
-  let authToken = null;
-  beforeEach(populateDB);
-
-  describe('VENDOR_ADMIN', () => {
-    beforeEach(async () => {
-      authToken = await getToken('vendor_admin');
-    });
-
-    it('should remove category from program', async () => {
-      const programId = programsList[0]._id;
-      const categoryLengthBefore = programsList[0].categories.length;
-      const response = await app.inject({
-        method: 'DELETE',
-        url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      await Program.findById(programId);
-
-      expect(response.statusCode).toBe(200);
-      const programUpdated = await Program.findOne({ _id: programId }).lean();
-      expect(programUpdated.categories.length).toEqual(categoryLengthBefore - 1);
-      expect(programUpdated.categories.some(c => c._id === programsList[0].categories[0]._id)).toBeFalsy();
-    });
-
-    it('should return a 404 if program does not exist', async () => {
-      const programId = new ObjectID();
-      const response = await app.inject({
-        method: 'DELETE',
-        url: `/programs/${programId}/categories/${programsList[0].categories[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return a 404 if program does not contain category', async () => {
-      const categoryId = new ObjectID();
-      const response = await app.inject({
-        method: 'DELETE',
-        url: `/programs/${programsList[0]._id}/categories/${categoryId}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-  });
-
-  describe('Other roles', () => {
-    const roles = [
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const programId = programsList[0]._id;
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
-      });
-    });
-  });
-});
+// describe('PROGRAMS ROUTES - POST /programs', () => {
+//   let authToken;
+//   beforeEach(populateDB);
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should create program', async () => {
+//       const categoryId = categoriesList[0]._id;
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: '/programs',
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//         payload: { name: 'program', categories: [categoryId] },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//     });
+
+//     it('should return 404 if wrong category id', async () => {
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: '/programs',
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//         payload: { name: 'program', categories: [new ObjectID()] },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const categoryId = categoriesList[0]._id;
+//         const response = await app.inject({
+//           method: 'POST',
+//           url: '/programs',
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//           payload: { name: 'program', categories: [categoryId] },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - GET /programs', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should get all programs', async () => {
+//       const programsNumber = programsList.length;
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: '/programs',
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//       expect(response.result.data.programs.length).toEqual(programsNumber);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const response = await app.inject({
+//           method: 'GET',
+//           url: '/programs',
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - GET /programs/e-learning', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should get all programs', async () => {
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: '/programs/e-learning',
+//         headers: { 'x-access-token': authToken },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//       expect(response.result.data.programs.length).toEqual(1);
+//       const coursesIds = response.result.data.programs[0].subPrograms[0].courses.map(c => c._id);
+
+//       const courses = await Course.find({ _id: { $in: coursesIds } }).lean();
+//       expect(courses.every(c => c.format === 'strictly_e_learning')).toBeTruthy();
+//     });
+
+//     it('should return 401 if user is not connected', async () => {
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: '/programs/e-learning',
+//         headers: { 'x-access-token': '' },
+//       });
+
+//       expect(response.statusCode).toBe(401);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 200 },
+//       { name: 'auxiliary', expectedCode: 200 },
+//       { name: 'auxiliary_without_company', expectedCode: 200 },
+//       { name: 'coach', expectedCode: 200 },
+//       { name: 'client_admin', expectedCode: 200 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 200 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const response = await app.inject({
+//           method: 'GET',
+//           url: '/programs/e-learning',
+//           headers: { 'x-access-token': authToken },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should get program', async () => {
+//       const programId = programsList[0]._id;
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: `/programs/${programId.toHexString()}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//       expect(response.result.data.program).toMatchObject({
+//         _id: programId,
+//         name: 'program',
+//         subPrograms: [{
+//           name: 'c\'est un sous-programme',
+//           steps: [{
+//             type: 'on_site',
+//             name: 'encore une étape',
+//             areActivitiesValid: true,
+//             activities: [{
+//               name: 'c\'est une activité',
+//               type: 'sharing_experience',
+//               areCardsValid: true,
+//             }],
+//           }],
+//         }],
+//       });
+//     });
+
+//     it('should return 404 if program does not exists', async () => {
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: `/programs/${new ObjectID()}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     it('should get program with non valid activities and non valid steps', async () => {
+//       const programId = programsList[2]._id;
+//       const response = await app.inject({
+//         method: 'GET',
+//         url: `/programs/${programId.toHexString()}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//       expect(response.result.data.program).toMatchObject({
+//         _id: programId,
+//         name: 'non valid program',
+//         subPrograms: [{
+//           name: 'c\'est un sous-programme',
+//           steps: [{
+//             type: 'on_site',
+//             name: 'encore une étape',
+//             areActivitiesValid: false,
+//             activities: [{ areCardsValid: false }],
+//           }],
+//         }],
+//       });
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const programId = programsList[0]._id;
+//         const response = await app.inject({
+//           method: 'GET',
+//           url: `/programs/${programId.toHexString()}`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - PUT /programs/{_id}', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should update program', async () => {
+//       const programId = programsList[0]._id;
+//       const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
+
+//       const response = await app.inject({
+//         method: 'PUT',
+//         url: `/programs/${programId.toHexString()}`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       const programUpdated = await Program.findById(programId);
+
+//       expect(response.statusCode).toBe(200);
+//       expect(programUpdated._id).toEqual(programId);
+//       expect(programUpdated.name).toEqual('new name');
+//       expect(programUpdated.description).toEqual('On apprend des trucs\nc\'est chouette');
+//     });
+
+//     it('should return 404 if program does not exist', async () => {
+//       const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
+//       const response = await app.inject({
+//         method: 'PUT',
+//         url: `/programs/${new ObjectID()}`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     it('should return 400 if payload is empty', async () => {
+//       const programId = programsList[0]._id;
+//       const response = await app.inject({
+//         method: 'PUT',
+//         url: `/programs/${programId.toHexString()}`,
+//         payload: {},
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(400);
+//     });
+
+//     const falsyParams = ['name', 'description', 'learningGoals'];
+//     falsyParams.forEach((param) => {
+//       it(`should return a 400 if ${param} is equal to '' `, async () => {
+//         const programId = programsList[0]._id;
+//         const payload = { name: 'new name', description: 'Trop top', learningGoals: 'Truc chouette' };
+//         const response = await app.inject({
+//           method: 'PUT',
+//           url: `/programs/${programId.toHexString()}`,
+//           payload: { ...payload, [param]: '' },
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(400);
+//       });
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const programId = programsList[0]._id;
+//         const response = await app.inject({
+//           method: 'PUT',
+//           payload: { learningGoals: 'On apprend des trucs\nc\'est chouette' },
+//           url: `/programs/${programId.toHexString()}`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - POST /programs/{_id}/subprogram', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+//   const payload = { name: 'new subProgram' };
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should create subProgram', async () => {
+//       const programId = programsList[0]._id;
+//       const subProgramLengthBefore = programsList[0].subPrograms.length;
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${programId.toHexString()}/subprograms`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       const programUpdated = await Program.findById(programId);
+
+//       expect(response.statusCode).toBe(200);
+//       expect(programUpdated._id).toEqual(programId);
+//       expect(programUpdated.subPrograms.length).toEqual(subProgramLengthBefore + 1);
+//     });
+
+//     it('should return 404 if program does not exist', async () => {
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${new ObjectID()}/subprograms`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     it('should return a 400 if missing name', async () => {
+//       const programId = programsList[0]._id;
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${programId.toHexString()}/subprograms`,
+//         payload: omit(payload, 'name'),
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(400);
+//     });
+
+//     it('should return a 400 if program does not exist', async () => {
+//       const invalidId = new ObjectID();
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${invalidId}/subprograms`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const programId = programsList[0]._id;
+//         const response = await app.inject({
+//           method: 'POST',
+//           payload,
+//           url: `/programs/${programId.toHexString()}/subprograms`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - POST /programs/:id/upload', () => {
+//   let authToken;
+//   let uploadProgramMediaStub;
+//   const program = programsList[0];
+//   beforeEach(() => {
+//     uploadProgramMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
+//   });
+//   afterEach(() => {
+//     uploadProgramMediaStub.restore();
+//   });
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(populateDB);
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should add a program image', async () => {
+//       uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
+
+//       const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${program._id}/upload`,
+//         payload: await GetStream(form),
+//         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       const programUpdated = await Program.findById(program._id, { name: 1, image: 1 }).lean();
+
+//       expect(response.statusCode).toBe(200);
+//       expect(programUpdated).toMatchObject({
+//         ...pick(program, ['_id', 'name']),
+//         image: { publicId: 'abcdefgh', link: 'https://alenvi.io' },
+//       });
+//       sinon.assert.calledOnceWithExactly(uploadProgramMediaStub, { fileName: 'program_image_test', file: 'true' });
+//     });
+
+//     it('should return 404 if program does not exist', async () => {
+//       const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${new ObjectID()}/upload`,
+//         payload: await GetStream(form),
+//         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     const wrongParams = ['file', 'fileName'];
+//     wrongParams.forEach((param) => {
+//       it(`should return a 400 error if missing '${param}' parameter`, async () => {
+//         const invalidForm = generateFormData(omit({ fileName: 'program_image_test', file: 'true' }, param));
+//         const response = await app.inject({
+//           method: 'POST',
+//           url: `/programs/${program._id}/upload`,
+//           payload: await GetStream(invalidForm),
+//           headers: { ...invalidForm.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(400);
+//       });
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+//         authToken = await getToken(role.name);
+//         uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
+
+//         const response = await app.inject({
+//           method: 'POST',
+//           url: `/programs/${program._id}/upload`,
+//           payload: await GetStream(form),
+//           headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
+//   let authToken;
+//   let deleteProgramMediaStub;
+//   beforeEach(() => {
+//     deleteProgramMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
+//   });
+//   afterEach(() => {
+//     deleteProgramMediaStub.restore();
+//   });
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(populateDB);
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should delete a program media', async () => {
+//       const program = programsList[0];
+//       const imageExistsBeforeUpdate = await Program
+//         .countDocuments({ _id: program._id, 'image.publicId': { $exists: true } });
+
+//       const response = await app.inject({
+//         method: 'DELETE',
+//         url: `/programs/${program._id}/upload`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(200);
+//       sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'au revoir');
+
+//       const isPictureDeleted = await Program.countDocuments({ _id: program._id, 'image.publicId': { $exists: false } });
+//       expect(imageExistsBeforeUpdate).toBeTruthy();
+//       expect(isPictureDeleted).toBeTruthy();
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const program = programsList[0];
+//         const response = await app.inject({
+//           method: 'DELETE',
+//           url: `/programs/${program._id}/upload`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - POST /programs/{_id}/categories', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+//   const programId = programsList[0]._id;
+//   const payload = { categoryId: categoriesList[1]._id };
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should add category', async () => {
+//       const categoryLengthBefore = programsList[0].categories.length;
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${programId.toHexString()}/categories`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       const programUpdated = await Program.findById(programId);
+
+//       expect(response.statusCode).toBe(200);
+//       expect(programUpdated._id).toEqual(programId);
+//       expect(programUpdated.categories.length).toEqual(categoryLengthBefore + 1);
+//     });
+
+//     it('should return 404 if program does not exist', async () => {
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${new ObjectID()}/categories`,
+//         payload,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     it('should return a 404 if category does not exist', async () => {
+//       const response = await app.inject({
+//         method: 'POST',
+//         url: `/programs/${programId.toHexString()}/categories`,
+//         payload: { categoryId: new ObjectID() },
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const response = await app.inject({
+//           method: 'POST',
+//           payload,
+//           url: `/programs/${programId.toHexString()}/categories`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
+
+// describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
+//   let authToken = null;
+//   beforeEach(populateDB);
+
+//   describe('VENDOR_ADMIN', () => {
+//     beforeEach(async () => {
+//       authToken = await getToken('vendor_admin');
+//     });
+
+//     it('should remove category from program', async () => {
+//       const programId = programsList[0]._id;
+//       const categoryLengthBefore = programsList[0].categories.length;
+//       const response = await app.inject({
+//         method: 'DELETE',
+//         url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       await Program.findById(programId);
+
+//       expect(response.statusCode).toBe(200);
+//       const programUpdated = await Program.findOne({ _id: programId }).lean();
+//       expect(programUpdated.categories.length).toEqual(categoryLengthBefore - 1);
+//       expect(programUpdated.categories.some(c => c._id === programsList[0].categories[0]._id)).toBeFalsy();
+//     });
+
+//     it('should return a 404 if program does not exist', async () => {
+//       const programId = new ObjectID();
+//       const response = await app.inject({
+//         method: 'DELETE',
+//         url: `/programs/${programId}/categories/${programsList[0].categories[0]._id}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+
+//     it('should return a 404 if program does not contain category', async () => {
+//       const categoryId = new ObjectID();
+//       const response = await app.inject({
+//         method: 'DELETE',
+//         url: `/programs/${programsList[0]._id}/categories/${categoryId}`,
+//         headers: { Cookie: `alenvi_token=${authToken}` },
+//       });
+
+//       expect(response.statusCode).toBe(404);
+//     });
+//   });
+
+//   describe('Other roles', () => {
+//     const roles = [
+//       { name: 'training_organisation_manager', expectedCode: 200 },
+//       { name: 'helper', expectedCode: 403 },
+//       { name: 'auxiliary', expectedCode: 403 },
+//       { name: 'auxiliary_without_company', expectedCode: 403 },
+//       { name: 'coach', expectedCode: 403 },
+//       { name: 'client_admin', expectedCode: 403 },
+//       { name: 'trainer', expectedCode: 403 },
+//     ];
+
+//     roles.forEach((role) => {
+//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+//         authToken = await getToken(role.name);
+//         const programId = programsList[0]._id;
+//         const response = await app.inject({
+//           method: 'DELETE',
+//           url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
+//           headers: { Cookie: `alenvi_token=${authToken}` },
+//         });
+
+//         expect(response.statusCode).toBe(role.expectedCode);
+//       });
+//     });
+//   });
+// });
 
 describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
   let authToken;
@@ -817,7 +817,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
       expect(program.testers).toHaveLength(1);
     });
 
-    it('should add an existing user a program', async () => {
+    it('should add an existing user to a program', async () => {
       const programId = programsList[0]._id;
       const payload = pick(vendorAdmin, ['local.email', 'identity.firstname', 'identity.lastname', 'contact.phone']);
 
@@ -847,21 +847,63 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
     });
 
     it('should return a 400 if missing email', async () => {
-      const programId = programsList[0]._id;
       const payload = {
         identity: { lastname: 'test', firstname: 'test' },
+        contact: { phone: '0123456789' },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 if user does not exist and missing lastname', async () => {
+      const payload = {
+        identity: { firstname: 'test' },
         local: { email: 'test@alenvi.io' },
         contact: { phone: '0123456789' },
       };
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programId.toHexString()}/tester`,
+        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
         headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: omit(payload, 'local.email'),
+        payload,
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 if user does not exist and missing phone', async () => {
+      const payload = {
+        identity: { firstname: 'test', lastname: 'oiuy' },
+        local: { email: 'test@alenvi.io' },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 409 if user already is a tester for this program', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programsList[1]._id.toHexString()}/tester`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: pick(vendorAdmin, 'local.email'),
+      });
+
+      expect(response.statusCode).toBe(409);
     });
   });
 
@@ -880,10 +922,9 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = await getToken(role.name);
-        const programId = programsList[0]._id;
         const response = await app.inject({
           method: 'POST',
-          url: `/programs/${programId.toHexString()}/tester`,
+          url: `/programs/${programsList[0]._id.toHexString()}/tester`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload,
         });

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -789,7 +789,7 @@ describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
   });
 });
 
-describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
+describe('PROGRAMS ROUTES - POST /{_id}/testers', () => {
   let authToken;
   beforeEach(populateDB);
   describe('ROF', () => {
@@ -807,7 +807,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programId.toHexString()}/tester`,
+        url: `/programs/${programId.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -823,7 +823,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programId.toHexString()}/tester`,
+        url: `/programs/${programId.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -838,7 +838,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${new ObjectID()}/tester`,
+        url: `/programs/${new ObjectID()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -854,7 +854,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+        url: `/programs/${programsList[0]._id.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -871,7 +871,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+        url: `/programs/${programsList[0]._id.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -887,7 +887,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
 
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+        url: `/programs/${programsList[0]._id.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
@@ -898,7 +898,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
     it('should return a 409 if user already is a tester for this program', async () => {
       const response = await app.inject({
         method: 'POST',
-        url: `/programs/${programsList[1]._id.toHexString()}/tester`,
+        url: `/programs/${programsList[1]._id.toHexString()}/testers`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload: pick(vendorAdmin, 'local.email'),
       });
@@ -924,7 +924,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'POST',
-          url: `/programs/${programsList[0]._id.toHexString()}/tester`,
+          url: `/programs/${programsList[0]._id.toHexString()}/testers`,
           headers: { Cookie: `alenvi_token=${authToken}` },
           payload,
         });

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -846,26 +846,22 @@ describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    let payload = {
-      identity: { lastname: 'test', firstname: 'test' },
-      local: { email: 'test@alenvi.io' },
-      contact: { phone: '0123456789' },
-    };
-    const missingParams = ['local.email', 'identity.firstname', 'identity.lastname', 'contact.phone'];
-    missingParams.forEach((param) => {
-      it(`should return a 400 if missing ${param}`, async () => {
-        const programId = programsList[0]._id;
-        payload = omit(payload, param);
+    it('should return a 400 if missing email', async () => {
+      const programId = programsList[0]._id;
+      const payload = {
+        identity: { lastname: 'test', firstname: 'test' },
+        local: { email: 'test@alenvi.io' },
+        contact: { phone: '0123456789' },
+      };
 
-        const response = await app.inject({
-          method: 'POST',
-          url: `/programs/${programId.toHexString()}/tester`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-          payload,
-        });
-
-        expect(response.statusCode).toBe(400);
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programId.toHexString()}/tester`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: omit(payload, 'local.email'),
       });
+
+      expect(response.statusCode).toBe(400);
     });
   });
 

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -23,771 +23,771 @@ describe('NODE ENV', () => {
   });
 });
 
-// describe('PROGRAMS ROUTES - POST /programs', () => {
-//   let authToken;
-//   beforeEach(populateDB);
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should create program', async () => {
-//       const categoryId = categoriesList[0]._id;
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: '/programs',
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//         payload: { name: 'program', categories: [categoryId] },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//     });
-
-//     it('should return 404 if wrong category id', async () => {
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: '/programs',
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//         payload: { name: 'program', categories: [new ObjectID()] },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const categoryId = categoriesList[0]._id;
-//         const response = await app.inject({
-//           method: 'POST',
-//           url: '/programs',
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//           payload: { name: 'program', categories: [categoryId] },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - GET /programs', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should get all programs', async () => {
-//       const programsNumber = programsList.length;
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: '/programs',
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.programs.length).toEqual(programsNumber);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: '/programs',
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - GET /programs/e-learning', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should get all programs', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: '/programs/e-learning',
-//         headers: { 'x-access-token': authToken },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.programs.length).toEqual(1);
-//       const coursesIds = response.result.data.programs[0].subPrograms[0].courses.map(c => c._id);
-
-//       const courses = await Course.find({ _id: { $in: coursesIds } }).lean();
-//       expect(courses.every(c => c.format === 'strictly_e_learning')).toBeTruthy();
-//     });
-
-//     it('should return 401 if user is not connected', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: '/programs/e-learning',
-//         headers: { 'x-access-token': '' },
-//       });
-
-//       expect(response.statusCode).toBe(401);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 200 },
-//       { name: 'auxiliary', expectedCode: 200 },
-//       { name: 'auxiliary_without_company', expectedCode: 200 },
-//       { name: 'coach', expectedCode: 200 },
-//       { name: 'client_admin', expectedCode: 200 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 200 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: '/programs/e-learning',
-//           headers: { 'x-access-token': authToken },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should get program', async () => {
-//       const programId = programsList[0]._id;
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/programs/${programId.toHexString()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.program).toMatchObject({
-//         _id: programId,
-//         name: 'program',
-//         subPrograms: [{
-//           name: 'c\'est un sous-programme',
-//           steps: [{
-//             type: 'on_site',
-//             name: 'encore une étape',
-//             areActivitiesValid: true,
-//             activities: [{
-//               name: 'c\'est une activité',
-//               type: 'sharing_experience',
-//               areCardsValid: true,
-//             }],
-//           }],
-//         }],
-//       });
-//     });
-
-//     it('should return 404 if program does not exists', async () => {
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/programs/${new ObjectID()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     it('should get program with non valid activities and non valid steps', async () => {
-//       const programId = programsList[2]._id;
-//       const response = await app.inject({
-//         method: 'GET',
-//         url: `/programs/${programId.toHexString()}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//       expect(response.result.data.program).toMatchObject({
-//         _id: programId,
-//         name: 'non valid program',
-//         subPrograms: [{
-//           name: 'c\'est un sous-programme',
-//           steps: [{
-//             type: 'on_site',
-//             name: 'encore une étape',
-//             areActivitiesValid: false,
-//             activities: [{ areCardsValid: false }],
-//           }],
-//         }],
-//       });
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const programId = programsList[0]._id;
-//         const response = await app.inject({
-//           method: 'GET',
-//           url: `/programs/${programId.toHexString()}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - PUT /programs/{_id}', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should update program', async () => {
-//       const programId = programsList[0]._id;
-//       const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
-
-//       const response = await app.inject({
-//         method: 'PUT',
-//         url: `/programs/${programId.toHexString()}`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       const programUpdated = await Program.findById(programId);
-
-//       expect(response.statusCode).toBe(200);
-//       expect(programUpdated._id).toEqual(programId);
-//       expect(programUpdated.name).toEqual('new name');
-//       expect(programUpdated.description).toEqual('On apprend des trucs\nc\'est chouette');
-//     });
-
-//     it('should return 404 if program does not exist', async () => {
-//       const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
-//       const response = await app.inject({
-//         method: 'PUT',
-//         url: `/programs/${new ObjectID()}`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     it('should return 400 if payload is empty', async () => {
-//       const programId = programsList[0]._id;
-//       const response = await app.inject({
-//         method: 'PUT',
-//         url: `/programs/${programId.toHexString()}`,
-//         payload: {},
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(400);
-//     });
-
-//     const falsyParams = ['name', 'description', 'learningGoals'];
-//     falsyParams.forEach((param) => {
-//       it(`should return a 400 if ${param} is equal to '' `, async () => {
-//         const programId = programsList[0]._id;
-//         const payload = { name: 'new name', description: 'Trop top', learningGoals: 'Truc chouette' };
-//         const response = await app.inject({
-//           method: 'PUT',
-//           url: `/programs/${programId.toHexString()}`,
-//           payload: { ...payload, [param]: '' },
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(400);
-//       });
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const programId = programsList[0]._id;
-//         const response = await app.inject({
-//           method: 'PUT',
-//           payload: { learningGoals: 'On apprend des trucs\nc\'est chouette' },
-//           url: `/programs/${programId.toHexString()}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - POST /programs/{_id}/subprogram', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-//   const payload = { name: 'new subProgram' };
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should create subProgram', async () => {
-//       const programId = programsList[0]._id;
-//       const subProgramLengthBefore = programsList[0].subPrograms.length;
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${programId.toHexString()}/subprograms`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       const programUpdated = await Program.findById(programId);
-
-//       expect(response.statusCode).toBe(200);
-//       expect(programUpdated._id).toEqual(programId);
-//       expect(programUpdated.subPrograms.length).toEqual(subProgramLengthBefore + 1);
-//     });
-
-//     it('should return 404 if program does not exist', async () => {
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${new ObjectID()}/subprograms`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     it('should return a 400 if missing name', async () => {
-//       const programId = programsList[0]._id;
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${programId.toHexString()}/subprograms`,
-//         payload: omit(payload, 'name'),
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(400);
-//     });
-
-//     it('should return a 400 if program does not exist', async () => {
-//       const invalidId = new ObjectID();
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${invalidId}/subprograms`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const programId = programsList[0]._id;
-//         const response = await app.inject({
-//           method: 'POST',
-//           payload,
-//           url: `/programs/${programId.toHexString()}/subprograms`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - POST /programs/:id/upload', () => {
-//   let authToken;
-//   let uploadProgramMediaStub;
-//   const program = programsList[0];
-//   beforeEach(() => {
-//     uploadProgramMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
-//   });
-//   afterEach(() => {
-//     uploadProgramMediaStub.restore();
-//   });
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(populateDB);
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should add a program image', async () => {
-//       uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
-
-//       const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${program._id}/upload`,
-//         payload: await GetStream(form),
-//         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       const programUpdated = await Program.findById(program._id, { name: 1, image: 1 }).lean();
-
-//       expect(response.statusCode).toBe(200);
-//       expect(programUpdated).toMatchObject({
-//         ...pick(program, ['_id', 'name']),
-//         image: { publicId: 'abcdefgh', link: 'https://alenvi.io' },
-//       });
-//       sinon.assert.calledOnceWithExactly(uploadProgramMediaStub, { fileName: 'program_image_test', file: 'true' });
-//     });
-
-//     it('should return 404 if program does not exist', async () => {
-//       const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${new ObjectID()}/upload`,
-//         payload: await GetStream(form),
-//         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     const wrongParams = ['file', 'fileName'];
-//     wrongParams.forEach((param) => {
-//       it(`should return a 400 error if missing '${param}' parameter`, async () => {
-//         const invalidForm = generateFormData(omit({ fileName: 'program_image_test', file: 'true' }, param));
-//         const response = await app.inject({
-//           method: 'POST',
-//           url: `/programs/${program._id}/upload`,
-//           payload: await GetStream(invalidForm),
-//           headers: { ...invalidForm.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(400);
-//       });
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
-//         authToken = await getToken(role.name);
-//         uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
-
-//         const response = await app.inject({
-//           method: 'POST',
-//           url: `/programs/${program._id}/upload`,
-//           payload: await GetStream(form),
-//           headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
-//   let authToken;
-//   let deleteProgramMediaStub;
-//   beforeEach(() => {
-//     deleteProgramMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
-//   });
-//   afterEach(() => {
-//     deleteProgramMediaStub.restore();
-//   });
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(populateDB);
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should delete a program media', async () => {
-//       const program = programsList[0];
-//       const imageExistsBeforeUpdate = await Program
-//         .countDocuments({ _id: program._id, 'image.publicId': { $exists: true } });
-
-//       const response = await app.inject({
-//         method: 'DELETE',
-//         url: `/programs/${program._id}/upload`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(200);
-//       sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'au revoir');
-
-//       const isPictureDeleted = await Program.countDocuments({ _id: program._id, 'image.publicId': { $exists: false } });
-//       expect(imageExistsBeforeUpdate).toBeTruthy();
-//       expect(isPictureDeleted).toBeTruthy();
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const program = programsList[0];
-//         const response = await app.inject({
-//           method: 'DELETE',
-//           url: `/programs/${program._id}/upload`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - POST /programs/{_id}/categories', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-//   const programId = programsList[0]._id;
-//   const payload = { categoryId: categoriesList[1]._id };
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should add category', async () => {
-//       const categoryLengthBefore = programsList[0].categories.length;
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${programId.toHexString()}/categories`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       const programUpdated = await Program.findById(programId);
-
-//       expect(response.statusCode).toBe(200);
-//       expect(programUpdated._id).toEqual(programId);
-//       expect(programUpdated.categories.length).toEqual(categoryLengthBefore + 1);
-//     });
-
-//     it('should return 404 if program does not exist', async () => {
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${new ObjectID()}/categories`,
-//         payload,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     it('should return a 404 if category does not exist', async () => {
-//       const response = await app.inject({
-//         method: 'POST',
-//         url: `/programs/${programId.toHexString()}/categories`,
-//         payload: { categoryId: new ObjectID() },
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const response = await app.inject({
-//           method: 'POST',
-//           payload,
-//           url: `/programs/${programId.toHexString()}/categories`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
-
-// describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
-//   let authToken = null;
-//   beforeEach(populateDB);
-
-//   describe('VENDOR_ADMIN', () => {
-//     beforeEach(async () => {
-//       authToken = await getToken('vendor_admin');
-//     });
-
-//     it('should remove category from program', async () => {
-//       const programId = programsList[0]._id;
-//       const categoryLengthBefore = programsList[0].categories.length;
-//       const response = await app.inject({
-//         method: 'DELETE',
-//         url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       await Program.findById(programId);
-
-//       expect(response.statusCode).toBe(200);
-//       const programUpdated = await Program.findOne({ _id: programId }).lean();
-//       expect(programUpdated.categories.length).toEqual(categoryLengthBefore - 1);
-//       expect(programUpdated.categories.some(c => c._id === programsList[0].categories[0]._id)).toBeFalsy();
-//     });
-
-//     it('should return a 404 if program does not exist', async () => {
-//       const programId = new ObjectID();
-//       const response = await app.inject({
-//         method: 'DELETE',
-//         url: `/programs/${programId}/categories/${programsList[0].categories[0]._id}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-
-//     it('should return a 404 if program does not contain category', async () => {
-//       const categoryId = new ObjectID();
-//       const response = await app.inject({
-//         method: 'DELETE',
-//         url: `/programs/${programsList[0]._id}/categories/${categoryId}`,
-//         headers: { Cookie: `alenvi_token=${authToken}` },
-//       });
-
-//       expect(response.statusCode).toBe(404);
-//     });
-//   });
-
-//   describe('Other roles', () => {
-//     const roles = [
-//       { name: 'training_organisation_manager', expectedCode: 200 },
-//       { name: 'helper', expectedCode: 403 },
-//       { name: 'auxiliary', expectedCode: 403 },
-//       { name: 'auxiliary_without_company', expectedCode: 403 },
-//       { name: 'coach', expectedCode: 403 },
-//       { name: 'client_admin', expectedCode: 403 },
-//       { name: 'trainer', expectedCode: 403 },
-//     ];
-
-//     roles.forEach((role) => {
-//       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-//         authToken = await getToken(role.name);
-//         const programId = programsList[0]._id;
-//         const response = await app.inject({
-//           method: 'DELETE',
-//           url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
-//           headers: { Cookie: `alenvi_token=${authToken}` },
-//         });
-
-//         expect(response.statusCode).toBe(role.expectedCode);
-//       });
-//     });
-//   });
-// });
+describe('PROGRAMS ROUTES - POST /programs', () => {
+  let authToken;
+  beforeEach(populateDB);
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should create program', async () => {
+      const categoryId = categoriesList[0]._id;
+      const response = await app.inject({
+        method: 'POST',
+        url: '/programs',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'program', categories: [categoryId] },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 404 if wrong category id', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/programs',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'program', categories: [new ObjectID()] },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const categoryId = categoriesList[0]._id;
+        const response = await app.inject({
+          method: 'POST',
+          url: '/programs',
+          headers: { Cookie: `alenvi_token=${authToken}` },
+          payload: { name: 'program', categories: [categoryId] },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - GET /programs', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should get all programs', async () => {
+      const programsNumber = programsList.length;
+      const response = await app.inject({
+        method: 'GET',
+        url: '/programs',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.programs.length).toEqual(programsNumber);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'GET',
+          url: '/programs',
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - GET /programs/e-learning', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should get all programs', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/programs/e-learning',
+        headers: { 'x-access-token': authToken },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.programs.length).toEqual(1);
+      const coursesIds = response.result.data.programs[0].subPrograms[0].courses.map(c => c._id);
+
+      const courses = await Course.find({ _id: { $in: coursesIds } }).lean();
+      expect(courses.every(c => c.format === 'strictly_e_learning')).toBeTruthy();
+    });
+
+    it('should return 401 if user is not connected', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/programs/e-learning',
+        headers: { 'x-access-token': '' },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 200 },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 200 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'client_admin', expectedCode: 200 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'GET',
+          url: '/programs/e-learning',
+          headers: { 'x-access-token': authToken },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - GET /programs/{_id}', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should get program', async () => {
+      const programId = programsList[0]._id;
+      const response = await app.inject({
+        method: 'GET',
+        url: `/programs/${programId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.program).toMatchObject({
+        _id: programId,
+        name: 'program',
+        subPrograms: [{
+          name: 'c\'est un sous-programme',
+          steps: [{
+            type: 'on_site',
+            name: 'encore une étape',
+            areActivitiesValid: true,
+            activities: [{
+              name: 'c\'est une activité',
+              type: 'sharing_experience',
+              areCardsValid: true,
+            }],
+          }],
+        }],
+      });
+    });
+
+    it('should return 404 if program does not exists', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/programs/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should get program with non valid activities and non valid steps', async () => {
+      const programId = programsList[2]._id;
+      const response = await app.inject({
+        method: 'GET',
+        url: `/programs/${programId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.program).toMatchObject({
+        _id: programId,
+        name: 'non valid program',
+        subPrograms: [{
+          name: 'c\'est un sous-programme',
+          steps: [{
+            type: 'on_site',
+            name: 'encore une étape',
+            areActivitiesValid: false,
+            activities: [{ areCardsValid: false }],
+          }],
+        }],
+      });
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const programId = programsList[0]._id;
+        const response = await app.inject({
+          method: 'GET',
+          url: `/programs/${programId.toHexString()}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - PUT /programs/{_id}', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should update program', async () => {
+      const programId = programsList[0]._id;
+      const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/programs/${programId.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      const programUpdated = await Program.findById(programId);
+
+      expect(response.statusCode).toBe(200);
+      expect(programUpdated._id).toEqual(programId);
+      expect(programUpdated.name).toEqual('new name');
+      expect(programUpdated.description).toEqual('On apprend des trucs\nc\'est chouette');
+    });
+
+    it('should return 404 if program does not exist', async () => {
+      const payload = { name: 'new name', description: 'On apprend des trucs\nc\'est chouette' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/programs/${new ObjectID()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 400 if payload is empty', async () => {
+      const programId = programsList[0]._id;
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/programs/${programId.toHexString()}`,
+        payload: {},
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    const falsyParams = ['name', 'description', 'learningGoals'];
+    falsyParams.forEach((param) => {
+      it(`should return a 400 if ${param} is equal to '' `, async () => {
+        const programId = programsList[0]._id;
+        const payload = { name: 'new name', description: 'Trop top', learningGoals: 'Truc chouette' };
+        const response = await app.inject({
+          method: 'PUT',
+          url: `/programs/${programId.toHexString()}`,
+          payload: { ...payload, [param]: '' },
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(400);
+      });
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const programId = programsList[0]._id;
+        const response = await app.inject({
+          method: 'PUT',
+          payload: { learningGoals: 'On apprend des trucs\nc\'est chouette' },
+          url: `/programs/${programId.toHexString()}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - POST /programs/{_id}/subprogram', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+  const payload = { name: 'new subProgram' };
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should create subProgram', async () => {
+      const programId = programsList[0]._id;
+      const subProgramLengthBefore = programsList[0].subPrograms.length;
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programId.toHexString()}/subprograms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      const programUpdated = await Program.findById(programId);
+
+      expect(response.statusCode).toBe(200);
+      expect(programUpdated._id).toEqual(programId);
+      expect(programUpdated.subPrograms.length).toEqual(subProgramLengthBefore + 1);
+    });
+
+    it('should return 404 if program does not exist', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${new ObjectID()}/subprograms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 400 if missing name', async () => {
+      const programId = programsList[0]._id;
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programId.toHexString()}/subprograms`,
+        payload: omit(payload, 'name'),
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 if program does not exist', async () => {
+      const invalidId = new ObjectID();
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${invalidId}/subprograms`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const programId = programsList[0]._id;
+        const response = await app.inject({
+          method: 'POST',
+          payload,
+          url: `/programs/${programId.toHexString()}/subprograms`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - POST /programs/:id/upload', () => {
+  let authToken;
+  let uploadProgramMediaStub;
+  const program = programsList[0];
+  beforeEach(() => {
+    uploadProgramMediaStub = sinon.stub(GCloudStorageHelper, 'uploadProgramMedia');
+  });
+  afterEach(() => {
+    uploadProgramMediaStub.restore();
+  });
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should add a program image', async () => {
+      uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
+
+      const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${program._id}/upload`,
+        payload: await GetStream(form),
+        headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+      });
+
+      const programUpdated = await Program.findById(program._id, { name: 1, image: 1 }).lean();
+
+      expect(response.statusCode).toBe(200);
+      expect(programUpdated).toMatchObject({
+        ...pick(program, ['_id', 'name']),
+        image: { publicId: 'abcdefgh', link: 'https://alenvi.io' },
+      });
+      sinon.assert.calledOnceWithExactly(uploadProgramMediaStub, { fileName: 'program_image_test', file: 'true' });
+    });
+
+    it('should return 404 if program does not exist', async () => {
+      const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${new ObjectID()}/upload`,
+        payload: await GetStream(form),
+        headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    const wrongParams = ['file', 'fileName'];
+    wrongParams.forEach((param) => {
+      it(`should return a 400 error if missing '${param}' parameter`, async () => {
+        const invalidForm = generateFormData(omit({ fileName: 'program_image_test', file: 'true' }, param));
+        const response = await app.inject({
+          method: 'POST',
+          url: `/programs/${program._id}/upload`,
+          payload: await GetStream(invalidForm),
+          headers: { ...invalidForm.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(400);
+      });
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        const form = generateFormData({ fileName: 'program_image_test', file: 'true' });
+        authToken = await getToken(role.name);
+        uploadProgramMediaStub.returns({ publicId: 'abcdefgh', link: 'https://alenvi.io' });
+
+        const response = await app.inject({
+          method: 'POST',
+          url: `/programs/${program._id}/upload`,
+          payload: await GetStream(form),
+          headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - DELETE /programs/:id/upload', () => {
+  let authToken;
+  let deleteProgramMediaStub;
+  beforeEach(() => {
+    deleteProgramMediaStub = sinon.stub(GCloudStorageHelper, 'deleteProgramMedia');
+  });
+  afterEach(() => {
+    deleteProgramMediaStub.restore();
+  });
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should delete a program media', async () => {
+      const program = programsList[0];
+      const imageExistsBeforeUpdate = await Program
+        .countDocuments({ _id: program._id, 'image.publicId': { $exists: true } });
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/programs/${program._id}/upload`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      sinon.assert.calledOnceWithExactly(deleteProgramMediaStub, 'au revoir');
+
+      const isPictureDeleted = await Program.countDocuments({ _id: program._id, 'image.publicId': { $exists: false } });
+      expect(imageExistsBeforeUpdate).toBeTruthy();
+      expect(isPictureDeleted).toBeTruthy();
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const program = programsList[0];
+        const response = await app.inject({
+          method: 'DELETE',
+          url: `/programs/${program._id}/upload`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - POST /programs/{_id}/categories', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+  const programId = programsList[0]._id;
+  const payload = { categoryId: categoriesList[1]._id };
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should add category', async () => {
+      const categoryLengthBefore = programsList[0].categories.length;
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programId.toHexString()}/categories`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      const programUpdated = await Program.findById(programId);
+
+      expect(response.statusCode).toBe(200);
+      expect(programUpdated._id).toEqual(programId);
+      expect(programUpdated.categories.length).toEqual(categoryLengthBefore + 1);
+    });
+
+    it('should return 404 if program does not exist', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${new ObjectID()}/categories`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 404 if category does not exist', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/programs/${programId.toHexString()}/categories`,
+        payload: { categoryId: new ObjectID() },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'POST',
+          payload,
+          url: `/programs/${programId.toHexString()}/categories`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('VENDOR_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('vendor_admin');
+    });
+
+    it('should remove category from program', async () => {
+      const programId = programsList[0]._id;
+      const categoryLengthBefore = programsList[0].categories.length;
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      await Program.findById(programId);
+
+      expect(response.statusCode).toBe(200);
+      const programUpdated = await Program.findOne({ _id: programId }).lean();
+      expect(programUpdated.categories.length).toEqual(categoryLengthBefore - 1);
+      expect(programUpdated.categories.some(c => c._id === programsList[0].categories[0]._id)).toBeFalsy();
+    });
+
+    it('should return a 404 if program does not exist', async () => {
+      const programId = new ObjectID();
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/programs/${programId}/categories/${programsList[0].categories[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 404 if program does not contain category', async () => {
+      const categoryId = new ObjectID();
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/programs/${programsList[0]._id}/categories/${categoryId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'training_organisation_manager', expectedCode: 200 },
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const programId = programsList[0]._id;
+        const response = await app.inject({
+          method: 'DELETE',
+          url: `/programs/${programId.toHexString()}/categories/${programsList[0].categories[0]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
 
 describe('PROGRAMS ROUTES - POST /{_id}/tester', () => {
   let authToken;

--- a/tests/integration/seed/programsSeed.js
+++ b/tests/integration/seed/programsSeed.js
@@ -104,4 +104,5 @@ module.exports = {
   activitiesList,
   activityHistoriesList,
   categoriesList,
+  vendorAdmin,
 };

--- a/tests/integration/seed/programsSeed.js
+++ b/tests/integration/seed/programsSeed.js
@@ -60,7 +60,7 @@ const programsList = [
     image: { link: 'bonjour', publicId: 'au revoir' },
     categories: [categoriesList[0]._id],
   },
-  { _id: new ObjectID(), name: 'training program', subPrograms: [subProgramsList[2]._id] },
+  { _id: new ObjectID(), name: 'training program', subPrograms: [subProgramsList[2]._id], testers: [vendorAdmin._id] },
   { _id: new ObjectID(), name: 'non valid program', subPrograms: [subProgramsList[1]._id] },
 ];
 

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -180,7 +180,11 @@ describe('getProgram', () => {
             },
           }],
         },
-        { query: 'populate', args: [{ path: 'categories' }] },
+        {
+          query: 'populate',
+          args: [{ path: 'testers', select: 'identity.firstname identity.lastname local.email contact.phone' }],
+        },
+        { query: 'populate', args: ['categories'] },
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -3,8 +3,10 @@ const flat = require('flat');
 const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const Program = require('../../../src/models/Program');
+const User = require('../../../src/models/User');
 const Course = require('../../../src/models/Course');
 const ProgramHelper = require('../../../src/helpers/programs');
+const UserHelper = require('../../../src/helpers/users');
 const GCloudStorageHelper = require('../../../src/helpers/gCloudStorage');
 const SinonMongoose = require('../sinonMongoose');
 
@@ -308,5 +310,70 @@ describe('removeCategory', () => {
     await ProgramHelper.removeCategory(programId, categoryId);
 
     sinon.assert.calledOnceWithExactly(updateOne, { _id: programId }, { $pull: { categories: categoryId } });
+  });
+});
+
+describe('addTester', () => {
+  let findOne;
+  let findOneAndUpdate;
+  let createUser;
+
+  beforeEach(() => {
+    findOne = sinon.stub(User, 'findOne');
+    findOneAndUpdate = sinon.stub(Program, 'findOneAndUpdate');
+    createUser = sinon.stub(UserHelper, 'createUser');
+  });
+
+  afterEach(() => {
+    findOne.restore();
+    findOneAndUpdate.restore();
+    createUser.restore();
+  });
+
+  it('should add existing user to program as tester', async () => {
+    const programId = new ObjectID();
+    const user = { _id: new ObjectID(), local: { email: 'test@test.fr' } };
+    findOne.returns(SinonMongoose.stubChainedQueries([user], ['lean']));
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+
+    await ProgramHelper.addTester(programId, user);
+
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ 'local.email': 'test@test.fr' }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: user._id } }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.notCalled(createUser);
+  });
+
+  it('should create a user and add it to program as tester', async () => {
+    const programId = new ObjectID();
+    const userId = new ObjectID();
+    const payload = { local: { email: 'test@test.fr' } };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    createUser.returns({ ...payload, _id: userId });
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+
+    await ProgramHelper.addTester(programId, payload);
+
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ 'local.email': 'test@test.fr' }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOne', args: [{ _id: programId }, { $addToSet: { testers: userId } }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.calledWithExactly(createUser, { ...payload, origin: 'webapp' });
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
_- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour_

- J'ai changé un modele :
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas - non utilise en mobile
  _- J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas_

- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites

- Périmetre interface : vendeur

- Périmetre roles : ROF/admin

- Cas d'usage : Je peux ajouter des testeurs a un programme
Ce qu'il reste a faire (prochaine pr) : suppression des testeurs
