### PR TITLE
COM-1971: trainer can send email

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -168,7 +168,11 @@ exports.formatDuration = (duration) => {
   return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
 };
 
-exports.areObjectIdsEquals = (id1, id2) => new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString();
+exports.areObjectIdsEquals = (id1, id2) => (
+  id1 && id2
+    ? new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString()
+    : false
+);
 
 exports.formatPhoneNumber = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -168,11 +168,9 @@ exports.formatDuration = (duration) => {
   return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
 };
 
-exports.areObjectIdsEquals = (id1, id2) => (
-  id1 && id2
-    ? new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString()
-    : false
-);
+exports.areObjectIdsEquals = (id1, id2) => !!id1 &&
+  !!id2 &&
+  new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString();
 
 exports.formatPhoneNumber = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -168,8 +168,7 @@ exports.formatDuration = (duration) => {
   return paddedMinutes ? `${hours}h${paddedMinutes}` : `${hours}h`;
 };
 
-exports.areObjectIdsEquals = (id1, id2) => !!id1 &&
-  !!id2 &&
+exports.areObjectIdsEquals = (id1, id2) => !!id1 && !!id2 &&
   new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString();
 
 exports.formatPhoneNumber = phoneNumber => (phoneNumber

--- a/src/routes/preHandlers/email.js
+++ b/src/routes/preHandlers/email.js
@@ -8,8 +8,8 @@ const { areObjectIdsEquals } = require('../../helpers/utils');
 const { language } = translate;
 
 exports.authorizeSendEmail = async (req) => {
-  const companyId = get(req, 'auth.credentials.company._id', '');
-  const isVendorUser = get(req, 'auth.credentials.role.vendor', false);
+  const companyId = get(req, 'auth.credentials.company._id') || '';
+  const isVendorUser = get(req, 'auth.credentials.role.vendor') || false;
 
   const receiver = await User.findOne({ 'local.email': req.payload.email })
     .populate({ path: 'role.vendor', select: 'name' })

--- a/src/routes/preHandlers/email.js
+++ b/src/routes/preHandlers/email.js
@@ -22,7 +22,7 @@ exports.authorizeSendEmail = async (req) => {
   const receiverIsCoachOrAdmin = [COACH, CLIENT_ADMIN].includes(get(receiver, 'role.client.name'));
   const userIsSendingToAuthorizedType = isVendorUser &&
     (receiverIsTrainer || req.payload.type === TRAINEE || receiverIsCoachOrAdmin);
-  const sameCompany = receiver.company && companyId && areObjectIdsEquals(receiver.company, companyId);
+  const sameCompany = areObjectIdsEquals(receiver.company, companyId);
   if (!userIsSendingToAuthorizedType && !sameCompany) throw Boom.forbidden();
 
   return null;

--- a/tests/integration/email.test.js
+++ b/tests/integration/email.test.js
@@ -52,6 +52,18 @@ describe('EMAIL ROUTES', () => {
     sinon.assert.calledWithExactly(sendinBlueTransporter);
   });
 
+  it('should send a welcoming email from trainer to newly registered trainee ', async () => {
+    const authToken = await getToken('trainer');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/email/send-welcome',
+      headers: { Cookie: `alenvi_token=${authToken}` },
+      payload: { type: 'trainee', email: emailUser.local.email },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
   it('should not throw an error if trainer is from an other company and user is vendor', async () => {
     const authToken = await getToken('vendor_admin');
     const response = await app.inject({

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -293,4 +293,22 @@ describe('areObjectIdsEquals', () => {
 
     expect(result).toBe(false);
   });
+
+  it('should return false if one object id is missing', () => {
+    const id1 = '';
+    const id2 = new ObjectID().toHexString();
+
+    const result = UtilsHelper.areObjectIdsEquals(id1, id2);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if both object ids are missing', () => {
+    const id1 = '';
+    const id2 = '';
+
+    const result = UtilsHelper.areObjectIdsEquals(id1, id2);
+
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
- ~~[ ] Mon code est testé unitairement~~
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : tous

- Périmetre roles : ROF/admin/formateur/coach

- Cas d'usage : fix bug : quand le formateur ajoute un stagiaire, le mail s'envoie
