### PR TITLE
COM-1957: access to subprogram when user is a tester

### DIFF
--- a/src/routes/preHandlers/subPrograms.js
+++ b/src/routes/preHandlers/subPrograms.js
@@ -76,22 +76,22 @@ exports.authorizeGetSubProgram = async (req) => {
     .lean();
   if (!subProgram) throw Boom.notFound();
 
-  const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
-  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
+  const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
+  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole)) return null;
 
-  const userId = get(req, 'auth.credentials._id');
+  const loggedUserId = get(req, 'auth.credentials._id');
   const testerList = subProgram.program.testers.map(tester => tester.toHexString());
-  if (!testerList.includes(userId)) throw Boom.forbidden();
+  if (!testerList.includes(loggedUserId)) throw Boom.forbidden();
 
   return null;
 };
 
 exports.authorizeGetDraftELearningSubPrograms = async (req) => {
-  const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
-  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
+  const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
+  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole)) return null;
 
-  const userId = get(req, 'auth.credentials._id');
-  const testerRestrictedPrograms = await Program.find({ testers: userId }, { _id: 1 }).lean();
+  const loggedUserId = get(req, 'auth.credentials._id');
+  const testerRestrictedPrograms = await Program.find({ testers: loggedUserId }, { _id: 1 }).lean();
 
   return testerRestrictedPrograms.map(program => program._id);
 };

--- a/src/routes/preHandlers/subPrograms.js
+++ b/src/routes/preHandlers/subPrograms.js
@@ -70,9 +70,18 @@ exports.authorizeSubProgramUpdate = async (req) => {
   return null;
 };
 
-exports.checkSubProgramExists = async (req) => {
-  const subProgram = await SubProgram.findOne({ _id: req.params._id }).lean();
+exports.authorizeGetSubProgram = async (req) => {
+  const subProgram = await SubProgram.findOne({ _id: req.params._id })
+    .populate({ path: 'program', select: 'testers' })
+    .lean();
   if (!subProgram) throw Boom.notFound();
+
+  const userVendorRole = get(req, 'auth.credentials.role.vendor.name');
+  if ([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(userVendorRole)) return null;
+
+  const userId = get(req, 'auth.credentials._id');
+  const testerList = subProgram.program.testers.map(tester => tester.toHexString());
+  if (!testerList.includes(userId)) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/subPrograms.js
+++ b/src/routes/subPrograms.js
@@ -6,7 +6,7 @@ const {
   authorizeStepDetachment,
   authorizeStepAdd,
   authorizeSubProgramUpdate,
-  checkSubProgramExists,
+  authorizeGetSubProgram,
   authorizeGetDraftELearningSubPrograms,
 } = require('./preHandlers/subPrograms');
 const { update, addStep, detachStep, listELearningDraft, getById } = require('../controllers/subProgramController');
@@ -77,11 +77,11 @@ exports.plugin = {
       method: 'GET',
       path: '/{_id}',
       options: {
-        auth: { scope: ['programs:read'] },
+        auth: { mode: 'required' },
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
-        pre: [{ method: checkSubProgramExists }],
+        pre: [{ method: authorizeGetSubProgram }],
       },
       handler: getById,
     });

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -575,8 +575,8 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/{_id}', () => {
         url: `/subprograms/${subProgramId.toHexString()}`,
         headers: { 'x-access-token': authToken },
       });
-      expect(response.statusCode).toBe(200);
 
+      expect(response.statusCode).toBe(200);
       expect(response.result.data.subProgram).toMatchObject({
         _id: subProgramId,
         name: 'subProgram 4',
@@ -610,28 +610,37 @@ describe('SUBPROGRAMS ROUTES - GET /subprograms/{_id}', () => {
   });
 
   describe('Other roles', () => {
-    const roles = [
-      { name: 'helper', expectedCode: 403 },
-      { name: 'auxiliary', expectedCode: 403 },
-      { name: 'auxiliary_without_company', expectedCode: 403 },
-      { name: 'coach', expectedCode: 403 },
-      { name: 'client_admin', expectedCode: 403 },
-      { name: 'training_organisation_manager', expectedCode: 200 },
-      { name: 'trainer', expectedCode: 403 },
-    ];
-
-    roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-        authToken = await getToken(role.name);
-        const subProgramId = subProgramsList[3]._id;
-        const response = await app.inject({
-          method: 'GET',
-          url: `/subprograms/${subProgramId.toHexString()}`,
-          headers: { 'x-access-token': authToken },
-        });
-
-        expect(response.statusCode).toBe(role.expectedCode);
+    it('should get subprogram if user is tester', async () => {
+      authToken = await getTokenByCredentials(tester.local);
+      const subProgramId = subProgramsList[3]._id;
+      const response = await app.inject({
+        method: 'GET',
+        url: `/subprograms/${subProgramId.toHexString()}`,
+        headers: { 'x-access-token': authToken },
       });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.subProgram).toMatchObject({
+        _id: subProgramId,
+        name: 'subProgram 4',
+        status: 'draft',
+        program: { name: 'program 2' },
+        steps: [
+          { _id: stepsList[2]._id, name: 'step 3', type: 'e_learning', activities: [activitiesList[0]] },
+        ],
+      });
+    });
+
+    it('should return 403 if user is not allowed to access this subprogram', async () => {
+      authToken = await getTokenByCredentials(tester.local);
+      const subProgramId = subProgramsList[0]._id;
+      const response = await app.inject({
+        method: 'GET',
+        url: `/subprograms/${subProgramId.toHexString()}`,
+        headers: { 'x-access-token': authToken },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 });


### PR DESCRIPTION
- ~~[ ] Mon code est testé unitairement~~
- Tests intégrations: (barrer ce qui n'est pas utile)
  -~~ Ce n'est pas une ancienne route utilisée par le mobile~~
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : mobile

- Périmetre roles : tous

- Cas d'usage : je peux accéder au contenu d'un programme dont je suis le testeur
