### PR TITLE
COM-1961: remove return from create administrative document

### DIFF
--- a/src/controllers/administrativeDocumentController.js
+++ b/src/controllers/administrativeDocumentController.js
@@ -37,11 +37,10 @@ const list = async (req) => {
 
 const remove = async (req) => {
   try {
-    const administrativeDocument = await AdministrativeDocumentHelper.removeAdministrativeDocument(req.params._id);
+    await AdministrativeDocumentHelper.removeAdministrativeDocument(req.params._id);
 
     return {
       message: translate[language].administrativeDocumentRemoved,
-      data: { administrativeDocument },
     };
   } catch (e) {
     req.log('error', e);

--- a/src/controllers/administrativeDocumentController.js
+++ b/src/controllers/administrativeDocumentController.js
@@ -6,15 +6,9 @@ const { language } = translate;
 
 const create = async (req) => {
   try {
-    const administrativeDocument = await AdministrativeDocumentHelper.createAdministrativeDocument(
-      req.payload,
-      req.auth.credentials
-    );
+    await AdministrativeDocumentHelper.createAdministrativeDocument(req.payload, req.auth.credentials);
 
-    return {
-      message: translate[language].administrativeDocumentCreated,
-      data: { administrativeDocument },
-    };
+    return { message: translate[language].administrativeDocumentCreated };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);
@@ -39,9 +33,7 @@ const remove = async (req) => {
   try {
     await AdministrativeDocumentHelper.removeAdministrativeDocument(req.params._id);
 
-    return {
-      message: translate[language].administrativeDocumentRemoved,
-    };
+    return { message: translate[language].administrativeDocumentRemoved };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/helpers/administrativeDocument.js
+++ b/src/helpers/administrativeDocument.js
@@ -25,11 +25,7 @@ exports.createAdministrativeDocument = async (payload, credentials) => {
     permission: { type: 'anyone', role: 'reader', allowFileDiscovery: false },
   });
 
-  return (await AdministrativeDocument.create({
-    company: companyId,
-    name: payload.name,
-    driveFile: { driveId, link },
-  })).toObject();
+  await AdministrativeDocument.create({ company: companyId, name: payload.name, driveFile: { driveId, link } });
 };
 
 exports.listAdministrativeDocuments = async credentials =>

--- a/tests/unit/helpers/administrativeDocument.test.js
+++ b/tests/unit/helpers/administrativeDocument.test.js
@@ -35,14 +35,11 @@ describe('createAdministrativeDocument', () => {
   it('should create an administrative document', async () => {
     const uploadedFile = { id: '12345', webViewLink: 'www.12345.fr' };
     addFileStub.returns(uploadedFile);
-    const administrativeDocument = { company: companyId, name: payload.name };
 
     findByIdCompany.returns(SinonMongoose.stubChainedQueries([{ folderId: '1234' }], ['lean']));
-    createAdministrativeDocument.returns(SinonMongoose.stubChainedQueries([administrativeDocument], ['toObject']));
 
-    const res = await AdministrativeDocumentHelper.createAdministrativeDocument(payload, credentials);
+    await AdministrativeDocumentHelper.createAdministrativeDocument(payload, credentials);
 
-    expect(res).toEqual(administrativeDocument);
     sinon.assert.calledWithExactly(
       addFileStub,
       { driveFolderId: '1234', name: payload.name, type: payload.mimeType, body: payload.file }
@@ -51,15 +48,9 @@ describe('createAdministrativeDocument', () => {
       createPermissionStub,
       { fileId: uploadedFile.id, permission: { type: 'anyone', role: 'reader', allowFileDiscovery: false } }
     );
-    SinonMongoose.calledWithExactly(
+    sinon.assert.calledWithExactly(
       createAdministrativeDocument,
-      [
-        {
-          query: 'create',
-          args: [{ company: companyId, name: payload.name, driveFile: { driveId: '12345', link: 'www.12345.fr' } }],
-        },
-        { query: 'toObject' },
-      ]
+      { company: companyId, name: payload.name, driveFile: { driveId: '12345', link: 'www.12345.fr' } }
     );
     SinonMongoose.calledWithExactly(findByIdCompany, [{ query: 'findById', args: [companyId] }, { query: 'lean' }]);
   });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
-~~ Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : suppression du retour de la fonction createAdministriveDocument qui n'était pas utilisé
