### PR TITLE
Add test:withTag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test:unit": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/unit/*",
     "test:integration": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/integration/*",
+    "test:withTag": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit --grep newTest tests/*",
     "test": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit tests/*",
     "test-watch": "nodemon --exec 'npm test'",
     "debug": "nodemon --inspect",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test:unit": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/unit/*",
     "test:integration": "NODE_ENV=test mocha --timeout 999999 --colors --exit tests/integration/*",
-    "test:withTag": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit --grep newTest tests/*",
+    "test:tag": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit --grep '#tag' tests/*",
     "test": "NODE_ENV=test mocha --timeout 999999 --colors --recursive --exit tests/*",
     "test-watch": "nodemon --exec 'npm test'",
     "debug": "nodemon --inspect",


### PR DESCRIPTION
Ajout des tests avec tags.

Il vous suffit de rajouter `#tag` à n'importe quel test (dans la description du `it()` ou du` describes()`) et lorsque vous lancerez `npm run test:tag`, tous les tests taggés seront lancés.