### PR TITLE
COM-1957: allow user to access draft elearning programs which for he/she is tester

### DIFF
--- a/src/controllers/subProgramController.js
+++ b/src/controllers/subProgramController.js
@@ -40,7 +40,7 @@ const detachStep = async (req) => {
 
 const listELearningDraft = async (req) => {
   try {
-    const subPrograms = await SubProgramHelper.listELearningDraft(req.pre.userRestrictedTestedPrograms);
+    const subPrograms = await SubProgramHelper.listELearningDraft(req.pre.testerRestrictedPrograms);
 
     return {
       message: subPrograms.length ? translate[language].subProgramsFound : translate[language].subProgramsNotFound,

--- a/src/controllers/subProgramController.js
+++ b/src/controllers/subProgramController.js
@@ -40,7 +40,7 @@ const detachStep = async (req) => {
 
 const listELearningDraft = async (req) => {
   try {
-    const subPrograms = await SubProgramHelper.listELearningDraft();
+    const subPrograms = await SubProgramHelper.listELearningDraft(req.pre.userRestrictedTestedPrograms);
 
     return {
       message: subPrograms.length ? translate[language].subProgramsFound : translate[language].subProgramsNotFound,

--- a/src/helpers/subPrograms.js
+++ b/src/helpers/subPrograms.js
@@ -32,13 +32,19 @@ exports.updateSubProgram = async (subProgramId, payload) => {
   return Activity.updateMany({ _id: { $in: activities } }, { status: payload.status });
 };
 
-exports.listELearningDraft = async () => {
+exports.listELearningDraft = async (userRestrictedTestedPrograms) => {
+  let query = { path: 'program', select: '_id name description image' };
+  if (userRestrictedTestedPrograms) {
+    const userRestrictedTestedProgramsIds = userRestrictedTestedPrograms.map(program => program._id);
+    query = { ...query, match: { _id: { $in: userRestrictedTestedProgramsIds } } };
+  }
+
   const subPrograms = await SubProgram.find({ status: DRAFT })
-    .populate({ path: 'program', select: '_id name description image' })
+    .populate(query)
     .populate({ path: 'steps', select: 'type' })
     .lean({ virtuals: true });
 
-  return subPrograms.filter(sp => sp.steps.length && sp.isStrictlyELearning);
+  return subPrograms.filter(sp => sp.steps.length && sp.isStrictlyELearning && sp.program);
 };
 
 exports.getSubProgram = async subProgramId => SubProgram

--- a/src/helpers/subPrograms.js
+++ b/src/helpers/subPrograms.js
@@ -32,12 +32,9 @@ exports.updateSubProgram = async (subProgramId, payload) => {
   return Activity.updateMany({ _id: { $in: activities } }, { status: payload.status });
 };
 
-exports.listELearningDraft = async (userRestrictedTestedPrograms) => {
+exports.listELearningDraft = async (testerRestrictedPrograms) => {
   let query = { path: 'program', select: '_id name description image' };
-  if (userRestrictedTestedPrograms) {
-    const userRestrictedTestedProgramsIds = userRestrictedTestedPrograms.map(program => program._id);
-    query = { ...query, match: { _id: { $in: userRestrictedTestedProgramsIds } } };
-  }
+  if (testerRestrictedPrograms) query = { ...query, match: { _id: { $in: testerRestrictedPrograms } } };
 
   const subPrograms = await SubProgram.find({ status: DRAFT })
     .populate(query)

--- a/src/routes/preHandlers/subPrograms.js
+++ b/src/routes/preHandlers/subPrograms.js
@@ -82,7 +82,7 @@ exports.authorizeGetDraftELearningSubPrograms = async (req) => {
   if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
 
   const userId = get(req, 'auth.credentials._id');
-  const userRestrictedTestedPrograms = await Program.find({ testers: userId }, { _id: 1 }).lean();
+  const testerRestrictedPrograms = await Program.find({ testers: userId }, { _id: 1 }).lean();
 
-  return userRestrictedTestedPrograms.map(program => program._id);
+  return testerRestrictedPrograms.map(program => program._id);
 };

--- a/src/routes/preHandlers/subPrograms.js
+++ b/src/routes/preHandlers/subPrograms.js
@@ -1,9 +1,10 @@
 const Boom = require('@hapi/boom');
+const get = require('lodash/get');
 const SubProgram = require('../../models/SubProgram');
 const Program = require('../../models/Program');
 const Company = require('../../models/Company');
 const CourseSlot = require('../../models/CourseSlot');
-const { PUBLISHED } = require('../../helpers/constants');
+const { PUBLISHED, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 
 const { language } = translate;
@@ -74,4 +75,14 @@ exports.checkSubProgramExists = async (req) => {
   if (!subProgram) throw Boom.notFound();
 
   return null;
+};
+
+exports.authorizeGetDraftELearningSubPrograms = async (req) => {
+  const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
+  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
+
+  const userId = get(req, 'auth.credentials._id');
+  const userRestrictedTestedPrograms = await Program.find({ testers: userId });
+
+  return userRestrictedTestedPrograms;
 };

--- a/src/routes/preHandlers/subPrograms.js
+++ b/src/routes/preHandlers/subPrograms.js
@@ -82,7 +82,7 @@ exports.authorizeGetDraftELearningSubPrograms = async (req) => {
   if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
 
   const userId = get(req, 'auth.credentials._id');
-  const userRestrictedTestedPrograms = await Program.find({ testers: userId });
+  const userRestrictedTestedPrograms = await Program.find({ testers: userId }, { _id: 1 }).lean();
 
-  return userRestrictedTestedPrograms;
+  return userRestrictedTestedPrograms.map(program => program._id);
 };

--- a/src/routes/subPrograms.js
+++ b/src/routes/subPrograms.js
@@ -68,7 +68,7 @@ exports.plugin = {
       path: '/draft-e-learning',
       options: {
         auth: { mode: 'required' },
-        pre: [{ method: authorizeGetDraftELearningSubPrograms, assign: 'userRestrictedTestedPrograms' }],
+        pre: [{ method: authorizeGetDraftELearningSubPrograms, assign: 'testerRestrictedPrograms' }],
       },
       handler: listELearningDraft,
     });

--- a/src/routes/subPrograms.js
+++ b/src/routes/subPrograms.js
@@ -7,6 +7,7 @@ const {
   authorizeStepAdd,
   authorizeSubProgramUpdate,
   checkSubProgramExists,
+  authorizeGetDraftELearningSubPrograms,
 } = require('./preHandlers/subPrograms');
 const { update, addStep, detachStep, listELearningDraft, getById } = require('../controllers/subProgramController');
 const { STEP_TYPES } = require('../models/Step');
@@ -66,7 +67,8 @@ exports.plugin = {
       method: 'GET',
       path: '/draft-e-learning',
       options: {
-        auth: { scope: ['programs:read'] },
+        auth: { mode: 'required' },
+        pre: [{ method: authorizeGetDraftELearningSubPrograms, assign: 'userRestrictedTestedPrograms' }],
       },
       handler: listELearningDraft,
     });

--- a/tests/integration/seed/subProgramsSeed.js
+++ b/tests/integration/seed/subProgramsSeed.js
@@ -7,6 +7,11 @@ const Course = require('../../../src/models/Course');
 const Card = require('../../../src/models/Card');
 const CourseSlot = require('../../../src/models/CourseSlot');
 const { populateDBForAuthentication } = require('./authenticationSeed');
+const { userList } = require('../../seed/userSeed');
+const { rolesList } = require('../../seed/roleSeed');
+
+const clientAdminRole = rolesList.find(role => role.name === 'client_admin')._id;
+const clientAdmin = userList.find(user => user.role.client === clientAdminRole);
 
 const cardsList = [
   { _id: new ObjectID(), template: 'transition', title: 'ceci est un titre' },
@@ -56,6 +61,7 @@ const programsList = [
     name: 'program 2',
     subPrograms: [subProgramsList[3]._id, subProgramsList[4]._id],
     image: 'link',
+    testers: [clientAdmin._id],
   },
 ];
 
@@ -103,4 +109,5 @@ module.exports = {
   stepsList,
   activitiesList,
   cardsList,
+  clientAdmin,
 };

--- a/tests/integration/seed/subProgramsSeed.js
+++ b/tests/integration/seed/subProgramsSeed.js
@@ -8,10 +8,8 @@ const Card = require('../../../src/models/Card');
 const CourseSlot = require('../../../src/models/CourseSlot');
 const { populateDBForAuthentication } = require('./authenticationSeed');
 const { userList } = require('../../seed/userSeed');
-const { rolesList } = require('../../seed/roleSeed');
 
-const clientAdminRole = rolesList.find(role => role.name === 'client_admin')._id;
-const clientAdmin = userList.find(user => user.role.client === clientAdminRole);
+const tester = userList.find(user => user.local.email === 'norole@alenvi.io');
 
 const cardsList = [
   { _id: new ObjectID(), template: 'transition', title: 'ceci est un titre' },
@@ -61,7 +59,7 @@ const programsList = [
     name: 'program 2',
     subPrograms: [subProgramsList[3]._id, subProgramsList[4]._id],
     image: 'link',
-    testers: [clientAdmin._id],
+    testers: [tester._id],
   },
 ];
 
@@ -109,5 +107,5 @@ module.exports = {
   stepsList,
   activitiesList,
   cardsList,
-  clientAdmin,
+  tester,
 };

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -541,8 +541,9 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
       expect(response.result.data.subPrograms.length).toEqual(1);
       const { subPrograms } = response.result.data;
       const stepsIds = subPrograms[0].steps.map(step => step._id);
+      const steps = await Step.find({ _id: { $in: stepsIds } }).lean();
       const eLearningSteps = await Step.countDocuments({ type: E_LEARNING, _id: { $in: stepsIds } });
-      expect(!!eLearningSteps).toBeTruthy();
+      expect(eLearningSteps).toEqual(steps.length);
     });
 
     it('should return an empty array if user is not a tester', async () => {

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -5,8 +5,8 @@ const app = require('../../server');
 const SubProgram = require('../../src/models/SubProgram');
 const Course = require('../../src/models/Course');
 const Step = require('../../src/models/Step');
-const { populateDB, subProgramsList, stepsList, activitiesList } = require('./seed/subProgramsSeed');
-const { getToken, authCompany } = require('./seed/authenticationSeed');
+const { populateDB, subProgramsList, stepsList, activitiesList, tester } = require('./seed/subProgramsSeed');
+const { getToken, authCompany, getTokenByCredentials } = require('./seed/authenticationSeed');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -529,7 +529,7 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
 
   describe('Other roles', () => {
     it('should get draft and e-learning subprograms for which user is a tester', async () => {
-      authToken = await getToken('client_admin');
+      authToken = await getTokenByCredentials(tester.local);
       const response = await app.inject({
         method: 'GET',
         url: '/subprograms/draft-e-learning',

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -541,9 +541,8 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
       expect(response.result.data.subPrograms.length).toEqual(1);
       const { subPrograms } = response.result.data;
       const stepsIds = subPrograms[0].steps.map(step => step._id);
-      const steps = await Step.find({ _id: { $in: stepsIds } }).lean();
       const eLearningSteps = await Step.countDocuments({ type: E_LEARNING, _id: { $in: stepsIds } });
-      expect(eLearningSteps).toEqual(steps.length);
+      expect(eLearningSteps).toEqual(stepsIds.length);
     });
 
     it('should return an empty array if user is not a tester', async () => {

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -5,6 +5,7 @@ const app = require('../../server');
 const SubProgram = require('../../src/models/SubProgram');
 const Course = require('../../src/models/Course');
 const Step = require('../../src/models/Step');
+const { E_LEARNING } = require('../../src/helpers/constants');
 const { populateDB, subProgramsList, stepsList, activitiesList, tester } = require('./seed/subProgramsSeed');
 const { getToken, authCompany, getTokenByCredentials } = require('./seed/authenticationSeed');
 
@@ -540,8 +541,8 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/draft-e-learning', () => {
       expect(response.result.data.subPrograms.length).toEqual(1);
       const { subPrograms } = response.result.data;
       const stepsIds = subPrograms[0].steps.map(step => step._id);
-      const steps = await Step.find({ _id: { $in: stepsIds } }).lean();
-      expect(steps.every(step => step.type === 'e_learning')).toBeTruthy();
+      const eLearningSteps = await Step.countDocuments({ type: E_LEARNING, _id: { $in: stepsIds } });
+      expect(!!eLearningSteps).toBeTruthy();
     });
 
     it('should return an empty array if user is not a tester', async () => {

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -247,6 +247,7 @@ describe('listELearningDraft', () => {
         _id: new ObjectID(),
         status: 'draft',
         steps: [{ type: 'e_learning' }],
+        isStrictlyELearning: true,
         program: [{ _id: new ObjectID(), name: 'name' }],
       },
       {
@@ -261,14 +262,12 @@ describe('listELearningDraft', () => {
         steps: [{ type: 'e_learning' }],
       },
     ];
-    const elearningSubProgramList = subProgramsList
-      .filter(subProgram => subProgram.steps.length && subProgram.isStrictlyELearning && subProgram.program);
 
     find.returns(SinonMongoose.stubChainedQueries([subProgramsList]));
 
     const result = await SubProgramHelper.listELearningDraft(testerRestrictedPrograms);
 
-    expect(result).toMatchObject(elearningSubProgramList);
+    expect(result).toMatchObject([subProgramsList[0]]);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ status: 'draft' }] },
       {

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -215,6 +215,7 @@ describe('listELearningDraft', () => {
         _id: new ObjectID(),
         status: 'draft',
         steps: [{ type: 'e_learning' }],
+        isStrictlyELearning: true,
         program: [{ _id: new ObjectID(), name: 'name' }],
       },
       {
@@ -224,14 +225,12 @@ describe('listELearningDraft', () => {
         program: [{ _id: new ObjectID(), name: 'test' }],
       },
     ];
-    const elearningSubProgramList = subProgramsList
-      .filter(subProgram => subProgram.steps.length && subProgram.isStrictlyELearning && subProgram.program);
 
     find.returns(SinonMongoose.stubChainedQueries([subProgramsList]));
 
     const result = await SubProgramHelper.listELearningDraft();
 
-    expect(result).toMatchObject(elearningSubProgramList);
+    expect(result).toMatchObject([subProgramsList[0]]);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ status: 'draft' }] },
       { query: 'populate', args: [{ path: 'program', select: '_id name description image' }] },

--- a/tests/unit/helpers/subPrograms.test.js
+++ b/tests/unit/helpers/subPrograms.test.js
@@ -241,7 +241,7 @@ describe('listELearningDraft', () => {
   });
 
   it('should return draft subprograms with elearning steps for tester', async () => {
-    const userRestrictedTestedPrograms = [{ _id: new ObjectID(), name: 'name' }];
+    const testerRestrictedPrograms = [new ObjectID()];
     const subProgramsList = [
       {
         _id: new ObjectID(),
@@ -255,13 +255,18 @@ describe('listELearningDraft', () => {
         steps: [{ type: 'on_site' }],
         program: [{ _id: new ObjectID(), name: 'test' }],
       },
+      {
+        _id: new ObjectID(),
+        status: 'draft',
+        steps: [{ type: 'e_learning' }],
+      },
     ];
     const elearningSubProgramList = subProgramsList
       .filter(subProgram => subProgram.steps.length && subProgram.isStrictlyELearning && subProgram.program);
 
     find.returns(SinonMongoose.stubChainedQueries([subProgramsList]));
 
-    const result = await SubProgramHelper.listELearningDraft(userRestrictedTestedPrograms);
+    const result = await SubProgramHelper.listELearningDraft(testerRestrictedPrograms);
 
     expect(result).toMatchObject(elearningSubProgramList);
     SinonMongoose.calledWithExactly(find, [
@@ -271,7 +276,7 @@ describe('listELearningDraft', () => {
         args: [{
           path: 'program',
           select: '_id name description image',
-          match: { _id: { $in: [userRestrictedTestedPrograms[0]._id] } },
+          match: { _id: { $in: testerRestrictedPrograms } },
         }],
       },
       { query: 'populate', args: [{ path: 'steps', select: 'type' }] },


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - ~~Ce n'est pas une ancienne route utilisée par le mobile~~
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - ~~Je n'ai pas fait de breaking change :~~
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a: la route qui n'était accessible que pour les ROF/admin-vendors devient accessible à tous, le tri se fait à partir de la liste des formations pour lesquelles l'utilisateur est testeur, définie dans le préhandler
  - ~~J'ai supprimé une route :~~
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - ~~J'ai renommé une route :~~
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - ~~J'ai ajoute un champ possible dans la route :~~
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - ~~J'ai rendu obligatoire un champs de la route :~~
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - ~~J'ai retiré un champ possible dans la route :~~
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - ~~J'ai supprimé un retour/un champs du retour de la route :~~
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : tous (testeurs/ROF/admin-vendors)

- Cas d'usage : en tant que testeur j'ai accès dans mes formations aux programmes pour lesquels je suis défini comme testeur.
Tester le cas où je me connecte en ROF/admin-vendeur (j'ai accès à tous les formations à tester), où je suis testeur (= non ROF/admin-vendeur) pour un ou plusieurs programmes (à configurer dans la webapp), où je suis testeur pour aucun programmes

PR 1 : je peux visualiser ces programmes dans la catégorie Formations à tester, onglet formation mais je ne peux pas encore y accéder en cliquant dessus (la route pour récupérer un sous programmes e-learning n'est encore accessibles qu'aux ROF/admin-vendeur uniquement, cela sera corrigé dans une seconde PR
