### PR TITLE
Com 1976

### DIFF
--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -292,6 +292,7 @@ module.exports = {
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
     draftExpectationQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
+    publishedQuestionnaireWithSameTypeExists: 'A questionnaire with the same type is already published.',
     questionnaireUpdated: 'questionnaire updated.',
     /* PartnerOrganization */
     partnerOrganizationCreated: 'Partner organization created.',
@@ -589,6 +590,7 @@ module.exports = {
     questionnaireCreated: 'Questionnaire créé.',
     draftExpectationQuestionnaireAlreadyExists: `Il existe déjà un questionnaire en brouillon de type 'Recueil des
     attentes'.`,
+    publishedQuestionnaireWithSameTypeExists: 'Un questionnaire du même type est déjà publié.',
     questionnaireUpdated: 'Questionnaire mis à jour.',
     /* PartnerOrganization */
     partnerOrganizationCreated: 'Structure partenaire créee.',

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -41,10 +41,10 @@ exports.authorizeQuestionnaireEdit = async (req) => {
 
   if (questionnaire.status === PUBLISHED && !req.payload.title) throw Boom.forbidden();
 
-  const isQuestionnaireWithSameTypePublished = await Questionnaire.countDocuments(
+  const publishedQuestionnaireWithSameTypeExists = await Questionnaire.countDocuments(
     { type: questionnaire.type, status: PUBLISHED }
   );
-  if (req.payload.status === PUBLISHED && isQuestionnaireWithSameTypePublished) throw Boom.forbidden();
+  if (req.payload.status === PUBLISHED && publishedQuestionnaireWithSameTypeExists) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -44,7 +44,6 @@ exports.authorizeQuestionnaireEdit = async (req) => {
   const isQuestionnaireWithSameTypePublished = await Questionnaire.countDocuments(
     { type: questionnaire.type, status: PUBLISHED }
   );
-
   if (req.payload.status === PUBLISHED && isQuestionnaireWithSameTypePublished) throw Boom.forbidden();
 
   return null;

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -36,10 +36,16 @@ exports.authorizeQuestionnaireGet = async (req) => {
 };
 
 exports.authorizeQuestionnaireEdit = async (req) => {
-  const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
+  const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1, type: 1 }).lean();
   if (!questionnaire) throw Boom.notFound();
 
-  if (questionnaire.status === PUBLISHED) throw Boom.forbidden();
+  if (questionnaire.status === PUBLISHED && !req.payload.title) throw Boom.forbidden();
+
+  const isQuestionnaireWithSameTypePublished = await Questionnaire.countDocuments(
+    { type: questionnaire.type, status: PUBLISHED }
+  );
+
+  if (req.payload.status === PUBLISHED && isQuestionnaireWithSameTypePublished) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -44,7 +44,9 @@ exports.authorizeQuestionnaireEdit = async (req) => {
   const publishedQuestionnaireWithSameTypeExists = await Questionnaire.countDocuments(
     { type: questionnaire.type, status: PUBLISHED }
   );
-  if (req.payload.status === PUBLISHED && publishedQuestionnaireWithSameTypeExists) throw Boom.forbidden();
+  if (req.payload.status === PUBLISHED && publishedQuestionnaireWithSameTypeExists) {
+    throw Boom.conflict(translate[language].publishedQuestionnaireWithSameTypeExists);
+  }
 
   return null;
 };

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -85,11 +85,11 @@ exports.plugin = {
       options: {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
-          payload: Joi.alternatives().try(
-            Joi.object({ title: Joi.string().required() }),
-            Joi.object({ cards: Joi.array().items(Joi.objectId()).required() }),
-            Joi.object({ status: Joi.string().required().valid(PUBLISHED) })
-          ),
+          payload: Joi.object({
+            title: Joi.string(),
+            cards: Joi.array().items(Joi.objectId()),
+            status: Joi.string().valid(PUBLISHED),
+          }),
         },
         auth: { scope: ['questionnaires:edit'] },
         pre: [{ method: authorizeQuestionnaireEdit }],

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -10,6 +10,7 @@ const {
   authorizeCardDeletion,
 } = require('./preHandlers/questionnaires');
 const { CARD_TEMPLATES } = require('../models/Card');
+const { PUBLISHED } = require('../helpers/constants');
 
 exports.plugin = {
   name: 'routes-questionnaires',
@@ -86,7 +87,8 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.alternatives().try(
             Joi.object({ title: Joi.string().required() }),
-            Joi.object({ cards: Joi.array().items(Joi.objectId()).required() })
+            Joi.object({ cards: Joi.array().items(Joi.objectId()).required() }),
+            Joi.object({ status: Joi.string().required().valid(PUBLISHED) })
           ),
         },
         auth: { scope: ['questionnaires:edit'] },

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -6,7 +6,7 @@ const Card = require('../../src/models/Card');
 const { populateDB, questionnairesList, cardsList } = require('./seed/questionnairesSeed');
 const { getToken, getTokenByCredentials } = require('./seed/authenticationSeed');
 const { noRoleNoCompany } = require('../seed/userSeed');
-const { SURVEY } = require('../../src/helpers/constants');
+const { SURVEY, PUBLISHED } = require('../../src/helpers/constants');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -233,8 +233,34 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should update questionnaire title even if questionnaire is published', async () => {
+      const payload = { title: 'test2' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     it('should update cards order', async () => {
       const payload = { cards: [questionnairesList[0].cards[1], questionnairesList[0].cards[0]] };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should update cards status', async () => {
+      await Questionnaire.deleteMany({ _id: questionnairesList[1]._id });
+
+      const payload = { status: PUBLISHED };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${questionnairesList[0]._id}`,
@@ -317,11 +343,11 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return 403 if questionnaire is published', async () => {
-      const payload = { title: 'test2' };
+    it('should return 403 if questionnaire with same type is already published', async () => {
+      const payload = { status: PUBLISHED };
       const response = await app.inject({
         method: 'PUT',
-        url: `/questionnaires/${questionnairesList[1]._id}`,
+        url: `/questionnaires/${questionnairesList[0]._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -345,6 +345,21 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(404);
     });
 
+    it('should return 403 if cards are not valid', async () => {
+      await Questionnaire.deleteMany({ _id: questionnairesList[1]._id });
+      await Card.updateMany({ title: 'test1' }, { $set: { title: '' } });
+
+      const payload = { status: PUBLISHED };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
     it('should return 409 if questionnaire with same type is already published', async () => {
       const payload = { status: PUBLISHED };
       const response = await app.inject({

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -257,7 +257,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(200);
     });
 
-    it('should update cards status', async () => {
+    it('should update questionnaire status', async () => {
       await Questionnaire.deleteMany({ _id: questionnairesList[1]._id });
 
       const payload = { status: PUBLISHED };
@@ -297,18 +297,6 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
 
     it('should return 400 if title is empty', async () => {
       const payload = { title: '' };
-      const response = await app.inject({
-        method: 'PUT',
-        url: `/questionnaires/${questionnairesList[0]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload,
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-
-    it('should return 400 if try to update title and cards', async () => {
-      const payload = { title: 'test2', cards: [questionnairesList[0].cards[1], questionnairesList[0].cards[0]] };
       const response = await app.inject({
         method: 'PUT',
         url: `/questionnaires/${questionnairesList[0]._id}`,

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -6,7 +6,7 @@ const Card = require('../../src/models/Card');
 const { populateDB, questionnairesList, cardsList } = require('./seed/questionnairesSeed');
 const { getToken, getTokenByCredentials } = require('./seed/authenticationSeed');
 const { noRoleNoCompany } = require('../seed/userSeed');
-const { SURVEY, PUBLISHED } = require('../../src/helpers/constants');
+const { SURVEY, PUBLISHED, DRAFT } = require('../../src/helpers/constants');
 
 describe('NODE ENV', () => {
   it('should be \'test\'', () => {
@@ -269,6 +269,20 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       });
 
       expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 400 if questionnaire status is not PUBLISHED', async () => {
+      await Questionnaire.deleteMany({ _id: questionnairesList[1]._id });
+
+      const payload = { status: DRAFT };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/questionnaires/${questionnairesList[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
     });
 
     it('should return 400 if cards is not an array of strings', async () => {

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -345,7 +345,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return 403 if questionnaire with same type is already published', async () => {
+    it('should return 409 if questionnaire with same type is already published', async () => {
       const payload = { status: PUBLISHED };
       const response = await app.inject({
         method: 'PUT',
@@ -354,7 +354,7 @@ describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
         payload,
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(409);
     });
   });
 

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -2,13 +2,13 @@ const { ObjectID } = require('mongodb');
 const Questionnaire = require('../../../src/models/Questionnaire');
 const Card = require('../../../src/models/Card');
 const { populateDBForAuthentication } = require('./authenticationSeed');
-const { TRANSITION, SURVEY } = require('../../../src/helpers/constants');
+const { TRANSITION, OPEN_QUESTION } = require('../../../src/helpers/constants');
 
 const cardsList = [
-  { _id: new ObjectID(), template: TRANSITION },
-  { _id: new ObjectID(), template: SURVEY },
-  { _id: new ObjectID(), template: TRANSITION },
-  { _id: new ObjectID(), template: SURVEY },
+  { _id: new ObjectID(), template: TRANSITION, title: 'test1' },
+  { _id: new ObjectID(), template: OPEN_QUESTION, question: 'question?' },
+  { _id: new ObjectID(), template: TRANSITION, title: 'test2' },
+  { _id: new ObjectID(), template: OPEN_QUESTION, question: 'question?' },
 ];
 
 const questionnairesList = [


### PR DESCRIPTION
- [ ] Mon code est testé unitairement -np
- Tests intégrations: (barrer ce qui n'est pas utile)
  - Ce n'est pas une ancienne route utilisée par le mobile
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par le mobile~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions du mobile
      fonctionnent

- [x] J'ai testé que les anciennes versions maintenues de l'application mobile fonctionnent toujours (a minima):
  - [x] Affichage des pages explorer/mes formations/About/CourseProfile
  - [x] Inscription a une formation e-learning
  - [x] Possibilité de faire une activité

- [x] Mes changements n'impactent pas une route utilisée par l'autre plateforme (mobile/webapp)
- ~~Mes changements impactent une route utilisée par l'autre plateforme (mobile/webapp):~~
  - [ ] J'ai décrit dans le cas d'usage les choses a tester sur l'autre plateforme
  - Je n'ai pas fait de breaking change :
    - [ ] Je n'ai pas changé les droits de la route
    - [ ] Je n'ai pas changé les droits dans le fichier rights.js
    - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
    - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
    - Justification des breaking changes s'il y en a:
  - J'ai supprimé une route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'utilise pas
  - J'ai renommé une route :
    - [ ] La route n'est pas utilisée par le mobile (si la route est utilisée en mobile: ne pas la renommer et plutôt
    créer une nouvelle route utilisée par la WEBAPP et toutes les nouvelles versions mobiles)
  - J'ai ajoute un champ possible dans la route :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs de la route :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible dans la route :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas
  - J'ai supprimé un retour/un champs du retour de la route :
    - [ ] Les anciennes versions mobiles + l'actuelle n'utilise pas ce retour

- ~~J'ai changé un modele :
  - J'ai ajoute un champ possible :
    - [ ] J'ai géré le cas ou on ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par le mobile (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + l'actuelle ne l'envoient pas

- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : je peux publier un questionnaire
