### PR TITLE
Change check version

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -184,6 +184,8 @@ module.exports = {
   VENDOR_ADMIN: 'vendor_admin',
   TRAINING_ORGANISATION_MANAGER: 'training_organisation_manager',
   TRAINER: 'trainer',
+  // APP NAMES
+  FORMATION: 'formation',
   // SUBSCRIPTIONS
   ERP: 'erp',
   // EXPORTS

--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -4,7 +4,7 @@ exports.shouldUpdate = async (query) => {
   const { apiVersion, mobileVersion, appName } = query;
   if (apiVersion) return true;
   if ((!appName || appName === FORMATION) && process.env.FORMATION_MOBILE_VERSION.includes(mobileVersion)) return false;
-  if (process.env[`${appName.toUpperCase()}_MOBILE_VERSION`].includes(mobileVersion)) return false;
+  if (appName && process.env[`${appName.toUpperCase()}_MOBILE_VERSION`].includes(mobileVersion)) return false;
 
   return true;
 };

--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -1,9 +1,7 @@
-const { FORMATION } = require('./constants');
-
 exports.shouldUpdate = async (query) => {
   const { apiVersion, mobileVersion, appName } = query;
   if (apiVersion) return true;
-  if ((!appName || appName === FORMATION) && process.env.FORMATION_MOBILE_VERSION.includes(mobileVersion)) return false;
+  if (!appName && process.env.FORMATION_MOBILE_VERSION.includes(mobileVersion)) return false;
   if (appName && process.env[`${appName.toUpperCase()}_MOBILE_VERSION`].includes(mobileVersion)) return false;
 
   return true;

--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -1,6 +1,10 @@
-exports.shouldUpdate = async (version) => {
-  if (version.apiVersion) return true;
-  if (process.env.MOBILE_VERSION.includes(version.mobileVersion)) return false;
+const { FORMATION } = require('./constants');
+
+exports.shouldUpdate = async (query) => {
+  const { apiVersion, mobileVersion, appName } = query;
+  if (apiVersion) return true;
+  if ((!appName || appName === FORMATION) && process.env.FORMATION_MOBILE_VERSION.includes(mobileVersion)) return false;
+  if (process.env[`${appName.toUpperCase()}_MOBILE_VERSION`].includes(mobileVersion)) return false;
 
   return true;
 };

--- a/src/routes/version.js
+++ b/src/routes/version.js
@@ -2,6 +2,7 @@
 
 const Joi = require('joi');
 const { shouldUpdate } = require('../controllers/versionController');
+const { ERP, FORMATION } = require('../helpers/constants');
 
 exports.plugin = {
   name: 'routes-version',
@@ -27,7 +28,7 @@ exports.plugin = {
         validate: {
           query: Joi.object({
             mobileVersion: Joi.string().required(),
-            appName: Joi.string(),
+            appName: Joi.string().valid(ERP, FORMATION),
           }).required(),
         },
       },

--- a/src/routes/version.js
+++ b/src/routes/version.js
@@ -26,7 +26,8 @@ exports.plugin = {
         auth: false,
         validate: {
           query: Joi.object({
-            mobileVersion: Joi.string(),
+            mobileVersion: Joi.string().required(),
+            appName: Joi.string(),
           }).required(),
         },
       },

--- a/tests/integration/version.test.js
+++ b/tests/integration/version.test.js
@@ -10,11 +10,13 @@ describe('NODE ENV', () => {
 describe('VERSION TEST', () => {
   beforeEach(() => {
     process.env.API_VERSION = '2';
-    process.env.MOBILE_VERSION = ['1.2.0'];
+    process.env.FORMATION_MOBILE_VERSION = ['1.2.0'];
+    process.env.ERP_MOBILE_VERSION = ['2.8.0'];
   });
   afterEach(() => {
     process.env.API_VERSION = '';
-    process.env.MOBILE_VERSION = '';
+    process.env.FORMATION_MOBILE_VERSION = '';
+    process.env.ERP_MOBILE_VERSION = '';
   });
 
   describe('POST /version/check-update', () => {
@@ -29,22 +31,48 @@ describe('VERSION TEST', () => {
   });
 
   describe('POST /version/should-update', () => {
-    it('should return false (new version)', async () => {
+    it('should return false - app formation (new version)', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/version/should-update?mobileVersion=1.2.0',
+        url: '/version/should-update?mobileVersion=1.2.0&appName=formation',
       });
       expect(response.statusCode).toBe(200);
       expect(response.result.data.mustUpdate).toBeFalsy();
     });
 
-    it('should return true (new version)', async () => {
+    it('should return true - app formation (new version)', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/version/should-update?mobileVersion=1.1.9',
+        url: '/version/should-update?mobileVersion=1.1.9&appName=formation',
       });
       expect(response.statusCode).toBe(200);
       expect(response.result.data.mustUpdate).toBeTruthy();
+    });
+
+    it('should return false - app erp (new version)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?mobileVersion=2.8.0&appName=erp',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.mustUpdate).toBeFalsy();
+    });
+
+    it('should return true - app erp (new version)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?mobileVersion=1.7.3&appName=erp',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.mustUpdate).toBeTruthy();
+    });
+
+    it('should return 400 if missing mobileVersion', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?appName=erp',
+      });
+      expect(response.statusCode).toBe(400);
     });
   });
 });

--- a/tests/integration/version.test.js
+++ b/tests/integration/version.test.js
@@ -74,5 +74,13 @@ describe('VERSION TEST', () => {
       });
       expect(response.statusCode).toBe(400);
     });
+
+    it('should return 400 if appName is neither erp nor formation', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?mobileVersion=1.7.3&appName=poiuytrtyu',
+      });
+      expect(response.statusCode).toBe(400);
+    });
   });
 });

--- a/tests/integration/version.test.js
+++ b/tests/integration/version.test.js
@@ -31,6 +31,24 @@ describe('VERSION TEST', () => {
   });
 
   describe('POST /version/should-update', () => {
+    it('should return false - app formation (without appName)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?mobileVersion=1.2.0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.mustUpdate).toBeFalsy();
+    });
+
+    it('should return true - app formation (without appName)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/version/should-update?mobileVersion=1.1.0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.mustUpdate).toBeTruthy();
+    });
+
     it('should return false - app formation (new version)', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/tests/integration/version.test.js
+++ b/tests/integration/version.test.js
@@ -43,7 +43,7 @@ describe('VERSION TEST', () => {
     it('should return true - app formation (without appName)', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/version/should-update?mobileVersion=1.1.0',
+        url: '/version/should-update?mobileVersion=1.1.9',
       });
       expect(response.statusCode).toBe(200);
       expect(response.result.data.mustUpdate).toBeTruthy();

--- a/tests/unit/helpers/version.test.js
+++ b/tests/unit/helpers/version.test.js
@@ -4,11 +4,13 @@ const VersionHelper = require('../../../src/helpers/version');
 describe('shouldUpdate', () => {
   beforeEach(() => {
     process.env.API_VERSION = '2';
-    process.env.MOBILE_VERSION = ['1.2.0'];
+    process.env.FORMATION_MOBILE_VERSION = ['1.2.0'];
+    process.env.ERP_MOBILE_VERSION = ['1.8.0'];
   });
   afterEach(() => {
     process.env.API_VERSION = '';
-    process.env.MOBILE_VERSION = '';
+    process.env.FORMATION_MOBILE_VERSION = '';
+    process.env.ERP_MOBILE_VERSION = '';
   });
 
   it('should return true if api version', async () => {
@@ -16,13 +18,28 @@ describe('shouldUpdate', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should return true if lower version in mobile (new version)', async () => {
-    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.1.0' });
+  it('should return false if in maintained version and no appName - app formation (new version)', async () => {
+    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.2.0' });
+    expect(result).toBeFalsy();
+  });
+
+  it('should return true if version not in maintained versions - app formation (new version)', async () => {
+    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.1.0', appName: 'formation' });
     expect(result).toBeTruthy();
   });
 
-  it('should return false if same version (new version)', async () => {
-    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.2.0' });
+  it('should return false if in maintained version - app formation (new version)', async () => {
+    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.2.0', appName: 'formation' });
+    expect(result).toBeFalsy();
+  });
+
+  it('should return true if version not in maintained versions - app erp (new version)', async () => {
+    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.2.0', appName: 'erp' });
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false if in maintained version - app erp (new version)', async () => {
+    const result = await VersionHelper.shouldUpdate({ mobileVersion: '1.8.0', appName: 'erp' });
     expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile -np
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [ ] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp) -np
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):
  - [x] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [x] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : mobile formation et erp

- Périmetre roles : aucun

- Cas d'usage : affichage de la modale de mise a jour. 
