### PR TITLE
Com 1926

### DIFF
--- a/src/controllers/attendanceController.js
+++ b/src/controllers/attendanceController.js
@@ -6,7 +6,8 @@ const { language } = translate;
 
 const list = async (req) => {
   try {
-    const attendances = await AttendanceHelper.list(req.pre.courseSlotsIds);
+    const { courseSlotsIds, company } = req.pre.attendancesInfos;
+    const attendances = await AttendanceHelper.list(courseSlotsIds, company);
 
     return {
       message: attendances.length ? translate[language].attendancesFound : translate[language].attendancesNotFound,

--- a/src/controllers/attendanceSheetController.js
+++ b/src/controllers/attendanceSheetController.js
@@ -6,7 +6,7 @@ const { language } = translate;
 
 const list = async (req) => {
   try {
-    const attendanceSheets = await AttendanceSheetHelper.list(req.query.course, req.pre.company);
+    const attendanceSheets = await AttendanceSheetHelper.list(req.query.course, req.pre.companyId);
 
     return {
       message: attendanceSheets.length

--- a/src/controllers/attendanceSheetController.js
+++ b/src/controllers/attendanceSheetController.js
@@ -6,7 +6,7 @@ const { language } = translate;
 
 const list = async (req) => {
   try {
-    const attendanceSheets = await AttendanceSheetHelper.list(req.query);
+    const attendanceSheets = await AttendanceSheetHelper.list(req.query.course, req.pre.company);
 
     return {
       message: attendanceSheets.length

--- a/src/helpers/attendanceSheets.js
+++ b/src/helpers/attendanceSheets.js
@@ -21,13 +21,13 @@ exports.create = async (payload) => {
   return AttendanceSheet.create({ ...omit(payload, 'file'), file: fileUploaded });
 };
 
-exports.list = async (course, company) => {
-  const attendanceSheets = await AttendanceSheet.find({ course })
+exports.list = async (courseId, companyId) => {
+  const attendanceSheets = await AttendanceSheet.find({ course: courseId })
     .populate({ path: 'trainee', select: 'company' })
     .lean();
 
-  return company
-    ? attendanceSheets.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), company))
+  return companyId
+    ? attendanceSheets.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), companyId))
     : attendanceSheets;
 };
 

--- a/src/helpers/attendanceSheets.js
+++ b/src/helpers/attendanceSheets.js
@@ -1,4 +1,5 @@
 const omit = require('lodash/omit');
+const get = require('lodash/get');
 const moment = require('moment');
 const AttendanceSheet = require('../models/AttendanceSheet');
 const User = require('../models/User');
@@ -20,7 +21,15 @@ exports.create = async (payload) => {
   return AttendanceSheet.create({ ...omit(payload, 'file'), file: fileUploaded });
 };
 
-exports.list = async query => AttendanceSheet.find({ course: query.course }).lean();
+exports.list = async (course, company) => {
+  const attendanceSheets = await AttendanceSheet.find({ course })
+    .populate({ path: 'trainee', select: 'company' })
+    .lean();
+
+  return company
+    ? attendanceSheets.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), company))
+    : attendanceSheets;
+};
 
 exports.delete = async (attendanceSheet) => {
   await GCloudStorageHelper.deleteCourseFile(attendanceSheet.file.publicId);

--- a/src/helpers/attendances.js
+++ b/src/helpers/attendances.js
@@ -1,7 +1,14 @@
 const Attendance = require('../models/Attendance');
+const UtilsHelper = require('./utils');
 
 exports.create = payload => (new Attendance(payload)).save();
 
-exports.list = async query => Attendance.find({ courseSlot: { $in: query } }).lean();
+exports.list = async (query, company) => {
+  const attendances = await Attendance.find({ courseSlot: { $in: query } })
+    .populate({ path: 'trainee', select: 'company' })
+    .lean();
+
+  return company ? attendances.filter(a => UtilsHelper.areObjectIdsEquals(a.trainee.company, company)) : attendances;
+};
 
 exports.delete = async attendanceId => Attendance.deleteOne({ _id: attendanceId });

--- a/src/helpers/attendances.js
+++ b/src/helpers/attendances.js
@@ -1,3 +1,4 @@
+const get = require('lodash/get');
 const Attendance = require('../models/Attendance');
 const UtilsHelper = require('./utils');
 
@@ -8,7 +9,9 @@ exports.list = async (query, company) => {
     .populate({ path: 'trainee', select: 'company' })
     .lean();
 
-  return company ? attendances.filter(a => UtilsHelper.areObjectIdsEquals(a.trainee.company, company)) : attendances;
+  return company
+    ? attendances.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), company))
+    : attendances;
 };
 
 exports.delete = async attendanceId => Attendance.deleteOne({ _id: attendanceId });

--- a/src/helpers/attendances.js
+++ b/src/helpers/attendances.js
@@ -4,13 +4,13 @@ const UtilsHelper = require('./utils');
 
 exports.create = payload => (new Attendance(payload)).save();
 
-exports.list = async (query, company) => {
+exports.list = async (query, companyId) => {
   const attendances = await Attendance.find({ courseSlot: { $in: query } })
     .populate({ path: 'trainee', select: 'company' })
     .lean();
 
-  return company
-    ? attendances.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), company))
+  return companyId
+    ? attendances.filter(a => UtilsHelper.areObjectIdsEquals(get(a, 'trainee.company'), companyId))
     : attendances;
 };
 

--- a/src/routes/attendanceSheets.js
+++ b/src/routes/attendanceSheets.js
@@ -4,7 +4,11 @@ const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 const { list, create, deleteAttendanceSheet } = require('../controllers/attendanceSheetController');
 const { formDataPayload } = require('./validations/utils');
-const { checkCourseType, attendanceSheetExists } = require('./preHandlers/attendanceSheets');
+const {
+  checkCourseType,
+  attendanceSheetExists,
+  authorizeAttendanceSheetsGet,
+} = require('./preHandlers/attendanceSheets');
 
 exports.plugin = {
   name: 'routes-attendancesheets',
@@ -17,6 +21,7 @@ exports.plugin = {
         validate: {
           query: Joi.object({ course: Joi.objectId() }),
         },
+        pre: [{ method: authorizeAttendanceSheetsGet, assign: 'company' }],
       },
       handler: list,
     });

--- a/src/routes/attendanceSheets.js
+++ b/src/routes/attendanceSheets.js
@@ -21,7 +21,7 @@ exports.plugin = {
         validate: {
           query: Joi.object({ course: Joi.objectId() }),
         },
-        pre: [{ method: authorizeAttendanceSheetsGet, assign: 'company' }],
+        pre: [{ method: authorizeAttendanceSheetsGet, assign: 'companyId' }],
       },
       handler: list,
     });

--- a/src/routes/attendances.js
+++ b/src/routes/attendances.js
@@ -23,7 +23,7 @@ exports.plugin = {
           ),
         },
         auth: { scope: ['attendancesheets:read'] },
-        pre: [{ method: authorizeAttendancesGet, assign: 'courseSlotsIds' }],
+        pre: [{ method: authorizeAttendancesGet, assign: 'attendancesInfos' }],
       },
       handler: list,
     });

--- a/src/routes/attendances.js
+++ b/src/routes/attendances.js
@@ -19,7 +19,7 @@ exports.plugin = {
         validate: {
           query: Joi.alternatives().try(
             Joi.object({ courseSlot: Joi.objectId().required() }),
-            Joi.object({ course: Joi.objectId().required(), company: Joi.objectId() })
+            Joi.object({ course: Joi.objectId().required() })
           ),
         },
         auth: { scope: ['attendancesheets:read'] },

--- a/src/routes/attendances.js
+++ b/src/routes/attendances.js
@@ -19,7 +19,7 @@ exports.plugin = {
         validate: {
           query: Joi.alternatives().try(
             Joi.object({ courseSlot: Joi.objectId().required() }),
-            Joi.object({ course: Joi.objectId().required() })
+            Joi.object({ course: Joi.objectId().required(), company: Joi.objectId() })
           ),
         },
         auth: { scope: ['attendancesheets:read'] },

--- a/src/routes/preHandlers/attendanceSheets.js
+++ b/src/routes/preHandlers/attendanceSheets.js
@@ -1,6 +1,7 @@
 const Boom = require('@hapi/boom');
 const moment = require('moment');
 const get = require('lodash/get');
+const UtilsHelper = require('../../helpers/utils');
 const Course = require('../../models/Course');
 const AttendanceSheet = require('../../models/AttendanceSheet');
 const { INTRA, INTER_B2B } = require('../../helpers/constants');
@@ -12,6 +13,10 @@ exports.authorizeAttendanceSheetsGet = async (req) => {
   const { credentials } = req.auth;
   const loggedUserCompany = get(credentials, 'company._id');
   const loggedUserHasVendorRole = get(credentials, 'role.vendor');
+  if (!UtilsHelper.areObjectIdsEquals(loggedUserCompany, course.company) && !loggedUserHasVendorRole) {
+    throw Boom.forbidden();
+  }
+
   return (course.type === INTER_B2B && !loggedUserHasVendorRole) ? loggedUserCompany : null;
 };
 

--- a/src/routes/preHandlers/attendanceSheets.js
+++ b/src/routes/preHandlers/attendanceSheets.js
@@ -1,8 +1,19 @@
 const Boom = require('@hapi/boom');
 const moment = require('moment');
+const get = require('lodash/get');
 const Course = require('../../models/Course');
 const AttendanceSheet = require('../../models/AttendanceSheet');
-const { INTRA } = require('../../helpers/constants');
+const { INTRA, INTER_B2B } = require('../../helpers/constants');
+
+exports.authorizeAttendanceSheetsGet = async (req) => {
+  const course = await Course.findOne({ _id: req.query.course });
+  if (!course) throw Boom.notFound();
+
+  const { credentials } = req.auth;
+  const loggedUserCompany = get(credentials, 'company._id');
+  const loggedUserHasVendorRole = get(credentials, 'role.vendor');
+  return (course.type === INTER_B2B && !loggedUserHasVendorRole) ? loggedUserCompany : null;
+};
 
 exports.checkCourseType = async (req) => {
   const course = await Course.findOne({ _id: req.payload.course }).populate('slots');

--- a/src/routes/preHandlers/attendanceSheets.js
+++ b/src/routes/preHandlers/attendanceSheets.js
@@ -11,13 +11,18 @@ exports.authorizeAttendanceSheetsGet = async (req) => {
   if (!course) throw Boom.notFound();
 
   const { credentials } = req.auth;
-  const loggedUserCompany = get(credentials, 'company._id');
   const loggedUserHasVendorRole = get(credentials, 'role.vendor');
-  if (!UtilsHelper.areObjectIdsEquals(loggedUserCompany, course.company) && !loggedUserHasVendorRole) {
+  if (loggedUserHasVendorRole) return null;
+
+  const loggedUserCompany = get(credentials, 'company._id');
+
+  if (course.type === INTRA && !UtilsHelper.areObjectIdsEquals(loggedUserCompany, course.company)) {
     throw Boom.forbidden();
   }
 
-  return (course.type === INTER_B2B && !loggedUserHasVendorRole) ? loggedUserCompany : null;
+  if (course.type === INTER_B2B) return loggedUserCompany;
+
+  return null;
 };
 
 exports.checkCourseType = async (req) => {

--- a/src/routes/preHandlers/attendances.js
+++ b/src/routes/preHandlers/attendances.js
@@ -41,11 +41,7 @@ exports.authorizeAttendancesGet = async (req) => {
     if (!UtilsHelper.areObjectIdsEquals(loggedUserCompany, course.company)) throw Boom.forbidden();
   }
 
-  if (course.type === INTER_B2B && req.query.company) {
-    if (!UtilsHelper.areObjectIdsEquals(loggedUserCompany, req.query.company)) {
-      throw Boom.forbidden();
-    }
-
+  if (course.type === INTER_B2B && !loggedUserHasVendorRole) {
     const companyTraineeInCourse = course.trainees.some(t =>
       UtilsHelper.areObjectIdsEquals(loggedUserCompany, t.company));
     if (!companyTraineeInCourse) throw Boom.forbidden();
@@ -57,7 +53,7 @@ exports.authorizeAttendancesGet = async (req) => {
 
   return {
     courseSlotsIds: courseSlots.map(cs => cs._id),
-    company: req.query.company ? loggedUserCompany : null,
+    company: !loggedUserHasVendorRole ? loggedUserCompany : null,
   };
 };
 

--- a/src/routes/preHandlers/attendances.js
+++ b/src/routes/preHandlers/attendances.js
@@ -2,7 +2,6 @@ const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const CourseSlot = require('../../models/CourseSlot');
 const Attendance = require('../../models/Attendance');
-const Course = require('../../models/Course');
 const { TRAINER, INTRA, INTER_B2B } = require('../../helpers/constants');
 const UtilsHelper = require('../../helpers/utils');
 const User = require('../../models/User');
@@ -21,8 +20,8 @@ const authorizeUserWithoutVendorRole = (loggedUserCompany, course) => {
   }
 
   if (course.type === INTER_B2B) {
-    const companyTraineeInCourse = course.trainees.some(t =>
-      UtilsHelper.areObjectIdsEquals(loggedUserCompany, t.company));
+    const companyTraineeInCourse = course.trainees
+      .some(t => UtilsHelper.areObjectIdsEquals(loggedUserCompany, t.company));
     if (!companyTraineeInCourse) throw Boom.forbidden();
   }
 };
@@ -38,11 +37,6 @@ exports.authorizeAttendancesGet = async (req) => {
     .lean();
 
   if (!courseSlots.length) throw Boom.notFound();
-
-  if (req.query.course) {
-    const courseExist = await Course.countDocuments({ _id: req.query.course });
-    if (!courseExist) throw Boom.notFound();
-  }
 
   const { credentials } = req.auth;
   const loggedUserCompany = get(credentials, 'company._id');

--- a/src/routes/preHandlers/attendances.js
+++ b/src/routes/preHandlers/attendances.js
@@ -23,12 +23,12 @@ exports.authorizeAttendancesGet = async (req) => {
     })
     .lean();
 
+  if (!courseSlots.length) throw Boom.notFound();
+
   if (req.query.course) {
     const courseExist = await Course.countDocuments({ _id: req.query.course });
     if (!courseExist) throw Boom.notFound();
   }
-
-  if (req.query.courseSlot && !courseSlots.length) throw Boom.notFound();
 
   const { credentials } = req.auth;
   const loggedUserCompany = get(credentials, 'company._id');

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -219,10 +219,58 @@ describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
       expect(response.statusCode).toBe(200);
       expect(response.result.data.attendanceSheets.length).toEqual(attendanceSheetsLength);
     });
+
+    it('should return a 400 if query course is not ObjectID', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/attendancesheets?course=skusku',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 404 if course doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
   });
 
   describe('Other roles', () => {
     beforeEach(populateDB);
+
+    it('should get only authComapny\'s attendance sheets for interB2B course if user does not have vendor role',
+      async () => {
+        authToken = await getToken('coach');
+
+        const response = await app.inject({
+          method: 'GET',
+          url: `/attendancesheets?course=${coursesList[1]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.result.data.attendanceSheets.length).toEqual(1);
+      });
+
+    it('should get course\'s attendance sheets for interB2B course if user has vendor role', async () => {
+      authToken = await getToken('trainer');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendanceSheets.length).toEqual(2);
+    });
+
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'coach', expectedCode: 200 },

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -269,7 +269,7 @@ describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
         expect(response.result.data.attendanceSheets.length).toEqual(1);
       });
 
-    it('should get course\'s attendance sheets for interB2B course if user has vendor role', async () => {
+    it('should get all course\'s attendance sheets for interB2B course if user has vendor role', async () => {
       authToken = await getToken('trainer');
 
       const response = await app.inject({

--- a/tests/integration/attendanceSheets.test.js
+++ b/tests/integration/attendanceSheets.test.js
@@ -244,7 +244,18 @@ describe('ATTENDANCE SHEETS ROUTES - GET /attendancesheets', () => {
   describe('Other roles', () => {
     beforeEach(populateDB);
 
-    it('should get only authComapny\'s attendance sheets for interB2B course if user does not have vendor role',
+    it('should return a 403 if course is not from userCompany and user has no vendor role', async () => {
+      authToken = await getToken('coach');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendancesheets?course=${coursesList[2]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should get only authCompany\'s attendance sheets for interB2B course if user does not have vendor role',
       async () => {
         authToken = await getToken('coach');
 

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -216,14 +216,14 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 400 if query has course and courseSlot but return a 404 and I have no idea why', async () => {
+    it('should return 400 if query has course and courseSlot', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/attendances/course=${coursesList[0]._id}&courseSlot=${slotsList[0]._id}`,
+        url: `/attendances?course=${coursesList[0]._id}&courseSlot=${slotsList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(404);
+      expect(response.statusCode).toBe(400);
     });
 
     it('should return 404 if invalid course', async () => {
@@ -236,7 +236,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return 404 if no courseSlot found', async () => {
+    it('should return 404 if invalid courseSlot', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/attendances?courseSlot=${new ObjectID()}`,

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -175,6 +175,17 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.result.data.attendances.length).toEqual(1);
     });
 
+    it('should get course attendances not filtered by company for inter course', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendances?course=${coursesList[3]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendances.length).toEqual(2);
+    });
+
     it('should return 400 if query is empty', async () => {
       const response = await app.inject({
         method: 'GET',
@@ -205,6 +216,16 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.statusCode).toBe(400);
     });
 
+    it('should return 400 if query has course and courseSlot but return a 404 and I have no idea why', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendances/course=${coursesList[0]._id}&courseSlot=${slotsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
     it('should return 404 if invalid course', async () => {
       const response = await app.inject({
         method: 'GET',
@@ -223,27 +244,6 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       });
 
       expect(response.statusCode).toBe(404);
-    });
-
-    it('should return 400 if query has course and courseSlot but return a 404 and I have no idea why', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/attendances/course=${coursesList[0]._id}&courseSlot=${slotsList[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should get course attendances not filtered by company for inter course', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/attendances?course=${coursesList[3]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.result.data.attendances.length).toEqual(2);
     });
   });
 

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -161,7 +161,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.attendances.length).toEqual(attendancesList.length);
+      expect(response.result.data.attendances.length).toEqual(1);
     });
 
     it('should get courseSlot attendances', async () => {
@@ -172,7 +172,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.result.data.attendances.length).toEqual(attendancesList.length);
+      expect(response.result.data.attendances.length).toEqual(1);
     });
 
     it('should return 400 if query is empty', async () => {
@@ -285,7 +285,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       authToken = await getToken('client_admin');
       const response = await app.inject({
         method: 'GET',
-        url: `/attendances?course=${coursesList[3]._id}`,
+        url: `/attendances?course=${coursesList[4]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -215,7 +215,7 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return 404 if invalid courseSlot', async () => {
+    it('should return 404 if no courseSlot found', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/attendances?courseSlot=${new ObjectID()}`,

--- a/tests/integration/attendances.test.js
+++ b/tests/integration/attendances.test.js
@@ -175,6 +175,36 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.result.data.attendances.length).toEqual(attendancesList.length);
     });
 
+    it('should return 400 if query is empty', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/attendances',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if query course has invalid type', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/attendances?course=skusku',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if query courseSlot has invalid type', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/attendances?courseSlot=skusku',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
     it('should return 404 if invalid course', async () => {
       const response = await app.inject({
         method: 'GET',
@@ -195,24 +225,25 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return 400 if query is empty', async () => {
+    it('should return 400 if query has course and courseSlot but return a 404 and I have no idea why', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/attendances',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
-    it('should return 404 if query has course and courseSlot', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: `/attendances/course=${coursesList[0]._id}&&courseSlot=${slotsList[0]._id}`,
+        url: `/attendances/course=${coursesList[0]._id}&courseSlot=${slotsList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    it('should get course attendances not filtered by company for inter course', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendances?course=${coursesList[3]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendances.length).toEqual(2);
     });
   });
 
@@ -248,6 +279,29 @@ describe('ATTENDANCES ROUTES - GET /attendances', () => {
       });
 
       expect(response.statusCode).toBe(403);
+    });
+
+    it('should return 403 if user is client_admin, course is inter and no trainee is from user company', async () => {
+      authToken = await getToken('client_admin');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendances?course=${coursesList[3]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should get course attendances filtered by company for inter course', async () => {
+      authToken = await getToken('client_admin');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/attendances?course=${coursesList[3]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.attendances.length).toEqual(1);
     });
 
     const roles = [

--- a/tests/integration/seed/attendanceSheetsSeed.js
+++ b/tests/integration/seed/attendanceSheetsSeed.js
@@ -34,7 +34,7 @@ const coursesList = [
   {
     _id: new ObjectID(),
     subProgram: new ObjectID(),
-    type: 'inter_b2b',
+    type: 'intra',
     company: otherCompany._id,
     trainees: [coachFromAuthCompany._id],
   },

--- a/tests/integration/seed/attendanceSheetsSeed.js
+++ b/tests/integration/seed/attendanceSheetsSeed.js
@@ -2,11 +2,19 @@ const { ObjectID } = require('mongodb');
 const AttendanceSheet = require('../../../src/models/AttendanceSheet');
 const Course = require('../../../src/models/Course');
 const CourseSlot = require('../../../src/models/CourseSlot');
-const { populateDBForAuthentication, authCompany, rolesList, userList } = require('./authenticationSeed');
-const { COACH } = require('../../../src/helpers/constants.js');
+const { populateDBForAuthentication, authCompany, rolesList, userList, otherCompany } = require('./authenticationSeed');
+const { COACH, WEBAPP } = require('../../../src/helpers/constants.js');
 
 const coachFromAuthCompany = userList
   .find(user => user.role.client === rolesList.find(role => role.name === COACH)._id);
+
+const traineeFromOtherCompany = {
+  _id: new ObjectID(),
+  identity: { firstname: 'traineeFromINTERB2B', lastname: 'withOtherCompany' },
+  local: { email: 'traineeFromINTERB2B@alenvi.io', password: '123456!eR' },
+  origin: WEBAPP,
+  company: otherCompany._id,
+};
 
 const coursesList = [
   {
@@ -36,6 +44,18 @@ const attendanceSheetsList = [
     course: coursesList[0],
     file: { publicId: 'mon upload', link: 'www.test.com' },
     trainee: coachFromAuthCompany._id,
+  },
+  {
+    _id: new ObjectID(),
+    course: coursesList[1],
+    file: { publicId: 'mon upload', link: 'www.test.com' },
+    trainee: coachFromAuthCompany._id,
+  },
+  {
+    _id: new ObjectID(),
+    course: coursesList[1],
+    file: { publicId: 'mon upload', link: 'www.test.com' },
+    trainee: traineeFromOtherCompany._id,
   },
 ];
 

--- a/tests/integration/seed/attendanceSheetsSeed.js
+++ b/tests/integration/seed/attendanceSheetsSeed.js
@@ -27,7 +27,15 @@ const coursesList = [
   {
     _id: new ObjectID(),
     subProgram: new ObjectID(),
+    company: authCompany._id,
     type: 'inter_b2b',
+    trainees: [coachFromAuthCompany._id],
+  },
+  {
+    _id: new ObjectID(),
+    subProgram: new ObjectID(),
+    type: 'inter_b2b',
+    company: otherCompany._id,
     trainees: [coachFromAuthCompany._id],
   },
 ];

--- a/tests/integration/seed/attendancesSeed.js
+++ b/tests/integration/seed/attendancesSeed.js
@@ -54,12 +54,20 @@ const coursesList = [
     trainees: [new ObjectID()],
     trainer: trainerList[0]._id,
   },
-  { // interb2b with trainees from otherCompany
+  { // interb2b
     _id: new ObjectID(),
     subProgram: new ObjectID(),
     company: authCompany._id,
     type: 'inter_b2b',
     trainees: [new ObjectID(), new ObjectID()],
+    trainer: trainerList[0]._id,
+  },
+  { // interb2b with only trainees from otherCompany
+    _id: new ObjectID(),
+    subProgram: new ObjectID(),
+    company: authCompany._id,
+    type: 'inter_b2b',
+    trainees: [new ObjectID()],
     trainer: trainerList[0]._id,
   },
 ];
@@ -91,6 +99,13 @@ const slotsList = [
     startDate: new Date('2020-01-23').toISOString(),
     endDate: new Date('2020-01-23').toISOString(),
     course: coursesList[3],
+    step: new ObjectID(),
+  },
+  { // slot for coursesList[4]
+    _id: new ObjectID(),
+    startDate: new Date('2020-01-23').toISOString(),
+    endDate: new Date('2020-01-23').toISOString(),
+    course: coursesList[4],
     step: new ObjectID(),
   },
 ];
@@ -140,6 +155,13 @@ const companyTraineesList = [
     local: { email: 'authTraineeFromINTERB2B@alenvi.io', password: '123456!eR' },
     origin: WEBAPP,
     company: authCompany._id,
+  },
+  {
+    _id: coursesList[4].trainees[0],
+    identity: { firstname: 'traineeFromINTERB2B', lastname: 'withOtherCompany' },
+    local: { email: 'otherTraineeFromINTERB2B@alenvi.io', password: '123456!eR' },
+    origin: WEBAPP,
+    company: otherCompany._id,
   },
 ];
 

--- a/tests/integration/seed/attendancesSeed.js
+++ b/tests/integration/seed/attendancesSeed.js
@@ -54,6 +54,14 @@ const coursesList = [
     trainees: [new ObjectID()],
     trainer: trainerList[0]._id,
   },
+  { // interb2b with trainees from otherCompany
+    _id: new ObjectID(),
+    subProgram: new ObjectID(),
+    company: authCompany._id,
+    type: 'inter_b2b',
+    trainees: [new ObjectID(), new ObjectID()],
+    trainer: trainerList[0]._id,
+  },
 ];
 
 const slotsList = [
@@ -78,6 +86,13 @@ const slotsList = [
     course: coursesList[2],
     step: new ObjectID(),
   },
+  { // slot for coursesList[3]
+    _id: new ObjectID(),
+    startDate: new Date('2020-01-23').toISOString(),
+    endDate: new Date('2020-01-23').toISOString(),
+    course: coursesList[3],
+    step: new ObjectID(),
+  },
 ];
 
 const attendancesList = [
@@ -85,6 +100,16 @@ const attendancesList = [
     _id: new ObjectID(),
     courseSlot: slotsList[0],
     trainee: coursesList[0].trainees[0],
+  },
+  {
+    _id: new ObjectID(),
+    courseSlot: slotsList[3],
+    trainee: coursesList[3].trainees[0],
+  },
+  {
+    _id: new ObjectID(),
+    courseSlot: slotsList[3],
+    trainee: coursesList[3].trainees[1],
   },
 ];
 
@@ -102,7 +127,20 @@ const companyTraineesList = [
     local: { email: 'traineeWithoutCompany@alenvi.io', password: '123456!eR' },
     origin: WEBAPP,
   },
-
+  {
+    _id: coursesList[3].trainees[0],
+    identity: { firstname: 'traineeFromINTERB2B', lastname: 'withOtherCompany' },
+    local: { email: 'traineeFromINTERB2B@alenvi.io', password: '123456!eR' },
+    origin: WEBAPP,
+    company: otherCompany._id,
+  },
+  {
+    _id: coursesList[3].trainees[1],
+    identity: { firstname: 'traineeFromINTERB2B', lastname: 'withAuthCompany' },
+    local: { email: 'authTraineeFromINTERB2B@alenvi.io', password: '123456!eR' },
+    origin: WEBAPP,
+    company: authCompany._id,
+  },
 ];
 
 const populateDB = async () => {

--- a/tests/unit/helpers/attendanceSheets.test.js
+++ b/tests/unit/helpers/attendanceSheets.test.js
@@ -21,18 +21,43 @@ describe('list', () => {
     const courseId = new ObjectID();
     const attendanceSheets = [{
       course: courseId,
-      file: {
-        publicId: 'mon premier upload',
-        link: 'www.test.com',
-      },
+      file: { publicId: 'mon premier upload', link: 'www.test.com' },
       date: '2020-04-03T10:00:00',
     }];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendanceSheets], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([attendanceSheets]));
 
-    const result = await attendanceSheetHelper.list({ course: courseId });
+    const result = await attendanceSheetHelper.list(courseId, null);
 
     expect(result).toMatchObject(attendanceSheets);
+    SinonMongoose.calledWithExactly(find, [
+      { query: 'find', args: [{ course: courseId }] },
+      { query: 'lean' },
+    ]);
+  });
+
+  it('should return course attendance sheets from logged user company', async () => {
+    const courseId = new ObjectID();
+    const authCompanyId = new ObjectID();
+    const otherCompanyId = new ObjectID();
+    const attendanceSheets = [
+      {
+        course: courseId,
+        file: { publicId: 'mon upload avec un trainne de authCompany', link: 'www.test.com' },
+        trainee: { _id: new ObjectID(), company: authCompanyId },
+      },
+      {
+        course: courseId,
+        file: { publicId: 'mon upload avec un trainne de otherCompany', link: 'www.test.com' },
+        trainee: { _id: new ObjectID(), company: otherCompanyId },
+      },
+    ];
+
+    find.returns(SinonMongoose.stubChainedQueries([attendanceSheets]));
+
+    const result = await attendanceSheetHelper.list(courseId, authCompanyId);
+
+    expect(result).toMatchObject([attendanceSheets[0]]);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ course: courseId }] },
       { query: 'lean' },

--- a/tests/unit/helpers/attendanceSheets.test.js
+++ b/tests/unit/helpers/attendanceSheets.test.js
@@ -30,10 +30,14 @@ describe('list', () => {
     const result = await attendanceSheetHelper.list(courseId, null);
 
     expect(result).toMatchObject(attendanceSheets);
-    SinonMongoose.calledWithExactly(find, [
-      { query: 'find', args: [{ course: courseId }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ course: courseId }] },
+        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should return course attendance sheets from logged user company', async () => {
@@ -58,10 +62,14 @@ describe('list', () => {
     const result = await attendanceSheetHelper.list(courseId, authCompanyId);
 
     expect(result).toMatchObject([attendanceSheets[0]]);
-    SinonMongoose.calledWithExactly(find, [
-      { query: 'find', args: [{ course: courseId }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ course: courseId }] },
+        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
@@ -111,10 +119,13 @@ describe('create', () => {
     formatIdentity.returns('monsieurPATATE');
 
     await attendanceSheetHelper.create(payload);
-    SinonMongoose.calledWithExactly(findOne, [
-      { query: '', args: [{ _id: 'id de quelqun' }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: '', args: [{ _id: 'id de quelqun' }] },
+        { query: 'lean' },
+      ]
+    );
     sinon.assert.calledOnceWithExactly(
       formatIdentity,
       { firstName: 'monsieur', lastname: 'patate' },

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -31,29 +31,7 @@ describe('list', () => {
     find.restore();
   });
 
-  it('should return a courseSlot attendances', async () => {
-    const courseSlot = new ObjectID();
-    const attendancesList = [
-      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot },
-      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot },
-    ];
-
-    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
-
-    const result = await AttendanceHelper.list([courseSlot], null);
-
-    expect(result).toMatchObject(attendancesList);
-    SinonMongoose.calledWithExactly(
-      find,
-      [
-        { query: 'find', args: [{ courseSlot: { $in: [courseSlot] } }] },
-        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should return all courseSlots attendances', async () => {
+  it('should return courseSlots\' attendances', async () => {
     const courseSlots = [new ObjectID(), new ObjectID()];
     const attendancesList = [
       { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot: courseSlots[0] },

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -43,11 +43,14 @@ describe('list', () => {
     const result = await AttendanceHelper.list([courseSlot], null);
 
     expect(result).toMatchObject(attendancesList);
-    SinonMongoose.calledWithExactly(find, [
-      { query: 'find', args: [{ courseSlot: { $in: [courseSlot] } }] },
-      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ courseSlot: { $in: [courseSlot] } }] },
+        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should return all courseSlots attendances', async () => {
@@ -62,11 +65,14 @@ describe('list', () => {
     const result = await AttendanceHelper.list([courseSlots], null);
 
     expect(result).toMatchObject(attendancesList);
-    SinonMongoose.calledWithExactly(find, [
-      { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
-      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
+        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should return all courseSlots attendances for a company', async () => {
@@ -83,11 +89,14 @@ describe('list', () => {
     const result = await AttendanceHelper.list([courseSlots], companyId);
 
     expect(result).toMatchObject([attendancesList[0]]);
-    SinonMongoose.calledWithExactly(find, [
-      { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
-      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
-      { query: 'lean' },
-    ]);
+    SinonMongoose.calledWithExactly(
+      find,
+      [
+        { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
+        { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -45,6 +45,7 @@ describe('list', () => {
     expect(result).toMatchObject(attendancesList);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ courseSlot: { $in: [courseSlot] } }] },
+      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
       { query: 'lean' },
     ]);
   });
@@ -63,6 +64,7 @@ describe('list', () => {
     expect(result).toMatchObject(attendancesList);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
+      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
       { query: 'lean' },
     ]);
   });
@@ -83,6 +85,7 @@ describe('list', () => {
     expect(result).toMatchObject([attendancesList[0]]);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
+      { query: 'populate', args: [{ path: 'trainee', select: 'company' }] },
       { query: 'lean' },
     ]);
   });

--- a/tests/unit/helpers/attendances.test.js
+++ b/tests/unit/helpers/attendances.test.js
@@ -31,20 +31,58 @@ describe('list', () => {
     find.restore();
   });
 
-  it('should return some courseSlots attendances', async () => {
+  it('should return a courseSlot attendances', async () => {
     const courseSlot = new ObjectID();
     const attendancesList = [
-      { trainee: new ObjectID(), courseSlot },
-      { trainee: new ObjectID(), courseSlot },
+      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot },
+      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot },
     ];
 
-    find.returns(SinonMongoose.stubChainedQueries([attendancesList], ['lean']));
+    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
 
-    const result = await AttendanceHelper.list([courseSlot]);
+    const result = await AttendanceHelper.list([courseSlot], null);
 
     expect(result).toMatchObject(attendancesList);
     SinonMongoose.calledWithExactly(find, [
       { query: 'find', args: [{ courseSlot: { $in: [courseSlot] } }] },
+      { query: 'lean' },
+    ]);
+  });
+
+  it('should return all courseSlots attendances', async () => {
+    const courseSlots = [new ObjectID(), new ObjectID()];
+    const attendancesList = [
+      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot: courseSlots[0] },
+      { trainee: { _id: new ObjectID(), company: new ObjectID() }, courseSlot: courseSlots[1] },
+    ];
+
+    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
+
+    const result = await AttendanceHelper.list([courseSlots], null);
+
+    expect(result).toMatchObject(attendancesList);
+    SinonMongoose.calledWithExactly(find, [
+      { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
+      { query: 'lean' },
+    ]);
+  });
+
+  it('should return all courseSlots attendances for a company', async () => {
+    const companyId = new ObjectID();
+    const otherCompanyId = new ObjectID();
+    const courseSlots = [new ObjectID(), new ObjectID()];
+    const attendancesList = [
+      { trainee: { _id: new ObjectID(), company: companyId }, courseSlot: courseSlots[0] },
+      { trainee: { _id: new ObjectID(), company: otherCompanyId }, courseSlot: courseSlots[1] },
+    ];
+
+    find.returns(SinonMongoose.stubChainedQueries([attendancesList]));
+
+    const result = await AttendanceHelper.list([courseSlots], companyId);
+
+    expect(result).toMatchObject([attendancesList[0]]);
+    SinonMongoose.calledWithExactly(find, [
+      { query: 'find', args: [{ courseSlot: { $in: [courseSlots] } }] },
       { query: 'lean' },
     ]);
   });


### PR DESCRIPTION
- [x] Mon code est testé unitairement

- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile 
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- ~~[ ] Je n'ai pas changé de constante~~

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites
  
  
Périmetre interface : vendor / client

Périmetre roles : trainer / coach / client_admin / rof / vendor_admin

Cas d'usage :
J'ai accès à l'onglet suivi des stagiaires sur l'interface client.
Quoi tester : 
- en tant que vendor_admin / trainer:
    - je peux ajouter / supprimer un émargement sur l'interface vendeur et client pour une formation intra et inter
    - je peux ajouter un apprenant externe et modifier ses émargements côté vendeur et client
    - je peux supprimer / télécharger  / ajouter une fiche d'émargement
    - côté client, je ne vois que les apprenants (inscrit ou non) de ma structure (émargement et fiche d'émargement)

- en tant que coach / client admin: 
    - je ne peux ni modifier les émargements, ni supprimer / ajouter de fiche d'émargement.
    - je ne vois que les apprenants de ma structure