### PR TITLE
Com 1955

### DIFF
--- a/src/controllers/courseController.js
+++ b/src/controllers/courseController.js
@@ -79,7 +79,7 @@ const getQuestionnaireAnswers = async (req) => {
     const questionnaireAnswers = await CoursesHelper.getQuestionnaireAnswers(req.params._id);
 
     return {
-      message: translate[language].courseFound,
+      message: translate[language].courseQuestionnairesFound,
       data: { questionnaireAnswers },
     };
   } catch (e) {

--- a/src/controllers/courseController.js
+++ b/src/controllers/courseController.js
@@ -76,7 +76,7 @@ const getFollowUp = async (req) => {
 
 const getQuestionnaireAnswers = async (req) => {
   try {
-    const questionnaireAnswers = await CoursesHelper.getQuestionnaireAnswers(req.query.activity, req.params._id);
+    const questionnaireAnswers = await CoursesHelper.getQuestionnaireAnswers(req.params._id);
 
     return {
       message: translate[language].courseFound,

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -152,8 +152,11 @@ exports.formatActivity = (activity) => {
   const filteredHistories = exports.selectUserHistory(activity.activityHistories);
   for (const history of filteredHistories) {
     for (const answer of history.questionnaireAnswersList) {
+      const { answerList } = answer;
+      if (answerList.length === 1 && !answerList[0].trim()) continue;
+
       if (!followUp[answer.card._id]) followUp[answer.card._id] = { ...answer.card, answers: [] };
-      followUp[answer.card._id].answers.push(...answer.answerList);
+      followUp[answer.card._id].answers.push(...answerList);
     }
   }
 

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -8,7 +8,6 @@ const os = require('os');
 const moment = require('moment');
 const flat = require('flat');
 const Course = require('../models/Course');
-const Activity = require('../models/Activity');
 const CourseSmsHistory = require('../models/CourseSmsHistory');
 const CourseRepository = require('../repositories/CourseRepository');
 const UsersHelper = require('./users');

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -215,7 +215,7 @@ exports.getCourseFollowUp = async (course, company) => {
 };
 
 exports.getQuestionnaireAnswers = async (courseId) => {
-  const course = await Course.findOne({ _id: courseId }, { misc: 1, trainees: 1 })
+  const course = await Course.findOne({ _id: courseId })
     .populate({
       path: 'subProgram',
       select: 'steps',

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -220,7 +220,6 @@ exports.getQuestionnaireAnswers = async (courseId) => {
       path: 'subProgram',
       select: 'steps',
       populate: [
-        { path: 'program', select: 'name' },
         {
           path: 'steps',
           select: 'activities',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -265,6 +265,7 @@ module.exports = {
     courseTraineeNotFromCourseCompany: 'Course trainee not connected to course company',
     courseAccessRuleAdded: 'Access rule added.',
     courseAccessRuleDeleted: 'Access rule deleted.',
+    courseQuestionnairesFound: 'Questionnaires found.',
     /* Course slots */
     courseSlotCreated: 'Course slot created.',
     courseSlotUpdated: 'Course slot updated.',
@@ -549,6 +550,7 @@ module.exports = {
     courseTraineeNotFromCourseCompany: 'Ce stagiaire n\'est pas relié à la structure de la formation',
     courseAccessRuleAdded: 'Règle d\'accès ajoutée.',
     courseAccessRuleDeleted: 'Règle d\'accès supprimée.',
+    courseQuestionnairesFound: 'Questionnaires trouvés.',
     /* Course slots */
     courseSlotCreated: 'Créneau de formation créé.',
     courseSlotUpdated: 'Créneau de formation mis à jour.',

--- a/src/routes/courses.js
+++ b/src/routes/courses.js
@@ -34,7 +34,6 @@ const {
   authorizeCourseGetByTrainee,
   authorizeRegisterToELearning,
   getCourse,
-  isQuestionnaire,
   authorizeAccessRuleAddition,
   authorizeAccessRuleDeletion,
   authorizeAndGetTrainee,
@@ -130,10 +129,9 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          query: Joi.object({ activity: Joi.objectId().required() }),
         },
         auth: { scope: ['courses:read'] },
-        pre: [{ method: isQuestionnaire }, { method: authorizeGetFollowUp }],
+        pre: [{ method: authorizeGetFollowUp }],
       },
       handler: getQuestionnaireAnswers,
     });

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -256,9 +256,3 @@ exports.authorizeGetFollowUp = async (req) => {
 
   return null;
 };
-
-exports.isQuestionnaire = async (req) => {
-  const activity = await Activity.countDocuments({ _id: req.query.activity, type: QUESTIONNAIRE });
-
-  return (!activity) ? Boom.badRequest() : null;
-};

--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -1,7 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const Course = require('../../models/Course');
-const Activity = require('../../models/Activity');
 const User = require('../../models/User');
 const {
   TRAINER,
@@ -12,7 +11,6 @@ const {
   COACH,
   TRAINING_ORGANISATION_MANAGER,
   STRICTLY_E_LEARNING,
-  QUESTIONNAIRE,
 } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const UtilsHelper = require('../../helpers/utils');

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -596,21 +596,11 @@ describe('COURSES ROUTES - GET /courses/{_id}/questionnaires', () => {
     it('should get questionnaire answers', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/courses/${coursesList[0]._id.toHexString()}/questionnaires?activity=${activitiesList[1]._id}`,
+        url: `/courses/${coursesList[0]._id.toHexString()}/questionnaires`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(200);
-    });
-
-    it('should return a 400 if the activity is not a questionnaire', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/courses/${coursesList[0]._id.toHexString()}/questionnaires?activity=${activitiesList[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
     });
   });
 
@@ -628,7 +618,7 @@ describe('COURSES ROUTES - GET /courses/{_id}/questionnaires', () => {
 
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/${coursesList[0]._id.toHexString()}/questionnaires?activity=${activitiesList[1]._id}`,
+          url: `/courses/${coursesList[0]._id.toHexString()}/questionnaires`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -169,7 +169,7 @@ describe('getCourseProgress', () => {
     expect(result).toBe(1);
   });
 
-  it('should return 0 if no steps', async () => {
+  it('should return 0 if no step', async () => {
     const steps = [];
 
     const result = await CourseHelper.getCourseProgress(steps);
@@ -538,24 +538,25 @@ describe('formatActivity', () => {
           _id: 'rfvgtgb',
           user: 'qwertyuiop',
           questionnaireAnswersList: [
-            { card: { _id: '1234567', title: 'Bonjour' }, answerList: [2] },
-            { card: { _id: '0987654', title: 'Hello' }, answerList: [3] },
+            { card: { _id: '1234567', title: 'Bonjour' }, answerList: ['2'] },
+            { card: { _id: '0987654', title: 'Hello' }, answerList: ['3'] },
           ],
         },
         {
           _id: 'yhnjujm',
           user: 'poiuytre',
           questionnaireAnswersList: [
-            { card: { _id: '1234567', title: 'Bonjour' }, answerList: [3] },
-            { card: { _id: '0987654', title: 'Hello' }, answerList: [4] },
+            { card: { _id: '1234567', title: 'Bonjour' }, answerList: ['3'] },
+            { card: { _id: '0987654', title: 'Hello' }, answerList: ['', '4'] },
           ],
         },
         {
           _id: 'zxcvbnm',
           user: 'xzcvbnm',
           questionnaireAnswersList: [
-            { card: { _id: '1234567', title: 'Bonjour' }, answerList: [1] },
-            { card: { _id: '0987654', title: 'Hello' }, answerList: [4] },
+            { card: { _id: '1234567', title: 'Bonjour' }, answerList: ['1'] },
+            { card: { _id: '0987654', title: 'Hello' }, answerList: ['4'] },
+            { card: { _id: '0987622', title: 'Coucou' }, answerList: [''] },
           ],
         },
       ],
@@ -566,8 +567,8 @@ describe('formatActivity', () => {
     expect(result).toEqual({
       activityHistories: ['rfvgtgb', 'yhnjujm', 'zxcvbnm'],
       followUp: [
-        { _id: '1234567', title: 'Bonjour', answers: [2, 3, 1] },
-        { _id: '0987654', title: 'Hello', answers: [3, 4, 4] },
+        { _id: '1234567', title: 'Bonjour', answers: ['2', '3', '1'] },
+        { _id: '0987654', title: 'Hello', answers: ['3', '', '4', '4'] },
       ],
     });
   });
@@ -850,7 +851,7 @@ describe('getQuestionnaireAnswers', () => {
     sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
   });
 
-  it('should return [] if no steps', async () => {
+  it('should return [] if no step', async () => {
     const courseId = new ObjectID();
     const userId = new ObjectID();
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -1,4 +1,3 @@
-const omit = require('lodash/omit');
 const sinon = require('sinon');
 const expect = require('expect');
 const { ObjectID } = require('mongodb');
@@ -8,7 +7,6 @@ const { PassThrough } = require('stream');
 const { fn: momentProto } = require('moment');
 const moment = require('moment');
 const Course = require('../../../src/models/Course');
-const Activity = require('../../../src/models/Activity');
 const CourseSmsHistory = require('../../../src/models/CourseSmsHistory');
 const Drive = require('../../../src/models/Google/Drive');
 const CourseHelper = require('../../../src/helpers/courses');

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -732,84 +732,193 @@ describe('getCourseFollowUp', () => {
   });
 });
 
-describe('get questionnaire answers', () => {
+describe('getQuestionnaireAnswers', () => {
   let findOneCourse;
-  let findOneActivity;
   let formatActivity;
   beforeEach(() => {
     findOneCourse = sinon.stub(Course, 'findOne');
-    findOneActivity = sinon.stub(Activity, 'findOne');
     formatActivity = sinon.stub(CourseHelper, 'formatActivity');
   });
   afterEach(() => {
     findOneCourse.restore();
-    findOneActivity.restore();
     formatActivity.restore();
   });
 
   it('should return questionnaire answers', async () => {
     const courseId = new ObjectID();
-    const activityId = new ObjectID();
     const userId = new ObjectID();
+    const activities = [
+      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
+      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
+    ];
+
+    const followUps = [
+      { question: 'test', answers: ['1', '2'] },
+      { question: 'test2', answers: ['3', '4'] },
+    ];
+
     const course = {
       _id: courseId,
       misc: 'Groupe 3',
       trainees: [userId],
-      subProgram: { steps: [{ _id: ObjectID(), program: { name: 'nom du programme' } }] },
+      subProgram: {
+        steps: [
+          {
+            _id: ObjectID(),
+            program: { name: 'nom du programme' },
+            activities: [activities[0]],
+          },
+          {
+            _id: ObjectID(),
+            program: { name: 'nom du programme' },
+            activities: [activities[1]],
+          },
+        ],
+      },
     };
-    const activity = {
-      _id: activityId,
-      name: 'le nom de l\'activité',
-      activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }],
-      steps: [{
-        id: new ObjectID(),
-        name: 'le nom de l\'étape',
-        subProgram: { _id: new ObjectID(), program: { name: 'le nom du programme' } },
-      }],
-    };
-    const questionnaireAnswers = {
-      ...course,
-      ...activity,
-      followUp: [{ template: 'survey', question: 'la question', answers: ['une réponse'] }],
-    };
+
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
-    findOneActivity.returns(SinonMongoose.stubChainedQueries([activity]));
-    formatActivity.returns(questionnaireAnswers);
+    formatActivity.onCall(0).returns({ followUp: [followUps[0]] });
+    formatActivity.onCall(1).returns({ followUp: [followUps[1]] });
 
-    const result = await CourseHelper.getQuestionnaireAnswers(activityId, courseId);
+    const result = await CourseHelper.getQuestionnaireAnswers(courseId);
 
-    expect(result).toMatchObject(questionnaireAnswers);
+    expect(result).toMatchObject(followUps);
     SinonMongoose.calledWithExactly(findOneCourse, [
-      { query: 'findOne', args: [{ _id: courseId }, { misc: 1, trainees: 1 }] },
-      {
-        query: 'populate',
-        args: [{ path: 'subProgram', select: 'steps', populate: [{ path: 'program', select: 'name' }] }],
-      },
-      { query: 'lean' },
-    ]);
-
-    SinonMongoose.calledWithExactly(findOneActivity, [
-      { query: 'findOne', args: [{ _id: activityId }, { name: 1 }] },
+      { query: 'findOne', args: [{ _id: courseId }] },
       {
         query: 'populate',
         args: [{
-          path: 'activityHistories',
-          populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-          match: { user: { $in: course.trainees.map(t => t.toHexString()) } },
-        }],
-      },
-      {
-        query: 'populate',
-        args: [{
-          path: 'steps',
-          select: 'name',
-          match: { _id: { $in: course.subProgram.steps.map(s => s._id.toHexString()) } },
+          path: 'subProgram',
+          select: 'steps',
+          populate: [
+            { path: 'program', select: 'name' },
+            {
+              path: 'steps',
+              select: 'activities',
+              populate: {
+                path: 'activities',
+                populate: {
+                  path: 'activityHistories',
+                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+                },
+              },
+            },
+          ],
         }],
       },
       { query: 'lean' },
     ]);
+    sinon.assert.calledWithExactly(formatActivity.getCall(0), activities[0]);
+    sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
+  });
 
-    sinon.assert.calledOnceWithExactly(formatActivity, omit(activity, 'steps'));
+  it('should return questionnaire answers', async () => {
+    const courseId = new ObjectID();
+    const userId = new ObjectID();
+    const activities = [
+      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
+      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
+    ];
+
+    const course = {
+      _id: courseId,
+      misc: 'Groupe 3',
+      trainees: [userId],
+      subProgram: {
+        steps: [
+          {
+            _id: ObjectID(),
+            program: { name: 'nom du programme' },
+            activities: [activities[0]],
+          },
+          {
+            _id: ObjectID(),
+            program: { name: 'nom du programme' },
+            activities: [activities[1]],
+          },
+        ],
+      },
+    };
+
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    formatActivity.onCall(0).returns({ followUp: [] });
+    formatActivity.onCall(1).returns({ followUp: [] });
+
+    const result = await CourseHelper.getQuestionnaireAnswers(courseId);
+
+    expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(findOneCourse, [
+      { query: 'findOne', args: [{ _id: courseId }] },
+      {
+        query: 'populate',
+        args: [{
+          path: 'subProgram',
+          select: 'steps',
+          populate: [
+            { path: 'program', select: 'name' },
+            {
+              path: 'steps',
+              select: 'activities',
+              populate: {
+                path: 'activities',
+                populate: {
+                  path: 'activityHistories',
+                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+                },
+              },
+            },
+          ],
+        }],
+      },
+      { query: 'lean' },
+    ]);
+    sinon.assert.calledWithExactly(formatActivity.getCall(0), activities[0]);
+    sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
+  });
+
+  it('should return questionnaire answers', async () => {
+    const courseId = new ObjectID();
+    const userId = new ObjectID();
+
+    const course = {
+      _id: courseId,
+      misc: 'Groupe 3',
+      trainees: [userId],
+      subProgram: {},
+    };
+
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+
+    const result = await CourseHelper.getQuestionnaireAnswers(courseId);
+
+    expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(findOneCourse, [
+      { query: 'findOne', args: [{ _id: courseId }] },
+      {
+        query: 'populate',
+        args: [{
+          path: 'subProgram',
+          select: 'steps',
+          populate: [
+            { path: 'program', select: 'name' },
+            {
+              path: 'steps',
+              select: 'activities',
+              populate: {
+                path: 'activities',
+                populate: {
+                  path: 'activityHistories',
+                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+                },
+              },
+            },
+          ],
+        }],
+      },
+      { query: 'lean' },
+    ]);
+    sinon.assert.notCalled(formatActivity);
   });
 });
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -761,16 +761,8 @@ describe('getQuestionnaireAnswers', () => {
       trainees: [userId],
       subProgram: {
         steps: [
-          {
-            _id: ObjectID(),
-            program: { name: 'nom du programme' },
-            activities: [activities[0]],
-          },
-          {
-            _id: ObjectID(),
-            program: { name: 'nom du programme' },
-            activities: [activities[1]],
-          },
+          { _id: new ObjectID(), program: { name: 'nom du programme' }, activities: [activities[0]] },
+          { _id: new ObjectID(), program: { name: 'nom du programme' }, activities: [activities[1]] },
         ],
       },
     };
@@ -789,19 +781,17 @@ describe('getQuestionnaireAnswers', () => {
         args: [{
           path: 'subProgram',
           select: 'steps',
-          populate: [
-            {
-              path: 'steps',
-              select: 'activities',
+          populate: [{
+            path: 'steps',
+            select: 'activities',
+            populate: {
+              path: 'activities',
               populate: {
-                path: 'activities',
-                populate: {
-                  path: 'activityHistories',
-                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-                },
+                path: 'activityHistories',
+                populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
               },
             },
-          ],
+          }],
         }],
       },
       { query: 'lean' },
@@ -821,16 +811,8 @@ describe('getQuestionnaireAnswers', () => {
       trainees: [userId],
       subProgram: {
         steps: [
-          {
-            _id: ObjectID(),
-            program: { name: 'nom du programme' },
-            activities: [activities[0]],
-          },
-          {
-            _id: ObjectID(),
-            program: { name: 'nom du programme' },
-            activities: [activities[1]],
-          },
+          { _id: new ObjectID(), program: { name: 'nom du programme' }, activities: [activities[0]] },
+          { _id: new ObjectID(), program: { name: 'nom du programme' }, activities: [activities[1]] },
         ],
       },
     };
@@ -849,19 +831,17 @@ describe('getQuestionnaireAnswers', () => {
         args: [{
           path: 'subProgram',
           select: 'steps',
-          populate: [
-            {
-              path: 'steps',
-              select: 'activities',
+          populate: [{
+            path: 'steps',
+            select: 'activities',
+            populate: {
+              path: 'activities',
               populate: {
-                path: 'activities',
-                populate: {
-                  path: 'activityHistories',
-                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-                },
+                path: 'activityHistories',
+                populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
               },
             },
-          ],
+          }],
         }],
       },
       { query: 'lean' },
@@ -870,7 +850,7 @@ describe('getQuestionnaireAnswers', () => {
     sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
   });
 
-  it('should return [] if no stepss', async () => {
+  it('should return [] if no steps', async () => {
     const courseId = new ObjectID();
     const userId = new ObjectID();
 
@@ -893,19 +873,17 @@ describe('getQuestionnaireAnswers', () => {
         args: [{
           path: 'subProgram',
           select: 'steps',
-          populate: [
-            {
-              path: 'steps',
-              select: 'activities',
+          populate: [{
+            path: 'steps',
+            select: 'activities',
+            populate: {
+              path: 'activities',
               populate: {
-                path: 'activities',
-                populate: {
-                  path: 'activityHistories',
-                  populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
-                },
+                path: 'activityHistories',
+                populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
               },
             },
-          ],
+          }],
         }],
       },
       { query: 'lean' },

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -792,7 +792,6 @@ describe('getQuestionnaireAnswers', () => {
           path: 'subProgram',
           select: 'steps',
           populate: [
-            { path: 'program', select: 'name' },
             {
               path: 'steps',
               select: 'activities',
@@ -813,13 +812,10 @@ describe('getQuestionnaireAnswers', () => {
     sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
   });
 
-  it('should return questionnaire answers', async () => {
+  it('should return [] if no followUp', async () => {
     const courseId = new ObjectID();
     const userId = new ObjectID();
-    const activities = [
-      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
-      { activityHistories: [{ _id: new ObjectID(), user: userId, questionnaireAnswersList: { card: {} } }] },
-    ];
+    const activities = [{ activityHistories: [] }, { activityHistories: [] }];
 
     const course = {
       _id: courseId,
@@ -856,7 +852,6 @@ describe('getQuestionnaireAnswers', () => {
           path: 'subProgram',
           select: 'steps',
           populate: [
-            { path: 'program', select: 'name' },
             {
               path: 'steps',
               select: 'activities',
@@ -877,7 +872,7 @@ describe('getQuestionnaireAnswers', () => {
     sinon.assert.calledWithExactly(formatActivity.getCall(1), activities[1]);
   });
 
-  it('should return questionnaire answers', async () => {
+  it('should return [] if no stepss', async () => {
     const courseId = new ObjectID();
     const userId = new ObjectID();
 
@@ -901,7 +896,6 @@ describe('getQuestionnaireAnswers', () => {
           path: 'subProgram',
           select: 'steps',
           populate: [
-            { path: 'program', select: 'name' },
             {
               path: 'steps',
               select: 'activities',


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : Possibilite de voir les reponses aux questionnaires d'une formation elearning
- Tester aussi la recuperation des statistiques sur la page d'une formation elearning et sur la page d'un apprenant (cf changment dans le service sur api)
