### PR TITLE
COM-1974: can't create a questionnaire if already one in draft

### DIFF
--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -291,7 +291,7 @@ module.exports = {
     questionnairesFound: 'Questionnaires found.',
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
-    draftQuestionnaireAlreadyExists: 'A draft questionnaire already exists.',
+    draftQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
   },
   'fr-FR': {
     /* Global errors */
@@ -582,6 +582,6 @@ module.exports = {
     questionnairesFound: 'Liste des questionnaires trouvée.',
     questionnairesNotFound: 'Liste des questionnaires non trouvée.',
     questionnaireCreated: 'Questionnaire créé.',
-    draftQuestionnaireAlreadyExists: 'Il existe déjà un questionnaire en brouillon.',
+    draftQuestionnaireAlreadyExists: 'Il existe déjà un questionnaire en brouillon de type \'Recueil des attentes\'.',
   },
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -291,7 +291,7 @@ module.exports = {
     questionnairesFound: 'Questionnaires found.',
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
-    draftQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
+    draftExpectationQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
   },
   'fr-FR': {
     /* Global errors */
@@ -582,6 +582,7 @@ module.exports = {
     questionnairesFound: 'Liste des questionnaires trouvée.',
     questionnairesNotFound: 'Liste des questionnaires non trouvée.',
     questionnaireCreated: 'Questionnaire créé.',
-    draftQuestionnaireAlreadyExists: 'Il existe déjà un questionnaire en brouillon de type \'Recueil des attentes\'.',
+    draftExpectationQuestionnaireAlreadyExists: `Il existe déjà un questionnaire en brouillon de type 'Recueil des
+      attentes'.`,
   },
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -291,6 +291,7 @@ module.exports = {
     questionnairesFound: 'Questionnaires found.',
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
+    draftQuestionnaireAlreadyExists: 'A draft questionnaire already exists.',
   },
   'fr-FR': {
     /* Global errors */
@@ -581,5 +582,6 @@ module.exports = {
     questionnairesFound: 'Liste des questionnaires trouvée.',
     questionnairesNotFound: 'Liste des questionnaires non trouvée.',
     questionnaireCreated: 'Questionnaire créé.',
+    draftQuestionnaireAlreadyExists: 'Il existe déjà un questionnaire en brouillon.',
   },
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -5,9 +5,11 @@ const Questionnaire = require('../../models/Questionnaire');
 
 const { language } = translate;
 
-exports.authorizeQuestionnaireCreation = async () => {
-  const draftQuestionnaires = await Questionnaire.countDocuments({ type: EXPECTATIONS, status: DRAFT });
+exports.authorizeQuestionnaireCreation = async (req) => {
+  const { type } = req.payload;
+  if (type !== EXPECTATIONS) return null;
 
+  const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
   if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
 
   return null;

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -10,7 +10,7 @@ exports.authorizeQuestionnaireCreation = async (req) => {
   if (type !== EXPECTATIONS) return null;
 
   const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
-  if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
+  if (draftQuestionnaires) throw Boom.conflict(translate[language].draftExpectationQuestionnaireAlreadyExists);
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,13 +1,12 @@
 const Boom = require('@hapi/boom');
-const { DRAFT } = require('../../helpers/constants');
+const { DRAFT, EXPECTATIONS } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
 
 const { language } = translate;
 
-exports.authorizeQuestionnaireCreation = async (req) => {
-  const { type } = req.payload;
-  const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
+exports.authorizeQuestionnaireCreation = async () => {
+  const draftQuestionnaires = await Questionnaire.countDocuments({ type: EXPECTATIONS, status: DRAFT });
 
   if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
 

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,0 +1,12 @@
+const Boom = require('@hapi/boom');
+const { DRAFT } = require('../../helpers/constants');
+const Questionnaire = require('../../models/Questionnaire');
+
+exports.authorizeQuestionnaireCreation = async (req) => {
+  const { type } = req.payload;
+  const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
+
+  if (draftQuestionnaires) throw Boom.forbidden();
+
+  return null;
+};

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,12 +1,15 @@
 const Boom = require('@hapi/boom');
 const { DRAFT } = require('../../helpers/constants');
+const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
+
+const { language } = translate;
 
 exports.authorizeQuestionnaireCreation = async (req) => {
   const { type } = req.payload;
   const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
 
-  if (draftQuestionnaires) throw Boom.forbidden();
+  if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
 
   return null;
 };

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 const { QUESTIONNAIRE_TYPES } = require('../models/Questionnaire');
 const { list, create } = require('../controllers/questionnaireController');
+const { authorizeQuestionnaireCreation } = require('./preHandlers/questionnaires');
 
 exports.plugin = {
   name: 'routes-questionnaires',
@@ -27,6 +28,7 @@ exports.plugin = {
           }),
         },
         auth: { scope: ['questionnaires:edit'] },
+        pre: [{ method: authorizeQuestionnaireCreation }],
       },
       handler: create,
     });

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -1,7 +1,5 @@
 const expect = require('expect');
-const { ObjectID } = require('mongodb');
 const app = require('../../server');
-const Questionnaire = require('../../src/models/Questionnaire');
 const { populateDB, questionnairesList } = require('./seed/questionnairesSeed');
 const { getToken } = require('./seed/authenticationSeed');
 
@@ -53,9 +51,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 409 if already exists a draft questionnaire with same type', async () => {
-      await Questionnaire.insertMany([{ _id: new ObjectID(), title: 'test', status: 'draft', type: 'expectations' }]);
-
+    it('should return 409 if already exists a draft questionnaire with type EXPECTATIONS', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/questionnaires',
@@ -63,7 +59,16 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
         payload: { title: 'test', type: 'expectations' },
       });
 
-      expect(response.statusCode).toBe(409);
+      expect(response.statusCode).toBe(200);
+
+      const failedResponse = await app.inject({
+        method: 'POST',
+        url: '/questionnaires',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { title: 'test', type: 'expectations' },
+      });
+
+      expect(failedResponse.statusCode).toBe(409);
     });
   });
 

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -53,7 +53,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 403 if already exists a draft questionnaire with same type', async () => {
+    it('should return 409 if already exists a draft questionnaire with same type', async () => {
       await Questionnaire.insertMany([{ _id: new ObjectID(), title: 'test', status: 'draft', type: 'expectations' }]);
 
       const response = await app.inject({
@@ -63,7 +63,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
         payload: { title: 'test', type: 'expectations' },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(409);
     });
   });
 

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -1,5 +1,7 @@
 const expect = require('expect');
+const { ObjectID } = require('mongodb');
 const app = require('../../server');
+const Questionnaire = require('../../src/models/Questionnaire');
 const { populateDB, questionnairesList } = require('./seed/questionnairesSeed');
 const { getToken } = require('./seed/authenticationSeed');
 
@@ -49,6 +51,19 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 403 if already exists a draft questionnaire with same type', async () => {
+      await Questionnaire.insertMany([{ _id: new ObjectID(), title: 'test', status: 'draft', type: 'expectations' }]);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/questionnaires',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { title: 'test', type: 'expectations' },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -2,7 +2,7 @@ const { ObjectID } = require('mongodb');
 const Questionnaire = require('../../../src/models/Questionnaire');
 const { populateDBForAuthentication } = require('./authenticationSeed');
 
-const questionnairesList = [{ _id: new ObjectID(), title: 'test', status: 'draft', type: 'expectations' }];
+const questionnairesList = [{ _id: new ObjectID(), title: 'test', status: 'published', type: 'expectations' }];
 
 const populateDB = async () => {
   await Questionnaire.deleteMany({});


### PR DESCRIPTION
- ~~[] Mon code est testé unitairement~~
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : admin/ROF

- Cas d'usage :  je ne peux pas créer un questionnaire d'un type donné s'il en existe déjà un en brouillon
