### PR TITLE
Com 1978

### DIFF
--- a/src/controllers/partnerOrganizationController.js
+++ b/src/controllers/partnerOrganizationController.js
@@ -28,7 +28,7 @@ const list = async (req) => {
 
 const getById = async (req) => {
   try {
-    const partnerOrganization = await PartnerOrganizationsHelper.getById(req.params._id);
+    const partnerOrganization = await PartnerOrganizationsHelper.getPartnerOrganisation(req.params._id);
 
     return { message: translate[language].partnerOrganizationFound, data: { partnerOrganization } };
   } catch (e) {

--- a/src/controllers/partnerOrganizationController.js
+++ b/src/controllers/partnerOrganizationController.js
@@ -37,4 +37,15 @@ const getById = async (req) => {
   }
 };
 
-module.exports = { create, list, getById };
+const update = async (req) => {
+  try {
+    await PartnerOrganizationsHelper.update(req.params._id, req.payload);
+
+    return { message: translate[language].partnerOrganizationUpdated };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { create, list, getById, update };

--- a/src/controllers/partnerOrganizationController.js
+++ b/src/controllers/partnerOrganizationController.js
@@ -28,7 +28,7 @@ const list = async (req) => {
 
 const getById = async (req) => {
   try {
-    const partnerOrganization = await PartnerOrganizationsHelper.getPartnerOrganisation(req.params._id);
+    const partnerOrganization = await PartnerOrganizationsHelper.getPartnerOrganization(req.params._id);
 
     return { message: translate[language].partnerOrganizationFound, data: { partnerOrganization } };
   } catch (e) {

--- a/src/controllers/partnerOrganizationController.js
+++ b/src/controllers/partnerOrganizationController.js
@@ -26,4 +26,15 @@ const list = async (req) => {
   }
 };
 
-module.exports = { create, list };
+const getById = async (req) => {
+  try {
+    const partnerOrganization = await PartnerOrganizationsHelper.getPartnerOrganization(req.params._id);
+
+    return { message: translate[language].partnerOrganizationFound, data: { partnerOrganization } };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { create, list, getById };

--- a/src/controllers/partnerOrganizationController.js
+++ b/src/controllers/partnerOrganizationController.js
@@ -28,7 +28,7 @@ const list = async (req) => {
 
 const getById = async (req) => {
   try {
-    const partnerOrganization = await PartnerOrganizationsHelper.getPartnerOrganization(req.params._id);
+    const partnerOrganization = await PartnerOrganizationsHelper.getById(req.params._id);
 
     return { message: translate[language].partnerOrganizationFound, data: { partnerOrganization } };
   } catch (e) {

--- a/src/helpers/partnerOrganizations.js
+++ b/src/helpers/partnerOrganizations.js
@@ -6,3 +6,6 @@ exports.list = credentials => PartnerOrganization.find({ company: credentials.co
 
 exports.getPartnerOrganization = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
   .lean();
+
+exports.update = async (partnerOrganizationId, payload) => PartnerOrganization
+  .updateOne({ _id: partnerOrganizationId }, { $set: payload });

--- a/src/helpers/partnerOrganizations.js
+++ b/src/helpers/partnerOrganizations.js
@@ -4,7 +4,7 @@ exports.create = (payload, credentials) => PartnerOrganization.create({ ...paylo
 
 exports.list = credentials => PartnerOrganization.find({ company: credentials.company._id }).lean();
 
-exports.getPartnerOrganisation = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
+exports.getPartnerOrganization = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
   .lean();
 
 exports.update = async (partnerOrganizationId, payload) => PartnerOrganization

--- a/src/helpers/partnerOrganizations.js
+++ b/src/helpers/partnerOrganizations.js
@@ -4,7 +4,7 @@ exports.create = (payload, credentials) => PartnerOrganization.create({ ...paylo
 
 exports.list = credentials => PartnerOrganization.find({ company: credentials.company._id }).lean();
 
-exports.getById = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
+exports.getPartnerOrganisation = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
   .lean();
 
 exports.update = async (partnerOrganizationId, payload) => PartnerOrganization

--- a/src/helpers/partnerOrganizations.js
+++ b/src/helpers/partnerOrganizations.js
@@ -4,7 +4,7 @@ exports.create = (payload, credentials) => PartnerOrganization.create({ ...paylo
 
 exports.list = credentials => PartnerOrganization.find({ company: credentials.company._id }).lean();
 
-exports.getPartnerOrganization = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
+exports.getById = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
   .lean();
 
 exports.update = async (partnerOrganizationId, payload) => PartnerOrganization

--- a/src/helpers/partnerOrganizations.js
+++ b/src/helpers/partnerOrganizations.js
@@ -3,3 +3,6 @@ const PartnerOrganization = require('../models/PartnerOrganization');
 exports.create = (payload, credentials) => PartnerOrganization.create({ ...payload, company: credentials.company._id });
 
 exports.list = credentials => PartnerOrganization.find({ company: credentials.company._id }).lean();
+
+exports.getPartnerOrganization = partnerOrganizationId => PartnerOrganization.findOne({ _id: partnerOrganizationId })
+  .lean();

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -297,6 +297,7 @@ module.exports = {
     partnerOrganizationCreated: 'Partner organization created.',
     partnerOrganizationAlreadyExists: 'A partner organization already exists.',
     partnerOrganizationsFound: 'Partner organizations found.',
+    partnerOrganizationFound: 'Partner organization found.',
   },
   'fr-FR': {
     /* Global errors */
@@ -594,5 +595,6 @@ module.exports = {
     partnerOrganizationCreated: 'Structure partenaire créee.',
     partnerOrganizationAlreadyExists: 'Structure partenaire déjà existante.',
     partnerOrganizationsFound: 'Liste des structures partenaires trouvées.',
+    partnerOrganizationFound: 'Structure partenaire trouvée.',
   },
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -298,6 +298,7 @@ module.exports = {
     partnerOrganizationAlreadyExists: 'A partner organization already exists.',
     partnerOrganizationsFound: 'Partner organizations found.',
     partnerOrganizationFound: 'Partner organization found.',
+    partnerOrganizationUpdated: 'Partner organization updated.',
   },
   'fr-FR': {
     /* Global errors */
@@ -596,5 +597,6 @@ module.exports = {
     partnerOrganizationAlreadyExists: 'Structure partenaire déjà existante.',
     partnerOrganizationsFound: 'Liste des structures partenaires trouvées.',
     partnerOrganizationFound: 'Structure partenaire trouvée.',
+    partnerOrganizationUpdated: 'Structure partenaire mise à jour.',
   },
 };

--- a/src/routes/partnerOrganizations.js
+++ b/src/routes/partnerOrganizations.js
@@ -60,9 +60,9 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.alternatives().try(
             Joi.object({ name: Joi.string().required() }),
-            Joi.object({ phone: phoneNumberValidation.required() }),
-            Joi.object({ address: addressValidation.required() }),
-            Joi.object({ email: Joi.string().email().required() })
+            Joi.object({ phone: phoneNumberValidation.required().allow('') }),
+            Joi.object({ address: addressValidation.required().allow({}) }),
+            Joi.object({ email: Joi.string().email().required().allow('') })
           ),
         },
         auth: { scope: ['partnerorganizations:edit'] },

--- a/src/routes/partnerOrganizations.js
+++ b/src/routes/partnerOrganizations.js
@@ -2,8 +2,11 @@
 
 const Joi = require('joi');
 const { phoneNumberValidation, addressValidation } = require('./validations/utils');
-const { create, list } = require('../controllers/partnerOrganizationController');
-const { authorizePartnerOrganizationCreation } = require('./preHandlers/partnerOrganizations');
+const { create, list, getById } = require('../controllers/partnerOrganizationController');
+const {
+  authorizePartnerOrganizationCreation,
+  partnerOrganizationExists,
+} = require('./preHandlers/partnerOrganizations');
 
 exports.plugin = {
   name: 'routes-partnerorganizations',
@@ -33,6 +36,19 @@ exports.plugin = {
         auth: { scope: ['partnerorganizations:edit'] },
       },
       handler: list,
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/{_id}',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+        },
+        auth: { scope: ['partnerorganizations:edit'] },
+        pre: [{ method: partnerOrganizationExists }],
+      },
+      handler: getById,
     });
   },
 };

--- a/src/routes/partnerOrganizations.js
+++ b/src/routes/partnerOrganizations.js
@@ -4,9 +4,9 @@ const Joi = require('joi');
 const { phoneNumberValidation, addressValidation } = require('./validations/utils');
 const { create, list, getById, update } = require('../controllers/partnerOrganizationController');
 const {
-  checkPartnerOrganizationAlreadyExists,
-  partnerOrganizationExists,
-  authorizePartnerOrganizationEdit,
+  authorizePartnerOrganizationCreation,
+  authorizePartnerOrganizationGetById,
+  authorizePartnerOrganizationUpdate,
 } = require('./preHandlers/partnerOrganizations');
 
 exports.plugin = {
@@ -25,7 +25,7 @@ exports.plugin = {
           }),
         },
         auth: { scope: ['partnerorganizations:edit'] },
-        pre: [{ method: checkPartnerOrganizationAlreadyExists }],
+        pre: [{ method: authorizePartnerOrganizationCreation }],
       },
       handler: create,
     });
@@ -47,7 +47,7 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
         auth: { scope: ['partnerorganizations:edit'] },
-        pre: [{ method: partnerOrganizationExists }],
+        pre: [{ method: authorizePartnerOrganizationGetById }],
       },
       handler: getById,
     });
@@ -58,15 +58,15 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.alternatives().try(
-            Joi.object({ name: Joi.string().required() }),
-            Joi.object({ phone: phoneNumberValidation.required().allow('') }),
-            Joi.object({ address: addressValidation.required().allow({}) }),
-            Joi.object({ email: Joi.string().email().required().allow('') })
-          ),
+          payload: Joi.object({
+            name: Joi.string(),
+            phone: phoneNumberValidation.allow(''),
+            address: Joi.alternatives().try(addressValidation, {}),
+            email: Joi.string().email().allow(''),
+          }),
         },
         auth: { scope: ['partnerorganizations:edit'] },
-        pre: [{ method: authorizePartnerOrganizationEdit }],
+        pre: [{ method: authorizePartnerOrganizationUpdate }],
       },
       handler: update,
     });

--- a/src/routes/preHandlers/partnerOrganizations.js
+++ b/src/routes/preHandlers/partnerOrganizations.js
@@ -4,7 +4,7 @@ const translate = require('../../helpers/translate');
 
 const { language } = translate;
 
-exports.checkPartnerOrganizationAlreadyExists = async (req) => {
+exports.checkPartnerOrganizationConflict = async (req) => {
   const { credentials } = req.auth;
 
   const partnerOrganizationAlreadyExist = await PartnerOrganization.countDocuments({
@@ -24,7 +24,7 @@ exports.checkPartnerOrganizationExists = async (req) => {
 };
 
 exports.authorizePartnerOrganizationCreation = async (req) => {
-  await this.checkPartnerOrganizationAlreadyExists(req);
+  await this.checkPartnerOrganizationConflict(req);
 
   return null;
 };
@@ -38,7 +38,7 @@ exports.authorizePartnerOrganizationGetById = async (req) => {
 exports.authorizePartnerOrganizationUpdate = async (req) => {
   await this.checkPartnerOrganizationExists(req);
 
-  if (req.payload.name) await this.checkPartnerOrganizationAlreadyExists(req);
+  if (req.payload.name) await this.checkPartnerOrganizationConflict(req);
 
   return null;
 };

--- a/src/routes/preHandlers/partnerOrganizations.js
+++ b/src/routes/preHandlers/partnerOrganizations.js
@@ -4,7 +4,7 @@ const translate = require('../../helpers/translate');
 
 const { language } = translate;
 
-exports.authorizePartnerOrganizationCreation = async (req) => {
+exports.checkPartnerOrganizationAlreadyExists = async (req) => {
   const { credentials } = req.auth;
 
   const partnerOrganizationAlreadyExist = await PartnerOrganization.countDocuments({
@@ -18,7 +18,15 @@ exports.authorizePartnerOrganizationCreation = async (req) => {
 
 exports.partnerOrganizationExists = async (req) => {
   const partnerOrganizationExists = await PartnerOrganization.countDocuments({ _id: req.params._id });
-  if (!partnerOrganizationExists) throw Boom.forbidden();
+  if (!partnerOrganizationExists) throw Boom.notFound();
+
+  return null;
+};
+
+exports.authorizePartnerOrganizationEdit = async (req) => {
+  await this.partnerOrganizationExists(req);
+
+  if (req.payload.name) await this.checkPartnerOrganizationAlreadyExists(req);
 
   return null;
 };

--- a/src/routes/preHandlers/partnerOrganizations.js
+++ b/src/routes/preHandlers/partnerOrganizations.js
@@ -16,15 +16,27 @@ exports.checkPartnerOrganizationAlreadyExists = async (req) => {
   return null;
 };
 
-exports.partnerOrganizationExists = async (req) => {
+exports.checkPartnerOrganizationExists = async (req) => {
   const partnerOrganizationExists = await PartnerOrganization.countDocuments({ _id: req.params._id });
   if (!partnerOrganizationExists) throw Boom.notFound();
 
   return null;
 };
 
-exports.authorizePartnerOrganizationEdit = async (req) => {
-  await this.partnerOrganizationExists(req);
+exports.authorizePartnerOrganizationCreation = async (req) => {
+  await this.checkPartnerOrganizationAlreadyExists(req);
+
+  return null;
+};
+
+exports.authorizePartnerOrganizationGetById = async (req) => {
+  await this.checkPartnerOrganizationExists(req);
+
+  return null;
+};
+
+exports.authorizePartnerOrganizationUpdate = async (req) => {
+  await this.checkPartnerOrganizationExists(req);
 
   if (req.payload.name) await this.checkPartnerOrganizationAlreadyExists(req);
 

--- a/src/routes/preHandlers/partnerOrganizations.js
+++ b/src/routes/preHandlers/partnerOrganizations.js
@@ -15,3 +15,10 @@ exports.authorizePartnerOrganizationCreation = async (req) => {
 
   return null;
 };
+
+exports.partnerOrganizationExists = async (req) => {
+  const partnerOrganizationExists = await PartnerOrganization.countDocuments({ _id: req.params._id });
+  if (!partnerOrganizationExists) throw Boom.forbidden();
+
+  return null;
+};

--- a/tests/integration/partnerOrganizations.test.js
+++ b/tests/integration/partnerOrganizations.test.js
@@ -287,17 +287,6 @@ describe('PARTNER ORGANIZATION ROUTES - PUT /partnerorganizations/{_id}', () => 
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 400 if more than one field is updated', async () => {
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { name: 'coucou', email: 'coucou@coucou.com' },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
     it('should return 404 if partner organization doesn\'t exist', async () => {
       const response = await app.inject({
         method: 'PUT',

--- a/tests/integration/partnerOrganizations.test.js
+++ b/tests/integration/partnerOrganizations.test.js
@@ -1,4 +1,5 @@
 const expect = require('expect');
+const { ObjectID } = require('mongodb');
 const app = require('../../server');
 const { populateDB, partnerOrganizationsList } = require('./seed/partnerOrganizationsSeed');
 const { getToken } = require('./seed/authenticationSeed');
@@ -161,6 +162,181 @@ describe('PARTNER ORGANIZATION ROUTES - GET /partnerorganizations', () => {
           method: 'GET',
           url: '/partnerorganizations',
           headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PARTNER ORGANIZATION ROUTES - GET /partnerorganizations/{_id}', () => {
+  let authToken;
+  beforeEach(populateDB);
+
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should return a partner organization', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 404 if partner organization doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/partnerorganizations/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'vendor_admin', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 403 },
+      { name: 'helper', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'GET',
+          url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('PARTNER ORGANIZATION ROUTES - PUT /partnerorganizations/{_id}', () => {
+  let authToken;
+  beforeEach(populateDB);
+
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should update a partner organization', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'skusku' },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 400 if name is not a string', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: null },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if phone is not a phoneNumber', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { phone: 'coucou' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if address is not a address', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { address: 'coucou' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if email is not a email', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { email: 'coucou' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if more than one field is updated', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'coucou', email: 'coucou@coucou.com' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 if partner organization doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'skusku' },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 409 if name is from an already existing partner organization', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { name: 'Gooogle' },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'vendor_admin', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 403 },
+      { name: 'helper', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const response = await app.inject({
+          method: 'PUT',
+          url: `/partnerorganizations/${partnerOrganizationsList[0]._id}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+          payload: { name: 'skusku' },
         });
 
         expect(response.statusCode).toBe(role.expectedCode);

--- a/tests/integration/seed/partnerOrganizationsSeed.js
+++ b/tests/integration/seed/partnerOrganizationsSeed.js
@@ -1,9 +1,11 @@
+const { ObjectID } = require('mongodb');
 const { authCompany, otherCompany } = require('../../seed/companySeed');
 const { populateDBForAuthentication } = require('./authenticationSeed');
 const PartnerOrganization = require('../../../src/models/PartnerOrganization');
 
 const partnerOrganizationsList = [
   {
+    _id: new ObjectID(),
     name: 'Gooogle',
     phone: '0123456789',
     email: 'skulysse@alenvi.io',

--- a/tests/unit/helpers/partnerOrganizations.test.js
+++ b/tests/unit/helpers/partnerOrganizations.test.js
@@ -71,3 +71,45 @@ describe('list', () => {
     );
   });
 });
+
+describe('getPartnerOrganization', () => {
+  let findOne;
+  beforeEach(() => {
+    findOne = sinon.stub(PartnerOrganization, 'findOne');
+  });
+  afterEach(() => {
+    findOne.restore();
+  });
+
+  it('should update a partner organizations', async () => {
+    const partnerOrganizationId = new ObjectID();
+
+    findOne.returns(SinonMongoose.stubChainedQueries([[{ _id: partnerOrganizationId, name: 'skusku' }]], ['lean']));
+
+    await PartnerOrganizationsHelper.getPartnerOrganization(partnerOrganizationId);
+
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ _id: partnerOrganizationId }] }, { query: 'lean' }]
+    );
+  });
+});
+
+describe('update', () => {
+  let updateOne;
+  beforeEach(() => {
+    updateOne = sinon.stub(PartnerOrganization, 'updateOne');
+  });
+  afterEach(() => {
+    updateOne.restore();
+  });
+
+  it('should update a partner organizations', async () => {
+    const payload = { name: 'skusku' };
+    const partnerOrganizationId = new ObjectID();
+
+    await PartnerOrganizationsHelper.update(partnerOrganizationId, payload);
+
+    sinon.assert.calledOnceWithExactly(updateOne, { _id: partnerOrganizationId }, { $set: { name: 'skusku' } });
+  });
+});

--- a/tests/unit/helpers/partnerOrganizations.test.js
+++ b/tests/unit/helpers/partnerOrganizations.test.js
@@ -72,7 +72,7 @@ describe('list', () => {
   });
 });
 
-describe('getPartnerOrganization', () => {
+describe('getById', () => {
   let findOne;
   beforeEach(() => {
     findOne = sinon.stub(PartnerOrganization, 'findOne');
@@ -86,7 +86,7 @@ describe('getPartnerOrganization', () => {
 
     findOne.returns(SinonMongoose.stubChainedQueries([[{ _id: partnerOrganizationId, name: 'skusku' }]], ['lean']));
 
-    await PartnerOrganizationsHelper.getPartnerOrganization(partnerOrganizationId);
+    await PartnerOrganizationsHelper.getById(partnerOrganizationId);
 
     SinonMongoose.calledWithExactly(
       findOne,

--- a/tests/unit/helpers/partnerOrganizations.test.js
+++ b/tests/unit/helpers/partnerOrganizations.test.js
@@ -86,7 +86,7 @@ describe('getById', () => {
 
     findOne.returns(SinonMongoose.stubChainedQueries([[{ _id: partnerOrganizationId, name: 'skusku' }]], ['lean']));
 
-    await PartnerOrganizationsHelper.getById(partnerOrganizationId);
+    await PartnerOrganizationsHelper.getPartnerOrganization(partnerOrganizationId);
 
     SinonMongoose.calledWithExactly(
       findOne,


### PR DESCRIPTION
- [x] Mon code est testé unitairement
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [ ] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima): -np
  - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
  - [ ] Inscription a une formation e-learning
  - [ ] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :~~
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : client

- Périmetre roles : coach / client_admin

- Cas d'usage : 
Si je clique sur une structure dans la liste des structures partenaires, je suis dirigé vers la page profile de celle ci, où je peux modifier les 4 champs d'une structure partenaire