### PR TITLE
COM-2007 fix creation of sectorHistory on second contract or on updat…

### DIFF
--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,0 +1,3 @@
+exports.isBefore = (date1, date2) => new Date(date1) < new Date(date2);
+
+exports.isAfter = (date1, date2) => new Date(date2) < new Date(date1);

--- a/src/helpers/sectorHistories.js
+++ b/src/helpers/sectorHistories.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-const Boom = require('@hapi/Boom');
+const Boom = require('@hapi/boom');
 const SectorHistory = require('../models/SectorHistory');
 const Contract = require('../models/Contract');
 

--- a/src/helpers/sectorHistories.js
+++ b/src/helpers/sectorHistories.js
@@ -45,7 +45,7 @@ exports.updateHistoryOnSectorUpdate = async (auxiliaryId, sector, companyId) => 
 
 exports.createHistoryOnContractCreation = async (user, newContract, companyId) => {
   const startDate = moment(newContract.startDate).startOf('day').toDate();
-  const wrongHistory = await SectorHistory.find({
+  const wrongHistory = await SectorHistory.countDocuments({
     startDate: { $exists: true },
     endDate: { $exists: false },
     auxiliary: user._id,

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -115,6 +115,7 @@ const coachAndTrainer = {
 
 const contractId = new ObjectID();
 const contractNotStartedId = new ObjectID();
+const endedContractId = new ObjectID();
 
 const usersSeedList = [
   {
@@ -179,7 +180,7 @@ const usersSeedList = [
     role: { client: rolesList.find(role => role.name === 'auxiliary')._id },
     refreshToken: uuidv4(),
     company: authCompany._id,
-    contracts: [contractNotStartedId],
+    contracts: [endedContractId, contractNotStartedId],
     administrative: {
       certificates: [{ driveId: '1234567890' }],
       driveFolder: { driveId: '0987654321' },
@@ -212,6 +213,16 @@ const usersSeedList = [
     inactivityDate: null,
     origin: WEBAPP,
   },
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'trainee_to_auxiliary', lastname: 'test' },
+    local: { email: 'trainee_to_auxiliary@alenvi.io', password: '123456!eR' },
+    role: {},
+    refreshToken: uuidv4(),
+    company: authCompany._id,
+    inactivityDate: null,
+    origin: WEBAPP,
+  },
 ];
 
 const userSectors = [
@@ -235,6 +246,14 @@ const contracts = [
     user: usersSeedList[4]._id,
     startDate: moment().add(1, 'month').toDate(),
     createdAt: moment('2018-10-10').toDate(),
+    company: authCompany._id,
+  },
+  {
+    _id: endedContractId,
+    serialNumber: 'testserialnumber',
+    user: usersSeedList[4]._id,
+    startDate: '2020-01-01T00:00:00',
+    createdAt: '2020-06-01T23:59:59',
     company: authCompany._id,
   },
 ];

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1050,7 +1050,7 @@ describe('PUT /users/:id/', () => {
       expect(histories[0].sector).toEqual(userSectors[0]._id);
     });
 
-    it('should not update sectorHistory if auxiliary does not have contract', async () => {
+    it('should update sectorHistory if auxiliary does not have contract', async () => {
       const res = await app.inject({
         method: 'PUT',
         url: `/users/${usersSeedList[1]._id}`,
@@ -1064,7 +1064,7 @@ describe('PUT /users/:id/', () => {
       expect(histories[0].sector).toEqual(userSectors[1]._id);
     });
 
-    it('should not update sectorHistory if auxiliary contract has not started yet', async () => {
+    it('should update sectorHistory if auxiliary contract is between contracts', async () => {
       const res = await app.inject({
         method: 'PUT',
         url: `/users/${usersSeedList[4]._id}`,
@@ -1076,6 +1076,26 @@ describe('PUT /users/:id/', () => {
       const histories = await SectorHistory.find({ auxiliary: usersSeedList[4]._id, company: authCompany }).lean();
       expect(histories.length).toEqual(1);
       expect(histories[0].sector).toEqual(userSectors[1]._id);
+    });
+
+    it('should create sectorHistory if auxiliary does not have one', async () => {
+      const role = await Role.find({ name: 'auxiliary' }).lean();
+      const previousHistories = await SectorHistory.find({ auxiliary: usersSeedList[7]._id, company: authCompany })
+        .lean();
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/users/${usersSeedList[7]._id}`,
+        payload: { role: role._id, sector: userSectors[1]._id },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(previousHistories).toHaveLength(0);
+      const histories = await SectorHistory.find({ auxiliary: usersSeedList[7]._id, company: authCompany }).lean();
+      expect(histories.length).toEqual(1);
+      expect(histories[0].sector).toEqual(userSectors[1]._id);
+      expect(histories[0].startDate).toBeUndefined();
     });
 
     it('should add helper role to user', async () => {

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -13,6 +13,12 @@ describe('isBefore', () => {
 
     expect(isBefore).toBe(false);
   });
+
+  it('should return false if date1 is equal to date2', () => {
+    const isBefore = DatesHelper.isBefore('2020-01-01', '2020-01-01');
+
+    expect(isBefore).toBe(false);
+  });
 });
 
 describe('isAfter', () => {
@@ -24,6 +30,12 @@ describe('isAfter', () => {
 
   it('should return false if date1 is before date2', () => {
     const isAfter = DatesHelper.isAfter('2020-01-01', new Date());
+
+    expect(isAfter).toBe(false);
+  });
+
+  it('should return false if date1 is equal to date2', () => {
+    const isAfter = DatesHelper.isAfter('2020-01-01', '2020-01-01');
 
     expect(isAfter).toBe(false);
   });

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -1,0 +1,30 @@
+const expect = require('expect');
+const DatesHelper = require('../../../src/helpers/dates');
+
+describe('isBefore', () => {
+  it('should return true if date1 is before date2', () => {
+    const isBefore = DatesHelper.isBefore('2020-01-01', new Date());
+
+    expect(isBefore).toBe(true);
+  });
+
+  it('should return false if date1 is after date2', () => {
+    const isBefore = DatesHelper.isBefore('2020-01-01', '2019-02-03');
+
+    expect(isBefore).toBe(false);
+  });
+});
+
+describe('isAfter', () => {
+  it('should return true if date1 is after date2', () => {
+    const isAfter = DatesHelper.isAfter(new Date('2020-12-25'), '2020-07-14');
+
+    expect(isAfter).toBe(true);
+  });
+
+  it('should return false if date1 is before date2', () => {
+    const isAfter = DatesHelper.isAfter('2020-01-01', new Date());
+
+    expect(isAfter).toBe(false);
+  });
+});

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -87,6 +87,7 @@ describe('updateHistoryOnSectorUpdate', () => {
       ));
 
       await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
+      expect(true).toBe(false);
     } catch (e) {
       expect(e).toEqual(Boom.badData());
     } finally {

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -89,7 +89,7 @@ describe('updateHistoryOnSectorUpdate', () => {
       await SectorHistoryHelper.updateHistoryOnSectorUpdate(auxiliaryId, sector.toHexString(), companyId);
       expect(true).toBe(false);
     } catch (e) {
-      expect(e).toEqual(Boom.badData('No last sector history for auxiliary in contract'));
+      expect(e).toEqual(Boom.conflict('No last sector history for auxiliary in contract'));
     } finally {
       SinonMongoose.calledWithExactly(
         findOne,
@@ -335,7 +335,10 @@ describe('createHistoryOnContractCreation', () => {
     SinonMongoose.calledWithExactly(
       countDocuments,
       [
-        { query: 'countDocuments', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
+        {
+          query: 'countDocuments',
+          args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }],
+        },
         { query: 'lean' },
       ]
     );
@@ -366,12 +369,15 @@ describe('createHistoryOnContractCreation', () => {
 
       expect(true).toBe(false);
     } catch (e) {
-      expect(e).toEqual(Boom.badData('There is a sector history with a startDate without an endDate'));
+      expect(e).toEqual(Boom.conflict('There is a sector history with a startDate without an endDate'));
     } finally {
       SinonMongoose.calledWithExactly(
         countDocuments,
         [
-          { query: 'countDocuments', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
+          {
+            query: 'countDocuments',
+            args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }],
+          },
           { query: 'lean' },
         ]
       );

--- a/tests/unit/helpers/sectorHistories.test.js
+++ b/tests/unit/helpers/sectorHistories.test.js
@@ -273,18 +273,18 @@ describe('createHistoryOnContractCreation', () => {
 
   let createHistoryStub;
   let findOne;
-  let find;
+  let countDocuments;
   let updateOne;
 
   beforeEach(() => {
-    find = sinon.stub(SectorHistory, 'find');
+    countDocuments = sinon.stub(SectorHistory, 'countDocuments');
     findOne = sinon.stub(SectorHistory, 'findOne');
     updateOne = sinon.stub(SectorHistory, 'updateOne');
     createHistoryStub = sinon.stub(SectorHistoryHelper, 'createHistory');
   });
 
   afterEach(() => {
-    find.restore();
+    countDocuments.restore();
     createHistoryStub.restore();
     findOne.restore();
     updateOne.restore();
@@ -294,15 +294,18 @@ describe('createHistoryOnContractCreation', () => {
     const user = { _id: auxiliaryId, sector };
     const existingHistory = { _id: new ObjectID(), sector };
 
-    find.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    countDocuments.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     findOne.returns(SinonMongoose.stubChainedQueries([existingHistory], ['lean']));
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
     SinonMongoose.calledWithExactly(
-      find,
+      countDocuments,
       [
-        { query: 'find', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
+        {
+          query: 'countDocuments',
+          args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }],
+        },
         { query: 'lean' },
       ]
     );
@@ -324,15 +327,15 @@ describe('createHistoryOnContractCreation', () => {
   it('should create sector history if does not exist without start date', async () => {
     const user = { _id: auxiliaryId, sector };
 
-    find.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+    countDocuments.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
 
     await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
     SinonMongoose.calledWithExactly(
-      find,
+      countDocuments,
       [
-        { query: 'find', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
+        { query: 'countDocuments', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
         { query: 'lean' },
       ]
     );
@@ -357,7 +360,7 @@ describe('createHistoryOnContractCreation', () => {
     try {
       const existingWrongHistory = { _id: new ObjectID(), sector };
 
-      find.returns(SinonMongoose.stubChainedQueries([existingWrongHistory], ['lean']));
+      countDocuments.returns(SinonMongoose.stubChainedQueries([existingWrongHistory], ['lean']));
 
       await SectorHistoryHelper.createHistoryOnContractCreation(user, newContract, companyId);
 
@@ -366,9 +369,9 @@ describe('createHistoryOnContractCreation', () => {
       expect(e).toEqual(Boom.badData('There is a sector history with a startDate without an endDate'));
     } finally {
       SinonMongoose.calledWithExactly(
-        find,
+        countDocuments,
         [
-          { query: 'find', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
+          { query: 'countDocuments', args: [{ startDate: { $exists: true }, endDate: { $exists: false }, auxiliary: user._id }] },
           { query: 'lean' },
         ]
       );


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par le mobile
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp): -np
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- J'ai changé un modele : -np
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [ ] Je n'ai pas changé de constante -np

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : client/vendeur

- Périmetre roles : rof/coach

- Cas d'usage : Mise a jour des sectorHistories
A tester : 
## 1er test 
- Creer un contrat pour un auxiliaire
- Changer le secteur de l'auxiliaire
- Creer un contrat pour l'auxiliaire 

## 2eme test 
- Creer un stagiaire Alenvi sur une formation mixte 
- L'ajouter en tant qu'auxiliaire
- Creer un contrat pour l'auxiliaire

## 3eme test
- lancer le dump/restore suivi du script de creation de compte

Dans les deux cas verifier qu'il n'y a qu'un seul sectorHistory. 
N'hesitez pas à faire pleins de tests. Ces deux tests ne sont pas exhaustifs, ce sont les deux comportements que j'ai identifié et fix dans la pr. 