### PR TITLE
Com 1975

### DIFF
--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -49,7 +49,7 @@ const update = async (req) => {
   try {
     await QuestionnaireHelper.update(req.params._id, req.payload);
 
-    return { message: translate[language].questionnaireFound };
+    return { message: translate[language].questionnaireUpdated };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -31,4 +31,18 @@ const create = async (req) => {
   }
 };
 
-module.exports = { list, create };
+const getById = async (req) => {
+  try {
+    const questionnaire = await QuestionnaireHelper.getQuestionnaire(req.params._id);
+
+    return {
+      message: translate[language].questionnaireFound,
+      data: { questionnaire },
+    };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { list, create, getById };

--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -45,9 +45,9 @@ const getById = async (req) => {
   }
 };
 
-const edit = async (req) => {
+const update = async (req) => {
   try {
-    await QuestionnaireHelper.edit(req.params._id, req.payload);
+    await QuestionnaireHelper.update(req.params._id, req.payload);
 
     return { message: translate[language].questionnaireFound };
   } catch (e) {
@@ -56,4 +56,4 @@ const edit = async (req) => {
   }
 };
 
-module.exports = { list, create, getById, edit };
+module.exports = { list, create, getById, update };

--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -45,4 +45,15 @@ const getById = async (req) => {
   }
 };
 
-module.exports = { list, create, getById };
+const edit = async (req) => {
+  try {
+    await QuestionnaireHelper.edit(req.params._id, req.payload);
+
+    return { message: translate[language].questionnaireFound };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { list, create, getById, edit };

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -5,3 +5,9 @@ exports.create = async payload => Questionnaire.create(payload);
 exports.list = async () => Questionnaire.find().lean();
 
 exports.getQuestionnaire = async id => Questionnaire.findOne({ _id: id }).lean();
+
+exports.edit = async (id, payload) => Questionnaire.findOneAndUpdate(
+  { _id: id },
+  { $set: payload },
+  { new: true }
+).lean();

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -6,8 +6,6 @@ exports.list = async () => Questionnaire.find().lean();
 
 exports.getQuestionnaire = async id => Questionnaire.findOne({ _id: id }).lean();
 
-exports.edit = async (id, payload) => Questionnaire.findOneAndUpdate(
-  { _id: id },
-  { $set: payload },
-  { new: true }
-).lean();
+exports.edit = async (id, payload) => Questionnaire
+  .findOneAndUpdate({ _id: id }, { $set: payload }, { new: true })
+  .lean();

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -3,3 +3,5 @@ const Questionnaire = require('../models/Questionnaire');
 exports.create = async payload => Questionnaire.create(payload);
 
 exports.list = async () => Questionnaire.find().lean();
+
+exports.getQuestionnaire = async id => Questionnaire.findOne({ _id: id }).lean();

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -6,6 +6,4 @@ exports.list = async () => Questionnaire.find().lean();
 
 exports.getQuestionnaire = async id => Questionnaire.findOne({ _id: id }).lean();
 
-exports.edit = async (id, payload) => Questionnaire
-  .findOneAndUpdate({ _id: id }, { $set: payload }, { new: true })
-  .lean();
+exports.update = async (id, payload) => Questionnaire.findOneAndUpdate({ _id: id }, { $set: payload }).lean();

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -292,6 +292,7 @@ module.exports = {
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
     draftExpectationQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
+    questionnaireUpdated: 'questionnaire updated.',
     /* PartnerOrganization */
     partnerOrganizationCreated: 'Partner organization created.',
     partnerOrganizationAlreadyExists: 'A partner organization already exists.',
@@ -586,7 +587,8 @@ module.exports = {
     questionnairesNotFound: 'Liste des questionnaires non trouvée.',
     questionnaireCreated: 'Questionnaire créé.',
     draftExpectationQuestionnaireAlreadyExists: `Il existe déjà un questionnaire en brouillon de type 'Recueil des
-      attentes'.`,
+    attentes'.`,
+    questionnaireUpdated: 'Questionnaire mis à jour.',
     /* PartnerOrganization */
     partnerOrganizationCreated: 'Structure partenaire créee.',
     partnerOrganizationAlreadyExists: 'Structure partenaire déjà existante.',

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,6 +1,12 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const { DRAFT, EXPECTATIONS, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } = require('../../helpers/constants');
+const {
+  DRAFT,
+  EXPECTATIONS,
+  TRAINING_ORGANISATION_MANAGER,
+  VENDOR_ADMIN,
+  PUBLISHED,
+} = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
 
@@ -23,6 +29,15 @@ exports.authorizeQuestionnaireGet = async (req) => {
   if (![TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) && questionnaire.status === DRAFT) {
     return Boom.forbidden();
   }
+
+  return null;
+};
+
+exports.authorizeQuestionnaireEdit = async (req) => {
+  const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
+  if (!questionnaire) return Boom.notFound();
+
+  if (questionnaire.status === PUBLISHED) return Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -23,7 +23,7 @@ exports.authorizeQuestionnaireCreation = async (req) => {
 };
 exports.authorizeQuestionnaireGet = async (req) => {
   const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
-  if (!questionnaire) return Boom.notFound();
+  if (!questionnaire) throw Boom.notFound();
 
   const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
   if (![TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) &&
@@ -36,9 +36,9 @@ exports.authorizeQuestionnaireGet = async (req) => {
 
 exports.authorizeQuestionnaireEdit = async (req) => {
   const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
-  if (!questionnaire) return Boom.notFound();
+  if (!questionnaire) throw Boom.notFound();
 
-  if (questionnaire.status === PUBLISHED) return Boom.forbidden();
+  if (questionnaire.status === PUBLISHED) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -26,8 +26,8 @@ exports.authorizeQuestionnaireGet = async (req) => {
   if (!questionnaire) return Boom.notFound();
 
   const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
-  if (!([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) ||
-    questionnaire.status === PUBLISHED)) {
+  if (![TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) &&
+    questionnaire.status !== PUBLISHED) {
     throw Boom.forbidden();
   }
 

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,5 +1,6 @@
 const Boom = require('@hapi/boom');
-const { DRAFT, EXPECTATIONS } = require('../../helpers/constants');
+const get = require('lodash/get');
+const { DRAFT, EXPECTATIONS, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
 
@@ -11,6 +12,17 @@ exports.authorizeQuestionnaireCreation = async (req) => {
 
   const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
   if (draftQuestionnaires) throw Boom.conflict(translate[language].draftExpectationQuestionnaireAlreadyExists);
+
+  return null;
+};
+exports.authorizeQuestionnaireGet = async (req) => {
+  const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
+  if (!questionnaire) return Boom.notFound();
+
+  const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
+  if (![TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) && questionnaire.status === DRAFT) {
+    return Boom.forbidden();
+  }
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -26,8 +26,9 @@ exports.authorizeQuestionnaireGet = async (req) => {
   if (!questionnaire) return Boom.notFound();
 
   const loggedUserVendorRole = get(req, 'auth.credentials.role.vendor.name');
-  if (![TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) && questionnaire.status === DRAFT) {
-    return Boom.forbidden();
+  if (!([TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN].includes(loggedUserVendorRole) ||
+    questionnaire.status === PUBLISHED)) {
+    throw Boom.forbidden();
   }
 
   return null;

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -2,8 +2,12 @@
 
 const Joi = require('joi');
 const { QUESTIONNAIRE_TYPES } = require('../models/Questionnaire');
-const { list, create, getById } = require('../controllers/questionnaireController');
-const { authorizeQuestionnaireGet, authorizeQuestionnaireCreation } = require('./preHandlers/questionnaires');
+const { list, create, getById, edit } = require('../controllers/questionnaireController');
+const {
+  authorizeQuestionnaireGet,
+  authorizeQuestionnaireCreation,
+  authorizeQuestionnaireEdit,
+} = require('./preHandlers/questionnaires');
 
 exports.plugin = {
   name: 'routes-questionnaires',
@@ -44,6 +48,19 @@ exports.plugin = {
         pre: [{ method: authorizeQuestionnaireCreation }],
       },
       handler: create,
+    });
+
+    server.route({
+      method: 'PUT',
+      path: '/{_id}',
+      options: {
+        validate: {
+          payload: Joi.object({ title: Joi.string().required() }),
+        },
+        auth: { scope: ['questionnaires:edit'] },
+        pre: [{ method: authorizeQuestionnaireEdit }],
+      },
+      handler: edit,
     });
   },
 };

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -2,8 +2,8 @@
 
 const Joi = require('joi');
 const { QUESTIONNAIRE_TYPES } = require('../models/Questionnaire');
-const { list, create } = require('../controllers/questionnaireController');
-const { authorizeQuestionnaireCreation } = require('./preHandlers/questionnaires');
+const { list, create, getById } = require('../controllers/questionnaireController');
+const { authorizeQuestionnaireGet, authorizeQuestionnaireCreation } = require('./preHandlers/questionnaires');
 
 exports.plugin = {
   name: 'routes-questionnaires',
@@ -15,6 +15,19 @@ exports.plugin = {
         auth: { scope: ['questionnaires:read'] },
       },
       handler: list,
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/{_id}',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+        },
+        auth: { mode: 'required' },
+        pre: [{ method: authorizeQuestionnaireGet }],
+      },
+      handler: getById,
     });
 
     server.route({

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const { QUESTIONNAIRE_TYPES } = require('../models/Questionnaire');
-const { list, create, getById, edit } = require('../controllers/questionnaireController');
+const { list, create, getById, update } = require('../controllers/questionnaireController');
 const {
   authorizeQuestionnaireGet,
   authorizeQuestionnaireCreation,
@@ -55,12 +55,13 @@ exports.plugin = {
       path: '/{_id}',
       options: {
         validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object({ title: Joi.string().required() }),
         },
         auth: { scope: ['questionnaires:edit'] },
         pre: [{ method: authorizeQuestionnaireEdit }],
       },
-      handler: edit,
+      handler: update,
     });
   },
 };

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -172,6 +172,16 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
+    it('should return 400 if questionnaire query has invalid type', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/questionnaires/blabla',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
   });
 
   describe('Other roles', () => {
@@ -193,7 +203,7 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
       { name: 'trainer', expectedCode: 403 },
     ];
     roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name} and questionnaire is not published`, async () => {
+      it(`should return ${role.expectedCode} as user is ${role.name} and questionnaire is draft`, async () => {
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
@@ -209,7 +219,6 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
 
 describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
   let authToken = null;
-  let payload = { title: 'test2' };
   beforeEach(populateDB);
 
   describe('TRAINING_ORGANISATION_MANAGER', () => {
@@ -217,7 +226,8 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       authToken = await getToken('training_organisation_manager');
     });
 
-    it('should edit questionnaire title', async () => {
+    it('should update questionnaire title', async () => {
+      const payload = { title: 'test2' };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${questionnairesList[0]._id}`,
@@ -233,6 +243,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
     });
 
     it('should return 404 if questionnaire does not exist', async () => {
+      const payload = { title: 'test2' };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${new ObjectID()}`,
@@ -244,6 +255,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
     });
 
     it('should return 403 if questionnaire is published', async () => {
+      const payload = { title: 'test2' };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${questionnairesList[1]._id}`,
@@ -254,8 +266,20 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(403);
     });
 
-    it('should return 400 if try to edit another field', async () => {
-      payload = { type: 'new_type' };
+    it('should return 400 if title is not a string', async () => {
+      const payload = { title: 123 };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if try to update another field', async () => {
+      const payload = { type: 'new_type' };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${questionnairesList[0]._id}`,
@@ -268,7 +292,6 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
   });
 
   describe('Other roles', () => {
-    payload = { title: 'test2' };
     const roles = [
       { name: 'helper', expectedCode: 403 },
       { name: 'planning_referent', expectedCode: 403 },
@@ -276,7 +299,8 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       { name: 'trainer', expectedCode: 403 },
     ];
     roles.forEach((role) => {
-      it(`should return ${role.expectedCode} as user is ${role.name} #tag`, async () => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        const payload = { title: 'test2' };
         authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'PUT',

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -1,6 +1,7 @@
 const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const app = require('../../server');
+const Questionnaire = require('../../src/models/Questionnaire');
 const { populateDB, questionnairesList } = require('./seed/questionnairesSeed');
 const { getToken, getTokenByCredentials } = require('./seed/authenticationSeed');
 const { noRoleNoCompany } = require('../seed/userSeed');
@@ -21,6 +22,8 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
     });
 
     it('should create questionnaire', async () => {
+      await Questionnaire.deleteMany({});
+
       const response = await app.inject({
         method: 'POST',
         url: '/questionnaires',
@@ -61,16 +64,7 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
         payload: { title: 'test', type: 'expectations' },
       });
 
-      expect(response.statusCode).toBe(200);
-
-      const failedResponse = await app.inject({
-        method: 'POST',
-        url: '/questionnaires',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { title: 'test', type: 'expectations' },
-      });
-
-      expect(failedResponse.statusCode).toBe(409);
+      expect(response.statusCode).toBe(409);
     });
   });
 

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -1,7 +1,9 @@
 const expect = require('expect');
+const { ObjectID } = require('mongodb');
 const app = require('../../server');
 const { populateDB, questionnairesList } = require('./seed/questionnairesSeed');
-const { getToken } = require('./seed/authenticationSeed');
+const { getToken, getTokenByCredentials } = require('./seed/authenticationSeed');
+const { noRoleNoCompany } = require('../seed/userSeed');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -131,6 +133,70 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires', () => {
         const response = await app.inject({
           method: 'GET',
           url: '/questionnaires',
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('TRAINING_ORGANISATION_MANAGER', () => {
+    beforeEach(async () => {
+      authToken = await getToken('training_organisation_manager');
+    });
+
+    it('should get questionnaire', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnairesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.questionnaire._id).toEqual(questionnairesList[0]._id);
+    });
+
+    it('should return 404 if questionnaire does not exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    it('should return 200 if questionnaire is published', async () => {
+      authToken = await getTokenByCredentials(noRoleNoCompany.local);
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnairesList[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 403 },
+      { name: 'client_admin', expectedCode: 403 },
+      { name: 'trainer', expectedCode: 403 },
+    ];
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name} and questionnaire is not published`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'GET',
+          url: `/questionnaires/${questionnairesList[0]._id}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -4,7 +4,6 @@ const app = require('../../server');
 const { populateDB, questionnairesList } = require('./seed/questionnairesSeed');
 const { getToken, getTokenByCredentials } = require('./seed/authenticationSeed');
 const { noRoleNoCompany } = require('../seed/userSeed');
-const Questionnaire = require('../../src/models/Questionnaire');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -163,6 +162,16 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
       expect(response.result.data.questionnaire._id).toEqual(questionnairesList[0]._id);
     });
 
+    it('should return 400 if invalid _id', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/questionnaires/blabla',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
     it('should return 404 if questionnaire does not exist', async () => {
       const response = await app.inject({
         method: 'GET',
@@ -171,16 +180,6 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(404);
-    });
-
-    it('should return 400 if questionnaire query has invalid type', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/questionnaires/blabla',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(400);
     });
   });
 
@@ -236,34 +235,6 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(200);
-
-      const questionnaire = await Questionnaire.findOne({ _id: questionnairesList[0]._id }).lean();
-
-      expect(questionnaire.title).toEqual(payload.title);
-    });
-
-    it('should return 404 if questionnaire does not exist', async () => {
-      const payload = { title: 'test2' };
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/questionnaires/${new ObjectID()}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload,
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('should return 403 if questionnaire is published', async () => {
-      const payload = { title: 'test2' };
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/questionnaires/${questionnairesList[1]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload,
-      });
-
-      expect(response.statusCode).toBe(403);
     });
 
     it('should return 400 if title is not a string', async () => {
@@ -288,6 +259,30 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 if questionnaire does not exist', async () => {
+      const payload = { title: 'test2' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 403 if questionnaire is published', async () => {
+      const payload = { title: 'test2' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -2,7 +2,10 @@ const { ObjectID } = require('mongodb');
 const Questionnaire = require('../../../src/models/Questionnaire');
 const { populateDBForAuthentication } = require('./authenticationSeed');
 
-const questionnairesList = [{ _id: new ObjectID(), title: 'test', status: 'published', type: 'expectations' }];
+const questionnairesList = [
+  { _id: new ObjectID(), title: 'test', status: 'draft', type: 'expectations' },
+  { _id: new ObjectID(), title: 'test', status: 'published', type: 'expectations' },
+];
 
 const populateDB = async () => {
   await Questionnaire.deleteMany({});

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const expect = require('expect');
+const { ObjectID } = require('mongodb');
 const Questionnaire = require('../../../src/models/Questionnaire');
 const QuestionnaireHelper = require('../../../src/helpers/questionnaires');
 const SinonMongoose = require('../sinonMongoose');
@@ -33,10 +34,34 @@ describe('list', () => {
   it('should return questionnaires', async () => {
     const questionnairesList = [{ title: 'test' }, { title: 'test2' }];
 
-    find.returns(SinonMongoose.stubChainedQueries([questionnairesList]));
+    find.returns(SinonMongoose.stubChainedQueries([questionnairesList], ['lean']));
 
     const result = await QuestionnaireHelper.list();
     expect(result).toMatchObject(questionnairesList);
     SinonMongoose.calledWithExactly(find, [{ query: 'find' }, { query: 'lean' }]);
+  });
+});
+
+describe('getQuestionnaire', () => {
+  let findOne;
+  beforeEach(() => {
+    findOne = sinon.stub(Questionnaire, 'findOne');
+  });
+  afterEach(() => {
+    findOne.restore();
+  });
+
+  it('should return questionnaire', async () => {
+    const questionnaireId = new ObjectID();
+    const questionnaire = { _id: questionnaireId, title: 'test' };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['lean']));
+
+    const result = await QuestionnaireHelper.getQuestionnaire(questionnaireId);
+    expect(result).toMatchObject(questionnaire);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ _id: questionnaireId }] }, { query: 'lean' }]
+    );
   });
 });

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -65,3 +65,30 @@ describe('getQuestionnaire', () => {
     );
   });
 });
+
+describe('editQuestionnaire', () => {
+  let findOneAndUpdate;
+  beforeEach(() => {
+    findOneAndUpdate = sinon.stub(Questionnaire, 'findOneAndUpdate');
+  });
+  afterEach(() => {
+    findOneAndUpdate.restore();
+  });
+
+  it('should update questionnaire', async () => {
+    const questionnaireId = new ObjectID();
+    const questionnaire = { _id: questionnaireId, title: 'test2' };
+
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([questionnaire], ['lean']));
+
+    const result = await QuestionnaireHelper.edit(questionnaireId, { title: 'test2' });
+    expect(result).toMatchObject(questionnaire);
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOneAndUpdate', args: [{ _id: questionnaireId }, { $set: { title: 'test2' } }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+});

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -37,6 +37,7 @@ describe('list', () => {
     find.returns(SinonMongoose.stubChainedQueries([questionnairesList], ['lean']));
 
     const result = await QuestionnaireHelper.list();
+
     expect(result).toMatchObject(questionnairesList);
     SinonMongoose.calledWithExactly(find, [{ query: 'find' }, { query: 'lean' }]);
   });
@@ -58,6 +59,7 @@ describe('getQuestionnaire', () => {
     findOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['lean']));
 
     const result = await QuestionnaireHelper.getQuestionnaire(questionnaireId);
+
     expect(result).toMatchObject(questionnaire);
     SinonMongoose.calledWithExactly(
       findOne,
@@ -81,12 +83,13 @@ describe('editQuestionnaire', () => {
 
     findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([questionnaire], ['lean']));
 
-    const result = await QuestionnaireHelper.edit(questionnaireId, { title: 'test2' });
+    const result = await QuestionnaireHelper.update(questionnaireId, { title: 'test2' });
+
     expect(result).toMatchObject(questionnaire);
     SinonMongoose.calledWithExactly(
       findOneAndUpdate,
       [
-        { query: 'findOneAndUpdate', args: [{ _id: questionnaireId }, { $set: { title: 'test2' } }, { new: true }] },
+        { query: 'findOneAndUpdate', args: [{ _id: questionnaireId }, { $set: { title: 'test2' } }] },
         { query: 'lean' },
       ]
     );


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : admin/ROF

- Cas d'usage : je peux accéder au profil d'un questionnaire et en modifier le titre
