### PR TITLE
COM-1954 add route to remove refund

### DIFF
--- a/src/controllers/paymentController.js
+++ b/src/controllers/paymentController.js
@@ -53,8 +53,20 @@ const update = async (req) => {
   }
 };
 
+const remove = async (req) => {
+  try {
+    await PaymentHelper.remove(req.params._id);
+
+    return { message: translate[language].paymentRemoved };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
 module.exports = {
   create,
   createList,
   update,
+  remove,
 };

--- a/src/helpers/payments.js
+++ b/src/helpers/payments.js
@@ -163,3 +163,5 @@ exports.savePayments = async (payload, credentials) => {
   );
   return exports.generateXML(firstPayments, recurPayments, company);
 };
+
+exports.remove = async paymentId => Payment.deleteOne({ _id: paymentId });

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -186,6 +186,7 @@ module.exports = {
     paymentNotFound: 'Payment not found.',
     paymentCreated: 'Payment created.',
     paymentUpated: 'Payment updated.',
+    paymentRemoved: 'Payment removed.',
     /* Pay */
     payListCreated: 'Pay list created.',
     hoursToWorkFound: 'Hours to work found.',
@@ -471,6 +472,7 @@ module.exports = {
     paymentCreated: 'Règlement créé.',
     paymentNotFound: 'Règlement non trouvé.',
     paymentUpated: 'Règlement modifié.',
+    paymentRemoved: 'Règlement supprimé.',
     /* Pay */
     payListCreated: 'Liste de paie créée',
     hoursToWorkFound: 'Heures à travailler trouvées.',

--- a/src/routes/payments.js
+++ b/src/routes/payments.js
@@ -3,16 +3,13 @@
 const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
-const {
-  create,
-  createList,
-  update,
-} = require('../controllers/paymentController');
+const { create, createList, update, remove } = require('../controllers/paymentController');
 const {
   getPayment,
   authorizePaymentUpdate,
   authorizePaymentsListCreation,
   authorizePaymentCreation,
+  authorizePaymentDeletion,
 } = require('./preHandlers/payments');
 const { PAYMENT_NATURES, PAYMENT_TYPES } = require('../models/Payment');
 
@@ -74,12 +71,24 @@ exports.plugin = {
             nature: Joi.string(),
           }),
         },
+        pre: [{ method: getPayment, assign: 'payment' }, { method: authorizePaymentUpdate }],
+      },
+      handler: update,
+    });
+
+    server.route({
+      method: 'DELETE',
+      path: '/{_id}',
+      options: {
+        auth: { scope: ['payments:edit'] },
+        validate: { params: Joi.object({ _id: Joi.objectId().required() }) },
         pre: [
           { method: getPayment, assign: 'payment' },
           { method: authorizePaymentUpdate },
+          { method: authorizePaymentDeletion },
         ],
       },
-      handler: update,
+      handler: remove,
     });
   },
 };

--- a/src/routes/preHandlers/payments.js
+++ b/src/routes/preHandlers/payments.js
@@ -4,6 +4,8 @@ const Payment = require('../../models/Payment');
 const Customer = require('../../models/Customer');
 const ThirdPartyPayer = require('../../models/ThirdPartyPayer');
 const translate = require('../../helpers/translate');
+const UtilsHelper = require('../../helpers/utils');
+const { REFUND } = require('../../helpers/constants');
 
 const { language } = translate;
 
@@ -23,7 +25,7 @@ exports.authorizePaymentUpdate = (req) => {
   try {
     const { credentials } = req.auth;
     const { payment } = req.pre;
-    if (payment.company.toHexString() === get(credentials, 'company._id', null).toHexString()) return null;
+    if (UtilsHelper.areObjectIdsEquals(payment.company, get(credentials, 'company._id', null))) return null;
 
     throw Boom.forbidden();
   } catch (e) {
@@ -69,4 +71,11 @@ exports.authorizePaymentCreation = async (req) => {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
   }
+};
+
+exports.authorizePaymentDeletion = async (req) => {
+  const { payment } = req.pre;
+  if (payment.nature !== REFUND) throw Boom.forbidden();
+
+  return null;
 };

--- a/tests/unit/helpers/payments.test.js
+++ b/tests/unit/helpers/payments.test.js
@@ -530,3 +530,21 @@ describe('savePayments', () => {
     sinon.assert.calledTwice(updateOneStub);
   });
 });
+
+describe('remove', () => {
+  let deleteOne;
+  beforeEach(() => {
+    deleteOne = sinon.stub(Payment, 'deleteOne');
+  });
+  afterEach(() => {
+    deleteOne.restore();
+  });
+
+  it('should remove a payment', async () => {
+    const paymentId = new ObjectID();
+
+    await PaymentsHelper.remove(paymentId);
+
+    sinon.assert.calledOnceWithExactly(deleteOne, { _id: paymentId });
+  });
+});


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile 
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile -np
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [ ] Je n'ai pas changé de constante - uniquement sur la webapp

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : Je peux supprimer un remboursement. Verifier qu'en tant qu'aidant je ne peux pas le faire.
REFACTO : Si j'essaye de creer ou modifier un reglement a une date ou il y a une attestation fiscale, j'ai un message de confirmation. Je ne savais pas si il fallait que le message y soit pour un tiers payeur, dans le doute je l'ai laissé car je ne trouvais pas ca tres genant. 