### PR TITLE
Com 1956 delete

### DIFF
--- a/src/controllers/programController.js
+++ b/src/controllers/programController.js
@@ -139,6 +139,17 @@ const addTester = async (req) => {
   }
 };
 
+const removeTester = async (req) => {
+  try {
+    await ProgramHelper.removeester(req.params._id, req.params.testerId);
+
+    return { message: translate[language].testerRemoved };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
 module.exports = {
   list,
   listELearning,
@@ -151,4 +162,5 @@ module.exports = {
   addCategory,
   removeCategory,
   addTester,
+  removeTester,
 };

--- a/src/controllers/programController.js
+++ b/src/controllers/programController.js
@@ -141,7 +141,7 @@ const addTester = async (req) => {
 
 const removeTester = async (req) => {
   try {
-    await ProgramHelper.removeester(req.params._id, req.params.testerId);
+    await ProgramHelper.removeTester(req.params._id, req.params.testerId);
 
     return { message: translate[language].testerRemoved };
   } catch (e) {

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -94,4 +94,4 @@ exports.addTester = async (programId, payload) => {
 };
 
 exports.removeTester = async (programId, testerId) =>
-  Program.updateOne({ _id: programId }, { $pull: { testers: testerId } }, { new: true }).lean();
+  Program.updateOne({ _id: programId }, { $pull: { testers: testerId } }).lean();

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -92,3 +92,6 @@ exports.addTester = async (programId, payload) => {
   return Program.findOneAndUpdate({ _id: programId }, { $addToSet: { testers: addedTester._id } }, { new: true })
     .lean();
 };
+
+exports.removeTester = async (programId, testerId) =>
+  Program.findOneAndUpdate({ _id: programId }, { $pull: { testers: testerId } }, { new: true }).lean();

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -94,4 +94,4 @@ exports.addTester = async (programId, payload) => {
 };
 
 exports.removeTester = async (programId, testerId) =>
-  Program.updateOne({ _id: programId }, { $pull: { testers: testerId } }).lean();
+  Program.updateOne({ _id: programId }, { $pull: { testers: testerId } });

--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -94,4 +94,4 @@ exports.addTester = async (programId, payload) => {
 };
 
 exports.removeTester = async (programId, testerId) =>
-  Program.findOneAndUpdate({ _id: programId }, { $pull: { testers: testerId } }, { new: true }).lean();
+  Program.updateOne({ _id: programId }, { $pull: { testers: testerId } }, { new: true }).lean();

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -224,6 +224,7 @@ module.exports = {
     programFound: 'Program found.',
     programUpdated: 'Program updated.',
     testerAdded: 'Tester added to program.',
+    testerRemoved: 'Tester removed from program.',
     testerConflict: 'Tester already added to program.',
     /* Categories */
     categoriesFound: 'Categories found.',
@@ -506,6 +507,7 @@ module.exports = {
     programFound: 'Programme trouvé.',
     programUpdated: 'Programme mis à jour.',
     testerAdded: 'Testeur ajouté au programme.',
+    testerRemoved: 'Testeur supprimé du programme.',
     testerConflict: 'Testeur déjà ajouté au programme.',
     /* Categories */
     categoriesFound: 'Catégories trouvées.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -225,6 +225,7 @@ module.exports = {
     programUpdated: 'Program updated.',
     testerAdded: 'Tester added to program.',
     testerRemoved: 'Tester removed from program.',
+    testerNotFound: 'Tester not found in program.',
     testerConflict: 'Tester already added to program.',
     /* Categories */
     categoriesFound: 'Categories found.',
@@ -508,6 +509,7 @@ module.exports = {
     programUpdated: 'Programme mis à jour.',
     testerAdded: 'Testeur ajouté au programme.',
     testerRemoved: 'Testeur supprimé du programme.',
+    testerNotFound: 'Testeur non trouvé dans le programme.',
     testerConflict: 'Testeur déjà ajouté au programme.',
     /* Categories */
     categoriesFound: 'Catégories trouvées.',

--- a/src/routes/preHandlers/programs.js
+++ b/src/routes/preHandlers/programs.js
@@ -47,7 +47,7 @@ exports.authorizeTesterAddition = async (req) => {
 exports.checkTesterInProgram = async (req) => {
   const { _id: programId, testerId } = req.params;
   const program = await Program.countDocuments({ _id: programId, testers: testerId });
-  if (!program) throw Boom.badData(translate[language].testerNotFound);
+  if (!program) throw Boom.conflict(translate[language].testerNotFound);
 
   return null;
 };

--- a/src/routes/preHandlers/programs.js
+++ b/src/routes/preHandlers/programs.js
@@ -47,7 +47,7 @@ exports.authorizeTesterAddition = async (req) => {
 exports.checkTesterInProgram = async (req) => {
   const { _id: programId, testerId } = req.params;
   const program = await Program.countDocuments({ _id: programId, testers: testerId });
-  if (!program) throw Boom.badData(translate[language].testerConflict);
+  if (!program) throw Boom.badData(translate[language].testerNotFound);
 
   return null;
 };

--- a/src/routes/preHandlers/programs.js
+++ b/src/routes/preHandlers/programs.js
@@ -43,3 +43,11 @@ exports.authorizeTesterAddition = async (req) => {
 
   return null;
 };
+
+exports.checkTesterInProgram = async (req) => {
+  const { _id: programId, testerId } = req.params;
+  const program = await Program.countDocuments({ _id: programId, testers: testerId });
+  if (!program) throw Boom.badData(translate[language].testerConflict);
+
+  return null;
+};

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -20,6 +20,7 @@ const {
   addCategory,
   removeCategory,
   addTester,
+  removeTester,
 } = require('../controllers/programController');
 const { formDataPayload, phoneNumberValidation } = require('./validations/utils');
 
@@ -189,6 +190,19 @@ exports.plugin = {
         pre: [{ method: checkProgramExists }, { method: authorizeTesterAddition }],
       },
       handler: addTester,
+    });
+
+    server.route({
+      method: 'DELETE',
+      path: '/{_id}/testers/{testerId}',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required(), testerId: Joi.objectId().required() }),
+        },
+        auth: { scope: ['programs:edit'] },
+        pre: [{ method: checkProgramExists }],
+      },
+      handler: removeTester,
     });
   },
 };

--- a/src/routes/programs.js
+++ b/src/routes/programs.js
@@ -7,6 +7,7 @@ const {
   getProgramImagePublicId,
   checkCategoryExists,
   authorizeTesterAddition,
+  checkTesterInProgram,
 } = require('./preHandlers/programs');
 const {
   list,
@@ -200,7 +201,7 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required(), testerId: Joi.objectId().required() }),
         },
         auth: { scope: ['programs:edit'] },
-        pre: [{ method: checkProgramExists }],
+        pre: [{ method: checkProgramExists }, { method: checkTesterInProgram }],
       },
       handler: removeTester,
     });

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -969,7 +969,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return a 422 if tester is not in program', async () => {
+    it('should return a 409 if tester is not in program', async () => {
       const response = await app.inject({
         method: 'DELETE',
         url: `/programs/${programsList[0]._id}/testers/${vendorAdmin._id}`,

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -976,7 +976,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(422);
+      expect(response.statusCode).toBe(409);
     });
   });
 

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -945,6 +945,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
 
     it('should remove a tester to a program', async () => {
       const programId = programsList[1]._id;
+      const programBefore = await Program.findById(programId);
 
       const response = await app.inject({
         method: 'DELETE',
@@ -954,6 +955,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
 
       expect(response.statusCode).toBe(200);
       const program = await Program.findById(programId);
+      expect(programBefore.testers).toHaveLength(1);
       expect(program.testers).toHaveLength(0);
     });
 
@@ -965,6 +967,16 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 422 if tester is not in program', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/programs/${programsList[0]._id}/testers/${vendorAdmin._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(422);
     });
   });
 

--- a/tests/integration/programs.test.js
+++ b/tests/integration/programs.test.js
@@ -311,7 +311,7 @@ describe('PROGRAMS ROUTES - PUT /programs/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const programUpdated = await Program.findById(programId);
+      const programUpdated = await Program.findById(programId).lean();
 
       expect(response.statusCode).toBe(200);
       expect(programUpdated._id).toEqual(programId);
@@ -408,7 +408,7 @@ describe('PROGRAMS ROUTES - POST /programs/{_id}/subprogram', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const programUpdated = await Program.findById(programId);
+      const programUpdated = await Program.findById(programId).lean();
 
       expect(response.statusCode).toBe(200);
       expect(programUpdated._id).toEqual(programId);
@@ -656,7 +656,7 @@ describe('PROGRAMS ROUTES - POST /programs/{_id}/categories', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const programUpdated = await Program.findById(programId);
+      const programUpdated = await Program.findById(programId).lean();
 
       expect(response.statusCode).toBe(200);
       expect(programUpdated._id).toEqual(programId);
@@ -731,7 +731,7 @@ describe('PROGRAMS ROUTES - DELETE /programs/{_id}/categories/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      await Program.findById(programId);
+      await Program.findById(programId).lean();
 
       expect(response.statusCode).toBe(200);
       const programUpdated = await Program.findOne({ _id: programId }).lean();
@@ -813,7 +813,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/testers', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const program = await Program.findById(programId);
+      const program = await Program.findById(programId).lean();
       expect(program.testers).toHaveLength(1);
     });
 
@@ -829,7 +829,7 @@ describe('PROGRAMS ROUTES - POST /{_id}/testers', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const program = await Program.findById(programId);
+      const program = await Program.findById(programId).lean();
       expect(program.testers).toHaveLength(1);
     });
 
@@ -945,7 +945,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
 
     it('should remove a tester to a program', async () => {
       const programId = programsList[1]._id;
-      const programBefore = await Program.findById(programId);
+      const programBefore = await Program.findById(programId).lean();
 
       const response = await app.inject({
         method: 'DELETE',
@@ -954,7 +954,7 @@ describe('PROGRAMS ROUTES - DELETE /{_id}/testers/{testerId}', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const program = await Program.findById(programId);
+      const program = await Program.findById(programId).lean();
       expect(programBefore.testers).toHaveLength(1);
       expect(program.testers).toHaveLength(0);
     });

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -383,25 +383,25 @@ describe('addTester', () => {
 });
 
 describe('removeTester', () => {
-  let findOneAndUpdate;
+  let updateOne;
 
   beforeEach(() => {
-    findOneAndUpdate = sinon.stub(Program, 'findOneAndUpdate');
+    updateOne = sinon.stub(Program, 'updateOne');
   });
 
   afterEach(() => {
-    findOneAndUpdate.restore();
+    updateOne.restore();
   });
 
   it('should remove tester', async () => {
     const programId = new ObjectID();
     const testerId = new ObjectID();
-    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+    updateOne.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
 
     await ProgramHelper.removeTester(programId, testerId);
 
     SinonMongoose.calledWithExactly(
-      findOneAndUpdate,
+      updateOne,
       [
         { query: 'findOne', args: [{ _id: programId }, { $pull: { testers: testerId } }, { new: true }] },
         { query: 'lean' },

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -396,16 +396,10 @@ describe('removeTester', () => {
   it('should remove tester', async () => {
     const programId = new ObjectID();
     const testerId = new ObjectID();
-    updateOne.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+    updateOne.returns({ _id: programId });
 
     await ProgramHelper.removeTester(programId, testerId);
 
-    SinonMongoose.calledWithExactly(
-      updateOne,
-      [
-        { query: 'findOne', args: [{ _id: programId }, { $pull: { testers: testerId } }] },
-        { query: 'lean' },
-      ]
-    );
+    sinon.assert.calledOnceWithExactly(updateOne, { _id: programId }, { $pull: { testers: testerId } });
   });
 });

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -403,7 +403,7 @@ describe('removeTester', () => {
     SinonMongoose.calledWithExactly(
       updateOne,
       [
-        { query: 'findOne', args: [{ _id: programId }, { $pull: { testers: testerId } }, { new: true }] },
+        { query: 'findOne', args: [{ _id: programId }, { $pull: { testers: testerId } }] },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -381,3 +381,31 @@ describe('addTester', () => {
     sinon.assert.calledWithExactly(createUser, { ...payload, origin: 'webapp' });
   });
 });
+
+describe('removeTester', () => {
+  let findOneAndUpdate;
+
+  beforeEach(() => {
+    findOneAndUpdate = sinon.stub(Program, 'findOneAndUpdate');
+  });
+
+  afterEach(() => {
+    findOneAndUpdate.restore();
+  });
+
+  it('should remove tester', async () => {
+    const programId = new ObjectID();
+    const testerId = new ObjectID();
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: programId }], ['lean']));
+
+    await ProgramHelper.removeTester(programId, testerId);
+
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOne', args: [{ _id: programId }, { $pull: { testers: testerId } }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+});


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp) 
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : Je peux supprimer un testeur d'un programme