### PR TITLE
COM-1980-fix - Add salesRepresentative identity to course

### DIFF
--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -138,6 +138,7 @@ exports.getCourse = async (course, loggedUser) => {
     })
     .populate({ path: 'trainer', select: 'identity.firstname identity.lastname' })
     .populate({ path: 'accessRules', select: 'name' })
+    .populate({ path: 'salesRepresentative', select: 'identity.firstname identity.lastname' })
     .lean();
 };
 

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -437,6 +437,7 @@ describe('getCourse', () => {
       },
       { query: 'populate', args: [{ path: 'trainer', select: 'identity.firstname identity.lastname' }] },
       { query: 'populate', args: [{ path: 'accessRules', select: 'name' }] },
+      { query: 'populate', args: [{ path: 'salesRepresentative', select: 'identity.firstname identity.lastname' }] },
       { query: 'lean' },
     ]);
   });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- ~~Tests intégrations: (barrer ce qui n'est pas utile)~~
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- ~~[ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):~~
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [ ] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
-~~ Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- ~~[ ] Je n'ai pas changé de constante~~

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


Périmetre interface : Trainer

Périmetre roles : trainer

Cas d'usage :
ETQ trainer, je vois le select du référent compani sur la page profile d'une formation blended. Je ne peux pas le modifier.
