### PR TITLE
COM-2030 - refacto event validation

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -16,6 +16,7 @@ const ContractNumber = require('../models/ContractNumber');
 const EventHelper = require('./events');
 const ReferentHistoryHelper = require('./referentHistories');
 const UtilsHelper = require('./utils');
+const DatesHelper = require('./dates');
 const GDriveStorageHelper = require('./gDriveStorage');
 const { AUXILIARY } = require('./constants');
 const { createAndReadFile } = require('./file');
@@ -373,5 +374,8 @@ exports.uploadFile = async (params, payload) => {
 };
 
 exports.auxiliaryHasActiveContractOnDay = (contracts, day) =>
-  contracts.some(contract => moment(contract.startDate).isSameOrBefore(day, 'd') &&
-    (!contract.endDate || moment(contract.endDate).isSameOrAfter(day, 'd')));
+  exports.auxiliaryHasActiveContractBetweenDates(contracts, day, day);
+
+exports.auxiliaryHasActiveContractBetweenDates = (contracts, startDate, endDate) =>
+  contracts.some(c => DatesHelper.isSameOrBefore(c.startDate, startDate) &&
+    (!c.endDate || DatesHelper.isSameOrAfter(c.endDate, endDate)));

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,3 +1,7 @@
 exports.isBefore = (date1, date2) => new Date(date1) < new Date(date2);
 
-exports.isAfter = (date1, date2) => new Date(date2) < new Date(date1);
+exports.isSameOrBefore = (date1, date2) => new Date(date1) <= new Date(date2);
+
+exports.isAfter = (date1, date2) => new Date(date1) > new Date(date2);
+
+exports.isSameOrAfter = (date1, date2) => new Date(date1) >= new Date(date2);

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -24,17 +24,17 @@ exports.isUserContractValidOnEventDates = async (event) => {
   const user = await User.findOne({ _id: event.auxiliary }).populate('contracts').lean();
   if (!user.contracts || user.contracts.length === 0) return false;
 
-  return event.type !== ABSENCE
-    ? ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate)
-    : ContractsHelper.auxiliaryHasActiveContractBetweenDates(user.contracts, event.startDate, event.endDate);
+  return event.type === ABSENCE
+    ? ContractsHelper.auxiliaryHasActiveContractBetweenDates(user.contracts, event.startDate, event.endDate)
+    : ContractsHelper.auxiliaryHasActiveContractOnDay(user.contracts, event.startDate);
 };
 
 exports.hasConflicts = async (event) => {
   const { _id, auxiliary, startDate, endDate } = event;
 
-  const auxiliaryEvents = event.type !== ABSENCE
-    ? await EventRepository.getAuxiliaryEventsBetweenDates(auxiliary, startDate, endDate, event.company)
-    : await EventRepository.getAuxiliaryEventsBetweenDates(auxiliary, startDate, endDate, event.company, ABSENCE);
+  const auxiliaryEvents = event.type === ABSENCE
+    ? await EventRepository.getAuxiliaryEventsBetweenDates(auxiliary, startDate, endDate, event.company, ABSENCE)
+    : await EventRepository.getAuxiliaryEventsBetweenDates(auxiliary, startDate, endDate, event.company);
 
   return auxiliaryEvents.some((ev) => {
     if ((_id && _id.toHexString() === ev._id.toHexString()) || ev.isCancelled) return false;

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -43,272 +43,169 @@ describe('NODE ENV', () => {
   });
 });
 
-describe('EVENTS ROUTES', () => {
+describe('GET /events', () => {
   let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
 
-  describe('GET /events', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
+    it('should return a list of events', async () => {
+      const startDate = moment('2019-01-18');
+      const endDate = moment('2019-01-20');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?startDate=${startDate.toDate()}&endDate=${endDate.toDate()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should return a list of events', async () => {
-        const startDate = moment('2019-01-18');
-        const endDate = moment('2019-01-20');
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?startDate=${startDate.toDate()}&endDate=${endDate.toDate()}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.events).toBeDefined();
-        response.result.data.events.forEach((event) => {
-          expect(moment(event.startDate).isSameOrAfter(startDate)).toBeTruthy();
-          expect(moment(event.startDate).isSameOrBefore(endDate)).toBeTruthy();
-          if (event.type === 'intervention') {
-            expect(event.subscription._id).toBeDefined();
-          }
-        });
-      });
-
-      it('should return a list of events groupedBy customers', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events?groupBy=customer&type=intervention',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.events).toBeDefined();
-        expect(response.result.data.events[0]._id).toBeDefined();
-        expect(response.result.data.events[0].events).toBeDefined();
-        response.result.data.events[0].events.forEach((event) => {
-          expect(event.customer._id).toEqual(response.result.data.events[0]._id);
-        });
-      });
-
-      it('should return a list of events groupedBy auxiliaries', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events?groupBy=auxiliary',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.events).toBeDefined();
-        expect(response.result.data.events[0]._id).toBeDefined();
-        expect(response.result.data.events[0].events).toBeDefined();
-        const index = response.result.data.events.findIndex(event => event.events[0].auxiliary);
-        response.result.data.events[index].events.forEach((event) => {
-          expect(event.auxiliary._id).toEqual(response.result.data.events[index]._id);
-        });
-      });
-
-      it('should return a 200 if same id send twice - sectors', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?sector=${sectors[0]._id}&sector=${sectors[0]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-      });
-
-      it('should return a 200 if same id send twice - auxiliaries', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?auxiliary=${auxiliaries[0]._id}&auxiliary=${auxiliaries[0]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-      });
-
-      it('should return a 200 if same id send twice - customers', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?customer=${customerAuxiliary._id}&customer=${customerAuxiliary._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-      });
-
-      it('should return a 403 if customer is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?customer=${customerFromOtherCompany._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if auxiliary is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?auxiliary=${auxiliaryFromOtherCompany._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if sector is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events?sector=${sectors[2]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.events).toBeDefined();
+      response.result.data.events.forEach((event) => {
+        expect(moment(event.startDate).isSameOrAfter(startDate)).toBeTruthy();
+        expect(moment(event.startDate).isSameOrBefore(endDate)).toBeTruthy();
+        if (event.type === 'intervention') {
+          expect(event.subscription._id).toBeDefined();
+        }
       });
     });
 
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        {
-          name: 'helper\'s customer',
-          expectedCode: 200,
-          url: `/events?customer=${customerAuxiliary._id.toHexString()}`,
-          customCredentials: { ...helpersCustomer.local },
-        },
-        { name: 'auxiliary', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-        { name: 'planning_referent', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
-          const response = await app.inject({
-            method: 'GET',
-            url: role.url || '/events',
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+    it('should return a list of events groupedBy customers', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events?groupBy=customer&type=intervention',
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.events).toBeDefined();
+      expect(response.result.data.events[0]._id).toBeDefined();
+      expect(response.result.data.events[0].events).toBeDefined();
+      response.result.data.events[0].events.forEach((event) => {
+        expect(event.customer._id).toEqual(response.result.data.events[0]._id);
+      });
+    });
+
+    it('should return a list of events groupedBy auxiliaries', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events?groupBy=auxiliary',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.events).toBeDefined();
+      expect(response.result.data.events[0]._id).toBeDefined();
+      expect(response.result.data.events[0].events).toBeDefined();
+      const index = response.result.data.events.findIndex(event => event.events[0].auxiliary);
+      response.result.data.events[index].events.forEach((event) => {
+        expect(event.auxiliary._id).toEqual(response.result.data.events[index]._id);
+      });
+    });
+
+    it('should return a 200 if same id send twice - sectors', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?sector=${sectors[0]._id}&sector=${sectors[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it('should return a 200 if same id send twice - auxiliaries', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?auxiliary=${auxiliaries[0]._id}&auxiliary=${auxiliaries[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it('should return a 200 if same id send twice - customers', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?customer=${customerAuxiliary._id}&customer=${customerAuxiliary._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it('should return a 403 if customer is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?customer=${customerFromOtherCompany._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if auxiliary is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?auxiliary=${auxiliaryFromOtherCompany._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if sector is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events?sector=${sectors[2]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
     });
   });
 
-  describe('GET /events/credit-notes', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
-      });
+  describe('Other roles', () => {
+    beforeEach(populateDB);
 
-      it('should return a list of billed events for specified customer', async () => {
-        const query = {
-          startDate: moment('2019-01-01').toDate(),
-          endDate: moment('2019-01-20').toDate(),
-          customer: customerAuxiliary._id.toHexString(),
-          creditNoteId: creditNotesList._id,
-        };
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      {
+        name: 'helper\'s customer',
+        expectedCode: 200,
+        url: `/events?customer=${customerAuxiliary._id.toHexString()}`,
+        customCredentials: { ...helpersCustomer.local },
+      },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 200 },
+    ];
 
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
-          url: `/events/credit-notes?${qs.stringify(query)}`,
+          url: role.url || '/events',
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.events).toBeDefined();
-        const filteredEvents = eventsList.filter(ev => ev.isBilled && !ev.bills.inclTaxesTpp);
-        expect(response.result.data.events.length).toBe(filteredEvents.length);
-      });
-
-      it('should return a list of billed events for specified customer and tpp', async () => {
-        const query = {
-          startDate: moment('2019-01-01').toDate(),
-          endDate: moment('2019-01-20').toDate(),
-          customer: customerAuxiliary._id.toHexString(),
-          thirdPartyPayer: thirdPartyPayer._id.toHexString(),
-          creditNoteId: creditNotesList._id,
-        };
-
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/credit-notes?${qs.stringify(query)}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-      });
-
-      const wrongParams = ['startDate', 'endDate', 'customer'];
-      wrongParams.forEach((param) => {
-        it(`should return a 400 error if missing '${param}' parameter`, async () => {
-          const query = {
-            startDate: moment('2019-01-01').toDate(),
-            endDate: moment('2019-01-20').toDate(),
-            customer: customerAuxiliary._id.toHexString(),
-          };
-          const wrongQuery = omit(query, param);
-
-          const response = await app.inject({
-            method: 'GET',
-            url: `/events/credit-notes?${qs.stringify(wrongQuery)}`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(400);
-        });
-      });
-
-      it('should return a 403 if customer is not from the same company', async () => {
-        const query = {
-          startDate: moment('2019-01-01').toDate(),
-          endDate: moment('2019-01-20').toDate(),
-          customer: customerFromOtherCompany._id.toHexString(),
-          thirdPartyPayer: thirdPartyPayer._id.toHexString(),
-          creditNoteId: creditNotesList._id,
-        };
-
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/credit-notes?${qs.stringify(query)}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if tpp is not from the same company', async () => {
-        const query = {
-          startDate: moment('2019-01-01').toDate(),
-          endDate: moment('2019-01-20').toDate(),
-          customer: customerAuxiliary._id.toHexString(),
-          thirdPartyPayer: thirdPartyPayerFromOtherCompany._id.toHexString(),
-          creditNoteId: creditNotesList._id,
-        };
-
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/credit-notes?${qs.stringify(query)}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
+  });
+});
 
-    describe('Other roles', () => {
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-        { name: 'planning_referent', expectedCode: 200 },
-      ];
+describe('GET /events/credit-notes', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should return a list of billed events for specified customer', async () => {
       const query = {
         startDate: moment('2019-01-01').toDate(),
         endDate: moment('2019-01-20').toDate(),
@@ -316,459 +213,404 @@ describe('EVENTS ROUTES', () => {
         creditNoteId: creditNotesList._id,
       };
 
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = await getToken(role.name);
-
-          const response = await app.inject({
-            method: 'GET',
-            url: `/events/credit-notes?${qs.stringify(query)}`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/credit-notes?${qs.stringify(query)}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.events).toBeDefined();
+      const filteredEvents = eventsList.filter(ev => ev.isBilled && !ev.bills.inclTaxesTpp);
+      expect(response.result.data.events.length).toBe(filteredEvents.length);
+    });
+
+    it('should return a list of billed events for specified customer and tpp', async () => {
+      const query = {
+        startDate: moment('2019-01-01').toDate(),
+        endDate: moment('2019-01-20').toDate(),
+        customer: customerAuxiliary._id.toHexString(),
+        thirdPartyPayer: thirdPartyPayer._id.toHexString(),
+        creditNoteId: creditNotesList._id,
+      };
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/credit-notes?${qs.stringify(query)}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+    });
+
+    const wrongParams = ['startDate', 'endDate', 'customer'];
+    wrongParams.forEach((param) => {
+      it(`should return a 400 error if missing '${param}' parameter`, async () => {
+        const query = {
+          startDate: moment('2019-01-01').toDate(),
+          endDate: moment('2019-01-20').toDate(),
+          customer: customerAuxiliary._id.toHexString(),
+        };
+        const wrongQuery = omit(query, param);
+
+        const response = await app.inject({
+          method: 'GET',
+          url: `/events/credit-notes?${qs.stringify(wrongQuery)}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    it('should return a 403 if customer is not from the same company', async () => {
+      const query = {
+        startDate: moment('2019-01-01').toDate(),
+        endDate: moment('2019-01-20').toDate(),
+        customer: customerFromOtherCompany._id.toHexString(),
+        thirdPartyPayer: thirdPartyPayer._id.toHexString(),
+        creditNoteId: creditNotesList._id,
+      };
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/credit-notes?${qs.stringify(query)}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if tpp is not from the same company', async () => {
+      const query = {
+        startDate: moment('2019-01-01').toDate(),
+        endDate: moment('2019-01-20').toDate(),
+        customer: customerAuxiliary._id.toHexString(),
+        thirdPartyPayer: thirdPartyPayerFromOtherCompany._id.toHexString(),
+        creditNoteId: creditNotesList._id,
+      };
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/credit-notes?${qs.stringify(query)}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
     });
   });
 
-  describe('GET /events/working-stats', () => {
-    const startDate = moment('2019-01-17').toDate();
-    const endDate = moment('2019-01-20').toDate();
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 200 },
+    ];
+    const query = {
+      startDate: moment('2019-01-01').toDate(),
+      endDate: moment('2019-01-20').toDate(),
+      customer: customerAuxiliary._id.toHexString(),
+      creditNoteId: creditNotesList._id,
+    };
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+
+        const response = await app.inject({
+          method: 'GET',
+          url: `/events/credit-notes?${qs.stringify(query)}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('GET /events/working-stats', () => {
+  let authToken = null;
+  const startDate = moment('2019-01-17').toDate();
+  const endDate = moment('2019-01-20').toDate();
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should return working stats for auxiliaries', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/working-stats?auxiliary=${auxiliaries[0]._id}&startDate=${startDate}&endDate=${endDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should return working stats for auxiliaries', async () => {
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.workingStats[auxiliaries[0]._id]).toBeDefined();
+      expect(response.result.data.workingStats[auxiliaries[0]._id].hoursToWork).toEqual(2);
+      expect(response.result.data.workingStats[auxiliaries[0]._id].workedHours).toEqual(5.5);
+    });
+
+    it('should return working stats for all auxiliaries', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/working-stats?startDate=${startDate}&endDate=${endDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it('should return a 403 if auxiliary is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/working-stats?auxiliary=${auxiliaryFromOtherCompany._id}&startDate=${startDate}
+          &endDate=${endDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+  });
+
+  describe('Other roles', () => {
+    beforeEach(populateDB);
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
           url: `/events/working-stats?auxiliary=${auxiliaries[0]._id}&startDate=${startDate}&endDate=${endDate}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.workingStats[auxiliaries[0]._id]).toBeDefined();
-        expect(response.result.data.workingStats[auxiliaries[0]._id].hoursToWork).toEqual(2);
-        expect(response.result.data.workingStats[auxiliaries[0]._id].workedHours).toEqual(5.5);
-      });
-
-      it('should return working stats for all auxiliaries', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/working-stats?startDate=${startDate}&endDate=${endDate}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-      });
-
-      it('should return a 403 if auxiliary is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/working-stats?auxiliary=${auxiliaryFromOtherCompany._id}&startDate=${startDate}
-            &endDate=${endDate}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-    });
-
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-        { name: 'planning_referent', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = await getToken(role.name);
-          const response = await app.inject({
-            method: 'GET',
-            url: `/events/working-stats?auxiliary=${auxiliaries[0]._id}&startDate=${startDate}&endDate=${endDate}`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
   });
+});
 
-  describe('GET /events/paid-transport', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
-      });
-
-      it('should return paid transport stats for many sectors', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/paid-transport?sector=${sectors[0]._id}&sector=${sectors[1]._id}&month=01-2020`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        const resultForFirstSector = response.result.data.paidTransportStatsBySector
-          .find(res => res.sector.toHexString() === sectors[0]._id.toHexString());
-        expect(resultForFirstSector.duration).toEqual(0.5);
-
-        const resultForSecondSector = response.result.data.paidTransportStatsBySector
-          .find(res => res.sector.toHexString() === sectors[1]._id.toHexString());
-        expect(resultForSecondSector.duration).toEqual(0.5);
-      });
-
-      it('should return a 403 if sector is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/paid-transport?sector=${sectors[2]._id}&month=01-2020`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 400 if missing sector', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events/paid-transport?month=01-2020',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 400 if missing month', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/paid-transport?sector=${sectors[0]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 400 if month does not correspond to regex', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events/paid-transport?month=012020',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
+describe('GET /events/paid-transport', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
     });
 
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-        { name: 'planning_referent', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = await getToken(role.name);
-          const response = await app.inject({
-            method: 'GET',
-            url: `/events/paid-transport?sector=${sectors[0]._id}&month=01-2020`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+    it('should return paid transport stats for many sectors', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/paid-transport?sector=${sectors[0]._id}&sector=${sectors[1]._id}&month=01-2020`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(response.statusCode).toEqual(200);
+      const resultForFirstSector = response.result.data.paidTransportStatsBySector
+        .find(res => res.sector.toHexString() === sectors[0]._id.toHexString());
+      expect(resultForFirstSector.duration).toEqual(0.5);
+
+      const resultForSecondSector = response.result.data.paidTransportStatsBySector
+        .find(res => res.sector.toHexString() === sectors[1]._id.toHexString());
+      expect(resultForSecondSector.duration).toEqual(0.5);
+    });
+
+    it('should return a 403 if sector is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/paid-transport?sector=${sectors[2]._id}&month=01-2020`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 400 if missing sector', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events/paid-transport?month=01-2020',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 400 if missing month', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/paid-transport?sector=${sectors[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 400 if month does not correspond to regex', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events/paid-transport?month=012020',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
     });
   });
 
-  describe('GET /events/unassigned-hours', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
-      });
+  describe('Other roles', () => {
+    beforeEach(populateDB);
 
-      it('should return an empty array if sector does not have unassigned event', async () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'GET',
-          url: `/events/unassigned-hours?sector=${sectors[0]._id}&month=02-2020`,
+          url: `/events/paid-transport?sector=${sectors[0]._id}&month=01-2020`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.unassignedHoursBySector.length).toEqual(0);
-      });
-
-      it('should return unassigned hours for many sectors', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/unassigned-hours?sector=${sectors[0]._id}&sector=${sectors[1]._id}&month=01-2020`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        const firstSectorResult = response.result.data.unassignedHoursBySector
-          .find(el => el.sector.toHexString() === sectors[0]._id.toHexString());
-        expect(firstSectorResult.duration).toEqual(5);
-
-        const secondSectorResult = response.result.data.unassignedHoursBySector
-          .find(el => el.sector.toHexString() === sectors[1]._id.toHexString());
-        expect(secondSectorResult.duration).toEqual(1.5);
-      });
-
-      it('should return a 403 if sector is not from the same company', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/unassigned-hours?sector=${sectors[2]._id}&month=01-2020`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 400 if missing sector', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events/unassigned-hours?month=01-2020',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 400 if missing month', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: `/events/unassigned-hours?sector=${sectors[0]._id}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 400 if month does not correspond to regex', async () => {
-        const response = await app.inject({
-          method: 'GET',
-          url: '/events/unassigned-hours?month=012020',
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-    });
-
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 200 },
-        { name: 'coach', expectedCode: 200 },
-        { name: 'planning_referent', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = await getToken(role.name);
-          const response = await app.inject({
-            method: 'GET',
-            url: `/events/unassigned-hours?sector=${sectors[0]._id}&month=01-2020`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
   });
+});
 
-  describe('POST /events', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
+describe('GET /events/unassigned-hours', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should return an empty array if sector does not have unassigned event', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/unassigned-hours?sector=${sectors[0]._id}&month=02-2020`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should create an internal hour', async () => {
-        const payload = {
-          type: INTERNAL_HOUR,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          internalHour: internalHour._id,
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.unassignedHoursBySector.length).toEqual(0);
+    });
 
+    it('should return unassigned hours for many sectors', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/unassigned-hours?sector=${sectors[0]._id}&sector=${sectors[1]._id}&month=01-2020`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      const firstSectorResult = response.result.data.unassignedHoursBySector
+        .find(el => el.sector.toHexString() === sectors[0]._id.toHexString());
+      expect(firstSectorResult.duration).toEqual(5);
+
+      const secondSectorResult = response.result.data.unassignedHoursBySector
+        .find(el => el.sector.toHexString() === sectors[1]._id.toHexString());
+      expect(secondSectorResult.duration).toEqual(1.5);
+    });
+
+    it('should return a 403 if sector is not from the same company', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/unassigned-hours?sector=${sectors[2]._id}&month=01-2020`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 400 if missing sector', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events/unassigned-hours?month=01-2020',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 400 if missing month', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/events/unassigned-hours?sector=${sectors[0]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 400 if month does not correspond to regex', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/events/unassigned-hours?month=012020',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+  });
+
+  describe('Other roles', () => {
+    beforeEach(populateDB);
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 200 },
+      { name: 'coach', expectedCode: 200 },
+      { name: 'planning_referent', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
         const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
+          method: 'GET',
+          url: `/events/unassigned-hours?sector=${sectors[0]._id}&month=01-2020`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
+        expect(response.statusCode).toBe(role.expectedCode);
       });
+    });
+  });
+});
 
-      it('should create an intervention with auxiliary', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
+describe('POST /events', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
 
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-      });
-
-      it('should create an intervention with sector', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          sector: sectors[0]._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-      });
-
-      it('should create an absence', async () => {
-        const auxiliary = auxiliaries[0];
-        const payload = {
-          type: ABSENCE,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliary._id.toHexString(),
-          absence: ILLNESS,
-          absenceNature: DAILY,
-          attachment: { driveId: 'qwertyuiop', link: 'asdfghjkl;' },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-      });
-
-      it('should create an unavailability', async () => {
-        const payload = {
-          type: UNAVAILABILITY,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id,
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-      });
-
-      it('should create a repetition', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-          repetition: { frequency: EVERY_DAY },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-        const repeatedEventsCount = await Event.countDocuments({
-          'repetition.parentId': response.result.data.event._id,
-          company: authCompany._id,
-        }).lean();
-        expect(repeatedEventsCount).toEqual(91);
-        const repetition = await Repetition.findOne({ parentId: response.result.data.event._id }).lean();
-        expect(repetition).toBeDefined();
-      });
-
-      const baseInterventionPayload = {
-        type: INTERVENTION,
+    it('should create an internal hour', async () => {
+      const payload = {
+        type: INTERNAL_HOUR,
         startDate: '2019-01-23T10:00:00',
         endDate: '2019-01-23T12:30:00',
         auxiliary: auxiliaries[0]._id.toHexString(),
-        customer: customerAuxiliary._id.toHexString(),
-        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        internalHour: internalHour._id,
         address: {
           fullAddress: '4 rue du test 92160 Antony',
           street: '4 rue du test',
@@ -777,367 +619,19 @@ describe('EVENTS ROUTES', () => {
           location: { type: 'Point', coordinates: [2.377133, 48.801389] },
         },
       };
-      const interventionMissingParams = [
-        { payload: { ...omit(baseInterventionPayload, 'address') }, reason: 'missing address' },
-        { payload: { ...omit(baseInterventionPayload, 'address.fullAddress') }, reason: 'missing address.fullAddress' },
-        { payload: { ...omit(baseInterventionPayload, 'address.street') }, reason: 'missing address.street' },
-        { payload: { ...omit(baseInterventionPayload, 'address.zipCode') }, reason: 'missing address.zipCode' },
-        { payload: { ...omit(baseInterventionPayload, 'address.city') }, reason: 'missing address.city' },
-        { payload: { ...omit(baseInterventionPayload, 'address.location') }, reason: 'missing address.location' },
-        {
-          payload: { ...omit(baseInterventionPayload, 'address.location.coordinates') },
-          reason: 'missing address.location.coordinates',
-        },
-        {
-          payload: { ...omit(baseInterventionPayload, 'address.location.type') },
-          reason: 'missing address.location.type',
-        },
-        { payload: { ...omit(baseInterventionPayload, 'customer') }, reason: 'missing customer' },
-        { payload: { ...omit(baseInterventionPayload, 'subscription') }, reason: 'missing subscription' },
-        { payload: { ...omit(baseInterventionPayload, 'type') }, reason: 'missing type' },
-        { payload: { ...omit(baseInterventionPayload, 'startDate') }, reason: 'missing startDate' },
-        { payload: { ...omit(baseInterventionPayload, 'endDate') }, reason: 'missing endDate' },
-      ];
-      interventionMissingParams.forEach((test) => {
-        it(`should return a 400 error as intervention payload is invalid: ${test.reason}`, async () => {
-          const response = await app.inject({
-            method: 'POST',
-            url: '/events',
-            payload: test.payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-          expect(response.statusCode).toEqual(400);
-        });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const baseInternalHourPayload = {
-        type: INTERNAL_HOUR,
-        startDate: '2019-01-23T10:00:00',
-        endDate: '2019-01-23T12:30:00',
-        auxiliary: auxiliaries[0]._id.toHexString(),
-        internalHour: internalHour._id,
-      };
-      const internalHourMissingParams = [
-        { payload: { ...omit(baseInternalHourPayload, 'internalHour') }, reason: 'missing internalHour' },
-        { payload: { ...omit(baseInternalHourPayload, 'startDate') }, reason: 'missing startDate' },
-        { payload: { ...omit(baseInternalHourPayload, 'endDate') }, reason: 'missing endDate' },
-        { payload: { ...omit(baseInternalHourPayload, 'auxiliary') }, reason: 'missing auxiliary' },
-      ];
-      internalHourMissingParams.forEach((test) => {
-        it(`should return a 400 error as internal hour payload is invalid: ${test.reason}`, async () => {
-          const response = await app.inject({
-            method: 'POST',
-            url: '/events',
-            payload: test.payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-          expect(response.statusCode).toEqual(400);
-        });
-      });
-
-      const baseAbsencePayload = {
-        type: ABSENCE,
-        startDate: '2019-01-23T10:00:00',
-        endDate: '2019-01-23T12:30:00',
-        auxiliary: auxiliaries[0]._id.toHexString(),
-        absence: ILLNESS,
-        absenceNature: DAILY,
-        attachment: { driveId: 'qwertyuiop', link: 'asdfghjkl;' },
-      };
-      const absenceMissingParams = [
-        { payload: { ...omit(baseAbsencePayload, 'absence') }, reason: 'missing absence' },
-        { payload: { ...omit(baseAbsencePayload, 'absenceNature') }, reason: 'missing absenceNature' },
-        { payload: { ...omit(baseAbsencePayload, 'startDate') }, reason: 'missing startDate' },
-        { payload: { ...omit(baseAbsencePayload, 'endDate') }, reason: 'missing endDate' },
-        { payload: { ...omit(baseAbsencePayload, 'auxiliary') }, reason: 'missing auxiliary' },
-        { payload: { ...omit(baseAbsencePayload, 'attachment') }, reason: 'missing attachment on illness' },
-      ];
-      absenceMissingParams.forEach((test) => {
-        it(`should return a 400 error as absence payload is invalid: ${test.reason}`, async () => {
-          const response = await app.inject({
-            method: 'POST',
-            url: '/events',
-            payload: test.payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-          expect(response.statusCode).toEqual(400);
-        });
-      });
-
-      const baseUnavailabilityPayload = {
-        type: UNAVAILABILITY,
-        startDate: '2019-01-23T10:00:00',
-        endDate: '2019-01-23T12:30:00',
-        auxiliary: auxiliaries[0]._id.toHexString(),
-      };
-      const unavailabilityMissingParams = [
-        { payload: { ...omit(baseUnavailabilityPayload, 'startDate') }, reason: 'missing startDate' },
-        { payload: { ...omit(baseUnavailabilityPayload, 'endDate') }, reason: 'missing endDate' },
-        { payload: { ...omit(baseUnavailabilityPayload, 'auxiliary') }, reason: 'missing auxiliary' },
-      ];
-      unavailabilityMissingParams.forEach((test) => {
-        it(`should return a 400 error as unavailability payload is invalid: ${test.reason}`, async () => {
-          const response = await app.inject({
-            method: 'POST',
-            url: '/events',
-            payload: test.payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-          expect(response.statusCode).toEqual(400);
-        });
-      });
-
-      it('should return a 400 error as payload contains auxiliary and sector', async () => {
-        const payload = {
-          type: 'intervention',
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: new ObjectID(),
-          customer: new ObjectID(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          sector: sectors[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 403 if customer is not from the same company', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          customer: customerFromOtherCompany._id.toHexString(),
-          subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if the subscription is not for the customer', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if auxiliary is not from the same company', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if internalHour is not from the same company', async () => {
-        const payload = {
-          type: INTERNAL_HOUR,
-          internalHour: internalHourFromOtherCompany._id,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if service is archived', async () => {
-        const payload = {
-          type: INTERVENTION,
-          startDate: '2020-09-23T10:00:00',
-          endDate: '2020-09-23T12:30:00',
-          auxiliary: auxiliaries[0]._id.toHexString(),
-          customer: customerAuxiliary._id.toHexString(),
-          subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
-          address: {
-            fullAddress: '4 rue du test 92160 Antony',
-            street: '4 rue du test',
-            zipCode: '92160',
-            city: 'Antony',
-            location: { type: 'Point', coordinates: [2.377133, 48.801389] },
-          },
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should create an extended absence', async () => {
-        const payload = {
-          type: ABSENCE,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: eventsList[20].auxiliary,
-          absenceNature: DAILY,
-          absence: PARENTAL_LEAVE,
-          extension: eventsList[20]._id,
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.result.data.event).toBeDefined();
-      });
-
-      it('should return 403 if absence extension and extended absence are not for the same valid reason', async () => {
-        const payload = {
-          type: ABSENCE,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: eventsList[20].auxiliary,
-          absenceNature: DAILY,
-          absence: MATERNITY_LEAVE,
-          extension: eventsList[20]._id,
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return 403 if extended absence reason is invalid', async () => {
-        const payload = {
-          type: ABSENCE,
-          startDate: '2019-01-23T10:00:00',
-          endDate: '2019-01-23T12:30:00',
-          auxiliary: eventsList[1].auxiliary,
-          absenceNature: DAILY,
-          absence: PAID_LEAVE,
-          extension: eventsList[1]._id,
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return 403 if event startDate is before extended absence startDate', async () => {
-        const payload = {
-          type: ABSENCE,
-          startDate: '2019-01-17T10:00:00',
-          endDate: '2019-01-17T12:30:00',
-          auxiliary: eventsList[20].auxiliary,
-          absenceNature: DAILY,
-          absence: PARENTAL_LEAVE,
-          extension: eventsList[20]._id,
-        };
-
-        const response = await app.inject({
-          method: 'POST',
-          url: '/events',
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
     });
 
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
+    it('should create an intervention with auxiliary', async () => {
       const payload = {
         type: INTERVENTION,
         startDate: '2019-01-23T10:00:00',
@@ -1154,568 +648,1112 @@ describe('EVENTS ROUTES', () => {
         },
       };
 
-      const roles = [
-        { name: 'helper', expectedCode: 403, erp: true },
-        { name: 'auxiliary', expectedCode: 403, erp: true },
-        { name: 'auxiliary_without_company', expectedCode: 403, erp: true },
-        { name: 'planning_referent', expectedCode: 200, erp: true },
-        {
-          name: 'auxiliary event',
-          expectedCode: 200,
-          erp: true,
-          customCredentials: auxiliaries[0].local,
-        },
-        {
-          name: 'auxiliary, unassigned event, same sector ',
-          expectedCode: 200,
-          erp: true,
-          customCredentials: auxiliaries[0].local,
-          customPayload: { ...omit(payload, 'auxiliary'), sector: sectors[0]._id },
-        },
-        { name: 'coach', expectedCode: 200, erp: true },
-        { name: 'client_admin', expectedCode: 403, erp: false },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}${role.erp ? '' : ' without erp'}`, async () => {
-          authToken = role.customCredentials
-            ? await getUserToken(role.customCredentials)
-            : await getToken(role.name, role.erp);
-          const response = await app.inject({
-            method: 'POST',
-            url: '/events',
-            payload: role.customPayload || payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+    });
+
+    it('should create an intervention with sector', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        sector: sectors[0]._id.toHexString(),
+        customer: customerAuxiliary._id.toHexString(),
+        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+    });
+
+    it('should create an absence', async () => {
+      const auxiliary = auxiliaries[0];
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliary._id.toHexString(),
+        absence: ILLNESS,
+        absenceNature: DAILY,
+        attachment: { driveId: 'qwertyuiop', link: 'asdfghjkl;' },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+    });
+
+    it('should create an unavailability', async () => {
+      const payload = {
+        type: UNAVAILABILITY,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaries[0]._id,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+    });
+
+    it('should create a repetition', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaries[0]._id.toHexString(),
+        customer: customerAuxiliary._id.toHexString(),
+        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+        repetition: { frequency: EVERY_DAY },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+      const repeatedEventsCount = await Event.countDocuments({
+        'repetition.parentId': response.result.data.event._id,
+        company: authCompany._id,
+      }).lean();
+      expect(repeatedEventsCount).toEqual(91);
+      const repetition = await Repetition.findOne({ parentId: response.result.data.event._id }).lean();
+      expect(repetition).toBeDefined();
+    });
+
+    const baseInterventionPayload = {
+      type: INTERVENTION,
+      startDate: '2019-01-23T10:00:00',
+      endDate: '2019-01-23T12:30:00',
+      auxiliary: auxiliaries[0]._id.toHexString(),
+      customer: customerAuxiliary._id.toHexString(),
+      subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+      address: {
+        fullAddress: '4 rue du test 92160 Antony',
+        street: '4 rue du test',
+        zipCode: '92160',
+        city: 'Antony',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+    };
+    const interventionMissingParams = [
+      { payload: { ...omit(baseInterventionPayload, 'address') }, reason: 'missing address' },
+      { payload: { ...omit(baseInterventionPayload, 'address.fullAddress') }, reason: 'missing address.fullAddress' },
+      { payload: { ...omit(baseInterventionPayload, 'address.street') }, reason: 'missing address.street' },
+      { payload: { ...omit(baseInterventionPayload, 'address.zipCode') }, reason: 'missing address.zipCode' },
+      { payload: { ...omit(baseInterventionPayload, 'address.city') }, reason: 'missing address.city' },
+      { payload: { ...omit(baseInterventionPayload, 'address.location') }, reason: 'missing address.location' },
+      {
+        payload: { ...omit(baseInterventionPayload, 'address.location.coordinates') },
+        reason: 'missing address.location.coordinates',
+      },
+      {
+        payload: { ...omit(baseInterventionPayload, 'address.location.type') },
+        reason: 'missing address.location.type',
+      },
+      { payload: { ...omit(baseInterventionPayload, 'customer') }, reason: 'missing customer' },
+      { payload: { ...omit(baseInterventionPayload, 'subscription') }, reason: 'missing subscription' },
+      { payload: { ...omit(baseInterventionPayload, 'type') }, reason: 'missing type' },
+      { payload: { ...omit(baseInterventionPayload, 'startDate') }, reason: 'missing startDate' },
+      { payload: { ...omit(baseInterventionPayload, 'endDate') }, reason: 'missing endDate' },
+    ];
+    interventionMissingParams.forEach((test) => {
+      it(`should return a 400 error as intervention payload is invalid: ${test.reason}`, async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload: test.payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+        expect(response.statusCode).toEqual(400);
+      });
+    });
+
+    const baseInternalHourPayload = {
+      type: INTERNAL_HOUR,
+      startDate: '2019-01-23T10:00:00',
+      endDate: '2019-01-23T12:30:00',
+      auxiliary: auxiliaries[0]._id.toHexString(),
+      internalHour: internalHour._id,
+    };
+    const internalHourMissingParams = [
+      { payload: { ...omit(baseInternalHourPayload, 'internalHour') }, reason: 'missing internalHour' },
+      { payload: { ...omit(baseInternalHourPayload, 'startDate') }, reason: 'missing startDate' },
+      { payload: { ...omit(baseInternalHourPayload, 'endDate') }, reason: 'missing endDate' },
+      { payload: { ...omit(baseInternalHourPayload, 'auxiliary') }, reason: 'missing auxiliary' },
+    ];
+    internalHourMissingParams.forEach((test) => {
+      it(`should return a 400 error as internal hour payload is invalid: ${test.reason}`, async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload: test.payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+        expect(response.statusCode).toEqual(400);
+      });
+    });
+
+    const baseAbsencePayload = {
+      type: ABSENCE,
+      startDate: '2019-01-23T10:00:00',
+      endDate: '2019-01-23T12:30:00',
+      auxiliary: auxiliaries[0]._id.toHexString(),
+      absence: ILLNESS,
+      absenceNature: DAILY,
+      attachment: { driveId: 'qwertyuiop', link: 'asdfghjkl;' },
+    };
+    const absenceMissingParams = [
+      { payload: { ...omit(baseAbsencePayload, 'absence') }, reason: 'missing absence' },
+      { payload: { ...omit(baseAbsencePayload, 'absenceNature') }, reason: 'missing absenceNature' },
+      { payload: { ...omit(baseAbsencePayload, 'startDate') }, reason: 'missing startDate' },
+      { payload: { ...omit(baseAbsencePayload, 'endDate') }, reason: 'missing endDate' },
+      { payload: { ...omit(baseAbsencePayload, 'auxiliary') }, reason: 'missing auxiliary' },
+      { payload: { ...omit(baseAbsencePayload, 'attachment') }, reason: 'missing attachment on illness' },
+    ];
+    absenceMissingParams.forEach((test) => {
+      it(`should return a 400 error as absence payload is invalid: ${test.reason}`, async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload: test.payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+        expect(response.statusCode).toEqual(400);
+      });
+    });
+
+    const baseUnavailabilityPayload = {
+      type: UNAVAILABILITY,
+      startDate: '2019-01-23T10:00:00',
+      endDate: '2019-01-23T12:30:00',
+      auxiliary: auxiliaries[0]._id.toHexString(),
+    };
+    const unavailabilityMissingParams = [
+      { payload: { ...omit(baseUnavailabilityPayload, 'startDate') }, reason: 'missing startDate' },
+      { payload: { ...omit(baseUnavailabilityPayload, 'endDate') }, reason: 'missing endDate' },
+      { payload: { ...omit(baseUnavailabilityPayload, 'auxiliary') }, reason: 'missing auxiliary' },
+    ];
+    unavailabilityMissingParams.forEach((test) => {
+      it(`should return a 400 error as unavailability payload is invalid: ${test.reason}`, async () => {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/events',
+          payload: test.payload,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+        expect(response.statusCode).toEqual(400);
+      });
+    });
+
+    it('should return a 400 error as payload contains auxiliary and sector', async () => {
+      const payload = {
+        type: 'intervention',
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: new ObjectID(),
+        customer: new ObjectID(),
+        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        sector: sectors[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 403 if customer is not from the same company', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaries[0]._id.toHexString(),
+        customer: customerFromOtherCompany._id.toHexString(),
+        subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if the subscription is not for the customer', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaries[0]._id.toHexString(),
+        customer: customerAuxiliary._id.toHexString(),
+        subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if auxiliary is not from the same company', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
+        customer: customerAuxiliary._id.toHexString(),
+        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if internalHour is not from the same company', async () => {
+      const payload = {
+        type: INTERNAL_HOUR,
+        internalHour: internalHourFromOtherCompany._id,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: auxiliaries[0]._id.toHexString(),
+        subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if service is archived', async () => {
+      const payload = {
+        type: INTERVENTION,
+        startDate: '2020-09-23T10:00:00',
+        endDate: '2020-09-23T12:30:00',
+        auxiliary: auxiliaries[0]._id.toHexString(),
+        customer: customerAuxiliary._id.toHexString(),
+        subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
+        address: {
+          fullAddress: '4 rue du test 92160 Antony',
+          street: '4 rue du test',
+          zipCode: '92160',
+          city: 'Antony',
+          location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+        },
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should create an extended absence', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: eventsList[20].auxiliary,
+        absenceNature: DAILY,
+        absence: PARENTAL_LEAVE,
+        extension: eventsList[20]._id,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.result.data.event).toBeDefined();
+    });
+
+    it('should return 403 if absence extension and extended absence are not for the same valid reason', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: eventsList[20].auxiliary,
+        absenceNature: DAILY,
+        absence: MATERNITY_LEAVE,
+        extension: eventsList[20]._id,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return 403 if extended absence reason is invalid', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-23T10:00:00',
+        endDate: '2019-01-23T12:30:00',
+        auxiliary: eventsList[1].auxiliary,
+        absenceNature: DAILY,
+        absence: PAID_LEAVE,
+        extension: eventsList[1]._id,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return 403 if event startDate is before extended absence startDate', async () => {
+      const payload = {
+        type: ABSENCE,
+        startDate: '2019-01-17T10:00:00',
+        endDate: '2019-01-17T12:30:00',
+        auxiliary: eventsList[20].auxiliary,
+        absenceNature: DAILY,
+        absence: PARENTAL_LEAVE,
+        extension: eventsList[20]._id,
+      };
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/events',
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
     });
   });
 
-  describe('PUT /events/{_id}', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
-      });
+  describe('Other roles', () => {
+    beforeEach(populateDB);
 
-      it('should update corresponding event with sector', async () => {
-        const event = eventsList[2];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          sector: sectors[0]._id.toHexString(),
-        };
+    const payload = {
+      type: INTERVENTION,
+      startDate: '2019-01-23T10:00:00',
+      endDate: '2019-01-23T12:30:00',
+      auxiliary: auxiliaries[0]._id.toHexString(),
+      customer: customerAuxiliary._id.toHexString(),
+      subscription: customerAuxiliary.subscriptions[0]._id.toHexString(),
+      address: {
+        fullAddress: '4 rue du test 92160 Antony',
+        street: '4 rue du test',
+        zipCode: '92160',
+        city: 'Antony',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+    };
 
+    const roles = [
+      { name: 'helper', expectedCode: 403, erp: true },
+      { name: 'auxiliary', expectedCode: 403, erp: true },
+      { name: 'auxiliary_without_company', expectedCode: 403, erp: true },
+      { name: 'planning_referent', expectedCode: 200, erp: true },
+      {
+        name: 'auxiliary event',
+        expectedCode: 200,
+        erp: true,
+        customCredentials: auxiliaries[0].local,
+      },
+      {
+        name: 'auxiliary, unassigned event, same sector ',
+        expectedCode: 200,
+        erp: true,
+        customCredentials: auxiliaries[0].local,
+        customPayload: { ...omit(payload, 'auxiliary'), sector: sectors[0]._id },
+      },
+      { name: 'coach', expectedCode: 200, erp: true },
+      { name: 'client_admin', expectedCode: 403, erp: false },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}${role.erp ? '' : ' without erp'}`, async () => {
+        authToken = role.customCredentials
+          ? await getUserToken(role.customCredentials)
+          : await getToken(role.name, role.erp);
         const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
+          method: 'POST',
+          url: '/events',
+          payload: role.customPayload || payload,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(200);
-        expect(response.result.data.event).toBeDefined();
-        expect(response.result.data.event._id).toEqual(event._id);
-        expect(moment(response.result.data.event.startDate).isSame(moment(payload.startDate))).toBeTruthy();
-        expect(moment(response.result.data.event.endDate).isSame(moment(payload.endDate))).toBeTruthy();
-      });
-
-      it('should update corresponding event with auxiliary', async () => {
-        const event = eventsList[0];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: event.auxiliary.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(200);
-        expect(response.result.data.event).toBeDefined();
-        expect(response.result.data.event._id).toEqual(event._id);
-        expect(moment(response.result.data.event.startDate).isSame(moment(payload.startDate))).toBeTruthy();
-        expect(moment(response.result.data.event.endDate).isSame(moment(payload.endDate))).toBeTruthy();
-      });
-
-      it('should update intervention with auxiliary', async () => {
-        const event = eventsList[2];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: auxiliaries[1]._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(200);
-      });
-
-      it('should update intervention with other subscription', async () => {
-        const event = eventsList[2];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: event.auxiliary.toHexString(),
-          subscription: customerAuxiliary.subscriptions[1]._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(200);
-      });
-
-      it('should update intervention even if sub service is archived if it was already the selected sub', async () => {
-        const event = eventsList[19];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: event.auxiliary.toHexString(),
-          subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(200);
-      });
-
-      it('should update internalhour if address is {}', async () => {
-        const event = eventsList[0];
-        const payload = { auxiliary: event.auxiliary.toHexString(), address: {} };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(200);
-        expect(response.result.data.event.address).toBeUndefined();
-      });
-
-      it('should return a 400 if event is not an internal hours and adress is {}', async () => {
-        const event = eventsList[2];
-        const payload = { address: {} };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(400);
-      });
-
-      it('should return a 400 error as payload is invalid', async () => {
-        const payload = { beginDate: '2019-01-23T10:00:00.000Z', sector: new ObjectID() };
-        const event = eventsList[0];
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(400);
-      });
-
-      it('should return a 400 error as startDate and endDate are not on the same day', async () => {
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-02-23T12:00:00.000Z',
-          sector: sectors[0]._id.toHexString(),
-        };
-        const event = eventsList[0];
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(400);
-      });
-
-      it('should return a 403 if auxiliary is not from the same company', async () => {
-        const event = eventsList[0];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-02-23T12:00:00.000Z',
-          auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(403);
-      });
-
-      it('should return a 404 error as event is not found', async () => {
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-02-23T12:00:00.000Z',
-          sector: sectors[0]._id.toHexString(),
-        };
-        const invalidId = new ObjectID();
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${invalidId.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(404);
-      });
-
-      it('should return a 403 if the subscription is not for the customer', async () => {
-        const event = eventsList[0];
-        const payload = {
-          sector: sectors[0]._id.toHexString(),
-          subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 400 if auxiliary sector and auxiliary are in the payload', async () => {
-        const event = eventsList[0];
-        const payload = {
-          sector: sectors[0]._id.toHexString(),
-          auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 400 if both auxiliary sector and auxiliary are missing', async () => {
-        const event = eventsList[0];
-        const payload = { subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString() };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(400);
-      });
-
-      it('should return a 403 if internalHour is not from the same company', async () => {
-        const event = eventsList[0];
-        const payload = {
-          sector: sectors[0]._id.toHexString(),
-          internalHour: internalHourFromOtherCompany._id,
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if sector is not from the same company', async () => {
-        const event = eventsList[0];
-        const payload = {
-          sector: sectors[2]._id.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if event is not from the same company', async () => {
-        const event = eventFromOtherCompany;
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: event.auxiliary.toHexString(),
-        };
-
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${event._id.toHexString()}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
-      });
-
-      it('should return a 403 if service is archived', async () => {
-        const event = eventsList[2];
-        const payload = {
-          startDate: '2019-01-23T10:00:00.000Z',
-          endDate: '2019-01-23T12:00:00.000Z',
-          auxiliary: event.auxiliary.toHexString(),
-          subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
-        };
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${eventsList[0]._id}`,
-          payload,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toEqual(403);
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
+  });
+});
 
-    describe('Other roles', () => {
-      beforeEach(populateDB);
+describe('PUT /events/{_id}', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
 
+    it('should update corresponding event with sector', async () => {
+      const event = eventsList[2];
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
         endDate: '2019-01-23T12:00:00.000Z',
         sector: sectors[0]._id.toHexString(),
       };
 
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 403 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'planning_referent', expectedCode: 200 },
-        { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
-        { name: 'coach', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
-          const response = await app.inject({
-            method: 'PUT',
-            url: `/events/${eventsList[2]._id.toHexString()}`,
-            payload,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.event).toBeDefined();
+      expect(response.result.data.event._id).toEqual(event._id);
+      expect(moment(response.result.data.event.startDate).isSame(moment(payload.startDate))).toBeTruthy();
+      expect(moment(response.result.data.event.endDate).isSame(moment(payload.endDate))).toBeTruthy();
+    });
+
+    it('should update corresponding event with auxiliary', async () => {
+      const event = eventsList[0];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.event).toBeDefined();
+      expect(response.result.data.event._id).toEqual(event._id);
+      expect(moment(response.result.data.event.startDate).isSame(moment(payload.startDate))).toBeTruthy();
+      expect(moment(response.result.data.event.endDate).isSame(moment(payload.endDate))).toBeTruthy();
+    });
+
+    it('should update intervention with auxiliary', async () => {
+      const event = eventsList[2];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: auxiliaries[1]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should update intervention with other subscription', async () => {
+      const event = eventsList[2];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+        subscription: customerAuxiliary.subscriptions[1]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should update intervention even if sub service is archived if it was already the selected sub', async () => {
+      const event = eventsList[19];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+        subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should update internalhour if address is {}', async () => {
+      const event = eventsList[0];
+      const payload = { auxiliary: event.auxiliary.toHexString(), address: {} };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.result.data.event.address).toBeUndefined();
+    });
+
+    it('should return a 400 if event is not an internal hours and adress is {}', async () => {
+      const event = eventsList[2];
+      const payload = { address: {} };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 error as payload is invalid', async () => {
+      const payload = { beginDate: '2019-01-23T10:00:00.000Z', sector: new ObjectID() };
+      const event = eventsList[0];
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 error as startDate and endDate are not on the same day', async () => {
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-02-23T12:00:00.000Z',
+        sector: sectors[0]._id.toHexString(),
+      };
+      const event = eventsList[0];
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 403 if auxiliary is not from the same company', async () => {
+      const event = eventsList[0];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-02-23T12:00:00.000Z',
+        auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should return a 404 error as event is not found', async () => {
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-02-23T12:00:00.000Z',
+        sector: sectors[0]._id.toHexString(),
+      };
+      const invalidId = new ObjectID();
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${invalidId.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 403 if the subscription is not for the customer', async () => {
+      const event = eventsList[0];
+      const payload = {
+        sector: sectors[0]._id.toHexString(),
+        subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 400 if auxiliary sector and auxiliary are in the payload', async () => {
+      const event = eventsList[0];
+      const payload = {
+        sector: sectors[0]._id.toHexString(),
+        auxiliary: auxiliaryFromOtherCompany._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 400 if both auxiliary sector and auxiliary are missing', async () => {
+      const event = eventsList[0];
+      const payload = { subscription: customerFromOtherCompany.subscriptions[0]._id.toHexString() };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return a 403 if internalHour is not from the same company', async () => {
+      const event = eventsList[0];
+      const payload = {
+        sector: sectors[0]._id.toHexString(),
+        internalHour: internalHourFromOtherCompany._id,
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if sector is not from the same company', async () => {
+      const event = eventsList[0];
+      const payload = {
+        sector: sectors[2]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if event is not from the same company', async () => {
+      const event = eventFromOtherCompany;
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${event._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it('should return a 403 if service is archived', async () => {
+      const event = eventsList[2];
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        auxiliary: event.auxiliary.toHexString(),
+        subscription: customerAuxiliary.subscriptions[2]._id.toHexString(),
+      };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[0]._id}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
     });
   });
 
-  describe('DELETE /events/{_id}', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
-      });
+  describe('Other roles', () => {
+    beforeEach(populateDB);
 
-      it('should delete corresponding event', async () => {
-        const event = eventsList[0];
+    const payload = {
+      startDate: '2019-01-23T10:00:00.000Z',
+      endDate: '2019-01-23T12:00:00.000Z',
+      sector: sectors[0]._id.toHexString(),
+    };
 
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 200 },
+      { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
+      { name: 'coach', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
         const response = await app.inject({
-          method: 'DELETE',
-          url: `/events/${event._id.toHexString()}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-        expect(response.statusCode).toBe(200);
-      });
-
-      it('should return a 404 error as event is not found', async () => {
-        const invalidId = new ObjectID();
-
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/events/${invalidId.toHexString()}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-
-        expect(response.statusCode).toBe(404);
-      });
-
-      it('should return a 403 if event is not from the same company', async () => {
-        const event = eventFromOtherCompany;
-
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/events/${event._id.toHexString()}`,
+          method: 'PUT',
+          url: `/events/${eventsList[2]._id.toHexString()}`,
+          payload,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toEqual(403);
-      });
-    });
-
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 403 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'planning_referent', expectedCode: 200 },
-        { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
-        { name: 'coach', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
-
-          const response = await app.inject({
-            method: 'DELETE',
-            url: `/events/${eventsList[2]._id.toHexString()}`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
   });
+});
 
-  describe('DELETE /events', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
+describe('DELETE /events/{_id}', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should delete corresponding event', async () => {
+      const event = eventsList[0];
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events/${event._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return a 404 error as event is not found', async () => {
+      const invalidId = new ObjectID();
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events/${invalidId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should delete all events from startDate including repetitions', async () => {
-        const customer = customerAuxiliary._id;
-        const startDate = '2019-10-14';
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return a 403 if event is not from the same company', async () => {
+      const event = eventFromOtherCompany;
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events/${event._id.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(403);
+    });
+  });
+
+  describe('Other roles', () => {
+    beforeEach(populateDB);
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 200 },
+      { name: 'auxiliary event', expectedCode: 200, customCredentials: auxiliaries[0].local },
+      { name: 'coach', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
+
         const response = await app.inject({
           method: 'DELETE',
-          url: `/events?customer=${customer}&startDate=${startDate}`,
+          url: `/events/${eventsList[2]._id.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(200);
-        expect(await Repetition.find({ company: authCompany._id }).lean()).toHaveLength(0);
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
+describe('DELETE /events', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should delete all events from startDate including repetitions', async () => {
+      const customer = customerAuxiliary._id;
+      const startDate = '2019-10-14';
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events?customer=${customer}&startDate=${startDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should delete all events from startDate to endDate', async () => {
-        const customer = customerAuxiliary._id;
-        const startDate = '2019-10-14';
-        const endDate = '2019-10-16';
+      expect(response.statusCode).toBe(200);
+      expect(await Repetition.find({ company: authCompany._id }).lean()).toHaveLength(0);
+    });
 
+    it('should delete all events from startDate to endDate', async () => {
+      const customer = customerAuxiliary._id;
+      const startDate = '2019-10-14';
+      const endDate = '2019-10-16';
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events?customer=${customer}&startDate=${startDate}&endDate=${endDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should not delete events if one event is billed', async () => {
+      const customer = customerAuxiliary._id;
+      const startDate = '2019-01-01';
+      const endDate = '2019-10-16';
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events?customer=${customer}&startDate=${startDate}&endDate=${endDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+      expect(response.statusCode).toBe(409);
+    });
+
+    it('should return a 403 if customer is not from the company', async () => {
+      const startDate = '2019-01-01';
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events?customer=${customerFromOtherCompany._id}&startDate=${startDate}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe('Other roles', () => {
+    beforeEach(populateDB);
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'planning_referent', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      const customer = customerAuxiliary._id;
+      const startDate = '2019-10-14';
+      const endDate = '2019-10-16';
+
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
         const response = await app.inject({
           method: 'DELETE',
           url: `/events?customer=${customer}&startDate=${startDate}&endDate=${endDate}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
-        expect(response.statusCode).toBe(200);
-      });
 
-      it('should not delete events if one event is billed', async () => {
-        const customer = customerAuxiliary._id;
-        const startDate = '2019-01-01';
-        const endDate = '2019-10-16';
-
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/events?customer=${customer}&startDate=${startDate}&endDate=${endDate}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-        expect(response.statusCode).toBe(409);
-      });
-
-      it('should return a 403 if customer is not from the company', async () => {
-        const startDate = '2019-01-01';
-        const response = await app.inject({
-          method: 'DELETE',
-          url: `/events?customer=${customerFromOtherCompany._id}&startDate=${startDate}`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-        });
-        expect(response.statusCode).toBe(403);
-      });
-    });
-
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 403 },
-        { name: 'planning_referent', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        const customer = customerAuxiliary._id;
-        const startDate = '2019-10-14';
-        const endDate = '2019-10-16';
-
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = await getToken(role.name);
-          const response = await app.inject({
-            method: 'DELETE',
-            url: `/events?customer=${customer}&startDate=${startDate}&endDate=${endDate}`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
   });
+});
 
-  describe('DELETE /{_id}/repetition', () => {
-    describe('CLIENT_ADMIN', () => {
-      beforeEach(populateDB);
-      beforeEach(async () => {
-        authToken = await getToken('client_admin');
+describe('DELETE /{_id}/repetition', () => {
+  let authToken = null;
+  describe('CLIENT_ADMIN', () => {
+    beforeEach(populateDB);
+    beforeEach(async () => {
+      authToken = await getToken('client_admin');
+    });
+
+    it('should delete repetition', async () => {
+      const event = eventsList[18];
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/events/${event._id.toHexString()}/repetition`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      it('should delete repetition', async () => {
+      expect(response.statusCode).toBe(200);
+      const repetitionCount = await Repetition.countDocuments({
+        company: authCompany._id,
+        'repetition.parentId': event.repetition.parentId,
+      });
+      expect(repetitionCount).toEqual(0);
+    });
+  });
+
+  describe('Other roles', () => {
+    beforeEach(populateDB);
+
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 200, customCredentials: auxiliaries[0].local },
+      { name: 'planning_referent', expectedCode: 200 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
+      { name: 'coach', expectedCode: 200 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
         const event = eventsList[18];
         const response = await app.inject({
           method: 'DELETE',
@@ -1723,39 +1761,7 @@ describe('EVENTS ROUTES', () => {
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(200);
-        const repetitionCount = await Repetition.countDocuments({
-          company: authCompany._id,
-          'repetition.parentId': event.repetition.parentId,
-        });
-        expect(repetitionCount).toEqual(0);
-      });
-    });
-
-    describe('Other roles', () => {
-      beforeEach(populateDB);
-
-      const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 200, customCredentials: auxiliaries[0].local },
-        { name: 'planning_referent', expectedCode: 200 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'coach', expectedCode: 200 },
-      ];
-
-      roles.forEach((role) => {
-        it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
-          authToken = role.customCredentials ? await getUserToken(role.customCredentials) : await getToken(role.name);
-          const event = eventsList[18];
-          const response = await app.inject({
-            method: 'DELETE',
-            url: `/events/${event._id.toHexString()}/repetition`,
-            headers: { Cookie: `alenvi_token=${authToken}` },
-          });
-
-          expect(response.statusCode).toBe(role.expectedCode);
-        });
+        expect(response.statusCode).toBe(role.expectedCode);
       });
     });
   });

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -21,6 +21,26 @@ describe('isBefore', () => {
   });
 });
 
+describe('isSameOrBefore', () => {
+  it('should return true if date1 is before date2', () => {
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', new Date());
+
+    expect(isBefore).toBe(true);
+  });
+
+  it('should return false if date1 is after date2', () => {
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', '2019-02-03');
+
+    expect(isBefore).toBe(false);
+  });
+
+  it('should return true if date1 is equal to date2', () => {
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', '2020-01-01');
+
+    expect(isBefore).toBe(true);
+  });
+});
+
 describe('isAfter', () => {
   it('should return true if date1 is after date2', () => {
     const isAfter = DatesHelper.isAfter(new Date('2020-12-25'), '2020-07-14');
@@ -38,5 +58,25 @@ describe('isAfter', () => {
     const isAfter = DatesHelper.isAfter('2020-01-01', '2020-01-01');
 
     expect(isAfter).toBe(false);
+  });
+});
+
+describe('isSameOrAfter', () => {
+  it('should return true if date1 is after date2', () => {
+    const isAfter = DatesHelper.isSameOrAfter(new Date('2020-12-25'), '2020-07-14');
+
+    expect(isAfter).toBe(true);
+  });
+
+  it('should return false if date1 is before date2', () => {
+    const isAfter = DatesHelper.isSameOrAfter('2020-01-01', new Date());
+
+    expect(isAfter).toBe(false);
+  });
+
+  it('should return true if date1 is equal to date2', () => {
+    const isAfter = DatesHelper.isSameOrAfter('2020-01-01', '2020-01-01');
+
+    expect(isAfter).toBe(true);
   });
 });

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -1,40 +1,24 @@
 const expect = require('expect');
 const sinon = require('sinon');
-const moment = require('moment');
 const { ObjectID } = require('mongodb');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
 const EventsValidationHelper = require('../../../src/helpers/eventsValidation');
 const EventRepository = require('../../../src/repositories/EventRepository');
-const {
-  INTERVENTION,
-  ABSENCE,
-  INTERNAL_HOUR,
-} = require('../../../src/helpers/constants');
+const { INTERVENTION, ABSENCE, INTERNAL_HOUR } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 
-describe('checkContracts', () => {
-  let findOneCustomer;
+describe('isCustomerSubscriptionValid #tag', () => {
+  let findOne;
   beforeEach(() => {
-    findOneCustomer = sinon.stub(Customer, 'findOne');
+    findOne = sinon.stub(Customer, 'findOne');
   });
   afterEach(() => {
-    findOneCustomer.restore();
+    findOne.restore();
   });
 
-  it('should return false as user has no contract', async () => {
-    const event = { auxiliary: (new ObjectID()).toHexString() };
-    const user = { _id: event.auxiliary };
-
-    const result = await EventsValidationHelper.checkContracts(event, user);
-
-    expect(result).toBe(false);
-    sinon.assert.notCalled(findOneCustomer);
-  });
-
-  it('should return false if contract and no active contract on day', async () => {
+  it('should return true if event subscription is in customer subscriptions', async () => {
     const subscriptionId = new ObjectID();
-    const sectorId = new ObjectID();
     const event = {
       auxiliary: (new ObjectID()).toHexString(),
       customer: (new ObjectID()).toHexString(),
@@ -42,84 +26,24 @@ describe('checkContracts', () => {
       subscription: subscriptionId.toHexString(),
       startDate: '2019-10-03T08:00:00.000Z',
       endDate: '2019-10-03T10:00:00.000Z',
-      sector: sectorId.toHexString(),
     };
-    const customer = {
-      _id: event.customer,
-      subscriptions: [{
-        _id: subscriptionId,
-        service: { versions: [{ startDate: '2019-10-02T00:00:00.000Z' }, { startDate: '2018-10-02T00:00:00.000Z' }] },
-        versions: [{ startDate: moment(event.startDate).subtract(1, 'd') }],
-      }],
-    };
-    const contract = {
-      user: event.auxiliary,
-      customer: event.customer,
-      versions: [{}],
-      startDate: moment(event.startDate).add(1, 'd'),
-    };
-    const user = { _id: event.auxiliary, contracts: [contract], sector: sectorId };
+    const customer = { _id: event.customer, subscriptions: [{ _id: subscriptionId }] };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
 
-    const result = await EventsValidationHelper.checkContracts(event, user);
-
-    expect(result).toBe(false);
-    SinonMongoose.calledWithExactly(
-      findOneCustomer,
-      [
-        { query: 'findOne', args: [{ _id: event.customer }] },
-        { query: 'populate', args: [{ path: 'subscriptions.service', populate: { path: 'versions.surcharge' } }] },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should return true if contract and active contract on day', async () => {
-    const subscriptionId = new ObjectID();
-    const sectorId = new ObjectID();
-    const event = {
-      auxiliary: (new ObjectID()).toHexString(),
-      customer: (new ObjectID()).toHexString(),
-      type: INTERVENTION,
-      subscription: subscriptionId.toHexString(),
-      startDate: '2019-10-03T08:00:00.000Z',
-      endDate: '2019-10-03T10:00:00.000Z',
-      sector: sectorId.toHexString(),
-    };
-    const customer = {
-      _id: event.customer,
-      subscriptions: [{
-        _id: subscriptionId,
-        service: { versions: [{ startDate: '2019-10-02T00:00:00.000Z' }, { startDate: '2018-10-02T00:00:00.000Z' }] },
-        versions: [{ startDate: moment(event.startDate).subtract(1, 'd') }],
-      }],
-    };
-    const contract = {
-      user: event.auxiliary,
-      customer: event.customer,
-      versions: [{ weeklyHours: 12 }],
-      startDate: moment(event.startDate).subtract(1, 'd'),
-    };
-    const user = { _id: event.auxiliary, contracts: [contract], sector: sectorId };
-
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
-
-    const result = await EventsValidationHelper.checkContracts(event, user);
+    const result = await EventsValidationHelper.isCustomerSubscriptionValid(event);
 
     expect(result).toBe(true);
     SinonMongoose.calledWithExactly(
-      findOneCustomer,
+      findOne,
       [
-        { query: 'findOne', args: [{ _id: event.customer }] },
-        { query: 'populate', args: [{ path: 'subscriptions.service', populate: { path: 'versions.surcharge' } }] },
+        { query: 'findOne', args: [{ _id: event.customer }, { subscriptions: 1 }] },
         { query: 'lean' },
       ]
     );
   });
 
-  it('should return false if customer has no subscription', async () => {
-    const sectorId = new ObjectID();
+  it('should return false if event subscription is not in customer subscriptions', async () => {
     const event = {
       auxiliary: (new ObjectID()).toHexString(),
       customer: (new ObjectID()).toHexString(),
@@ -127,75 +51,140 @@ describe('checkContracts', () => {
       subscription: (new ObjectID()).toHexString(),
       startDate: '2019-10-03T08:00:00.000Z',
       endDate: '2019-10-03T10:00:00.000Z',
-      sector: sectorId.toHexString(),
     };
-    const customer = {
-      _id: event.customer,
-      subscriptions: [{
-        _id: new ObjectID(),
-        service: { versions: [{ startDate: '2019-10-02T00:00:00.000Z' }, { startDate: '2018-10-02T00:00:00.000Z' }] },
-        versions: [{ startDate: moment(event.startDate).add(1, 'd') }],
-      }],
-    };
-    const contract = {
-      user: event.auxiliary,
-      customer: event.customer,
-      versions: [{ weeklyHours: 12 }],
-      startDate: moment(event.startDate).subtract(1, 'd'),
-    };
-    const user = { _id: event.auxiliary, contracts: [contract], sector: sectorId };
+    const customer = { _id: event.customer, subscriptions: [{ _id: new ObjectID() }] };
 
-    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer]));
+    findOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
 
-    const result = await EventsValidationHelper.checkContracts(event, user);
+    const result = await EventsValidationHelper.isCustomerSubscriptionValid(event);
 
     expect(result).toBe(false);
     SinonMongoose.calledWithExactly(
-      findOneCustomer,
+      findOne,
       [
-        { query: 'findOne', args: [{ _id: event.customer }] },
-        { query: 'populate', args: [{ path: 'subscriptions.service', populate: { path: 'versions.surcharge' } }] },
+        { query: 'findOne', args: [{ _id: event.customer }, { subscriptions: 1 }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+});
+
+describe('isUserContractValidOnEventDates #tag', () => {
+  let findOne;
+  beforeEach(() => {
+    findOne = sinon.stub(User, 'findOne');
+  });
+  afterEach(() => {
+    findOne.restore();
+  });
+
+  it('should return false as user has no contract', async () => {
+    const event = { auxiliary: (new ObjectID()).toHexString() };
+    const user = { _id: event.auxiliary };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
+
+    expect(result).toBe(false);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
         { query: 'lean' },
       ]
     );
   });
 
-  it('should return false if event is internal hour and auxiliary does not have contract with company', async () => {
-    const sectorId = new ObjectID();
-    const event = {
-      auxiliary: (new ObjectID()).toHexString(),
-      type: INTERNAL_HOUR,
-      startDate: '2019-10-03T00:00:00.000Z',
-      sector: sectorId.toHexString(),
-    };
-    const user = { _id: event.auxiliary, contracts: [], sector: sectorId };
+  it('should return false if contract and no active contract on day and event not absence', async () => {
+    const event = { auxiliary: new ObjectID(), startDate: '2020-04-30T09:00:00', type: INTERVENTION };
+    const contract = { user: event.auxiliary, startDate: '2020-12-05T00:00:00' };
+    const user = { _id: event.auxiliary, contracts: [contract] };
 
-    const result = await EventsValidationHelper.checkContracts(event, user);
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(false);
-    sinon.assert.notCalled(findOneCustomer);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
+        { query: 'lean' },
+      ]
+    );
   });
 
-  it('should return true if event type isn\'t intervention nor internal hour', async () => {
-    const sectorId = new ObjectID();
-    const event = {
-      auxiliary: (new ObjectID()).toHexString(),
-      type: ABSENCE,
-      startDate: '2019-10-03T00:00:00.000Z',
-      sector: sectorId.toHexString(),
-    };
-    const contract = {
-      user: event.auxiliary,
-      customer: event.customer,
-      versions: [{ weeklyHours: 12 }],
-      startDate: moment(event.startDate).subtract(1, 'd'),
-    };
-    const user = { _id: event.auxiliary, contracts: [contract], sector: sectorId };
+  it('should return true if contract and active contract on day and event not absence', async () => {
+    const event = { auxiliary: new ObjectID(), startDate: '2020-04-30T09:00:00', type: INTERNAL_HOUR };
+    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
+    const user = { _id: event.auxiliary, contracts: [contract] };
 
-    const result = await EventsValidationHelper.checkContracts(event, user);
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
 
     expect(result).toBe(true);
-    sinon.assert.notCalled(findOneCustomer);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should return false if contract and no active contract on day and event is absence', async () => {
+    const event = {
+      auxiliary: new ObjectID(),
+      startDate: '2020-04-30T09:00:00',
+      endDate: '2020-05-12T23:25:59',
+      type: ABSENCE,
+    };
+    const contract = { user: event.auxiliary, startDate: '2020-05-04T00:00:00' };
+    const user = { _id: event.auxiliary, contracts: [contract] };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
+
+    expect(result).toBe(false);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should return true if contract and active contract on day and event is absence', async () => {
+    const event = {
+      auxiliary: new ObjectID(),
+      startDate: '2020-04-30T09:00:00',
+      endDate: '2020-05-12T23:25:59',
+      type: ABSENCE,
+    };
+    const contract = { user: event.auxiliary, startDate: '2020-01-04T00:00:00' };
+    const user = { _id: event.auxiliary, contracts: [contract] };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
+
+    expect(result).toBe(true);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
@@ -290,16 +279,16 @@ describe('hasConflicts', () => {
   });
 });
 
-describe('isEditionAllowed', () => {
-  let findOne;
-  let checkContracts;
+describe('isEditionAllowed #tag', () => {
+  let isUserContractValidOnEventDates;
+  let isCustomerSubscriptionValid;
   beforeEach(() => {
-    findOne = sinon.stub(User, 'findOne');
-    checkContracts = sinon.stub(EventsValidationHelper, 'checkContracts');
+    isUserContractValidOnEventDates = sinon.stub(EventsValidationHelper, 'isUserContractValidOnEventDates');
+    isCustomerSubscriptionValid = sinon.stub(EventsValidationHelper, 'isCustomerSubscriptionValid');
   });
   afterEach(() => {
-    findOne.restore();
-    checkContracts.restore();
+    isUserContractValidOnEventDates.restore();
+    isCustomerSubscriptionValid.restore();
   });
 
   it('should return false as event is not absence and not on one day', async () => {
@@ -315,8 +304,8 @@ describe('isEditionAllowed', () => {
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
 
     expect(result).toBeFalsy();
-    sinon.assert.notCalled(checkContracts);
-    sinon.assert.notCalled(findOne);
+    sinon.assert.notCalled(isUserContractValidOnEventDates);
+    sinon.assert.notCalled(isCustomerSubscriptionValid);
   });
 
   it('should return false as event has no auxiliary and is not intervention', async () => {
@@ -332,25 +321,8 @@ describe('isEditionAllowed', () => {
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
 
     expect(result).toBeFalsy();
-    sinon.assert.notCalled(checkContracts);
-    sinon.assert.notCalled(findOne);
-  });
-
-  it('should return true as event has no auxiliary and is intervention', async () => {
-    const companyId = new ObjectID();
-    const credentials = { company: { _id: companyId } };
-    const event = {
-      sector: (new ObjectID()).toHexString(),
-      type: INTERVENTION,
-      startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
-    };
-
-    const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
-
-    expect(result).toBeTruthy();
-    sinon.assert.notCalled(checkContracts);
-    sinon.assert.notCalled(findOne);
+    sinon.assert.notCalled(isUserContractValidOnEventDates);
+    sinon.assert.notCalled(isCustomerSubscriptionValid);
   });
 
   it('should return false as auxiliary does not have contracts', async () => {
@@ -363,55 +335,74 @@ describe('isEditionAllowed', () => {
       startDate: '2019-04-13T09:00:00',
       endDate: '2019-04-13T11:00:00',
     };
-    const user = { _id: auxiliaryId, sector: new ObjectID() };
 
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
-    checkContracts.returns(false);
+    isUserContractValidOnEventDates.returns(false);
 
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
 
     expect(result).toBeFalsy();
-    sinon.assert.calledWithExactly(checkContracts, event, user);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
-        { query: 'populate', args: ['contracts'] },
-        { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
-        { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
-      ]
-    );
+    sinon.assert.calledWithExactly(isUserContractValidOnEventDates, event);
+    sinon.assert.notCalled(isCustomerSubscriptionValid);
   });
 
-  it('should return true', async () => {
+  it('should return false if event is intervention and customer subscription is not valid', async () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
     const auxiliaryId = new ObjectID();
-    const sectorId = new ObjectID();
     const event = {
       auxiliary: auxiliaryId.toHexString(),
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
       endDate: '2019-04-13T11:00:00',
     };
-    const user = { _id: auxiliaryId, sector: sectorId };
 
-    checkContracts.returns(true);
-    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+    isUserContractValidOnEventDates.returns(true);
+    isCustomerSubscriptionValid.returns(false);
+
+    const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
+
+    expect(result).toBeFalsy();
+    sinon.assert.calledWithExactly(isUserContractValidOnEventDates, event);
+    sinon.assert.calledWithExactly(isCustomerSubscriptionValid, event);
+  });
+
+  it('should return true if event is intervention and customer subscription is valid', async () => {
+    const companyId = new ObjectID();
+    const credentials = { company: { _id: companyId } };
+    const auxiliaryId = new ObjectID();
+    const event = {
+      auxiliary: auxiliaryId.toHexString(),
+      type: INTERVENTION,
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+    };
+
+    isUserContractValidOnEventDates.returns(true);
+    isCustomerSubscriptionValid.returns(true);
 
     const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
 
     expect(result).toBeTruthy();
-    sinon.assert.calledWithExactly(checkContracts, event, user);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
-        { query: 'populate', args: ['contracts'] },
-        { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
-        { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
-      ]
-    );
+    sinon.assert.calledWithExactly(isUserContractValidOnEventDates, event);
+    sinon.assert.calledWithExactly(isCustomerSubscriptionValid, event);
+  });
+
+  it('should return true', async () => {
+    const credentials = { company: { _id: new ObjectID() } };
+    const event = {
+      auxiliary: new ObjectID().toHexString(),
+      type: INTERNAL_HOUR,
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+    };
+
+    isUserContractValidOnEventDates.returns(true);
+
+    const result = await EventsValidationHelper.isEditionAllowed(event, credentials);
+
+    expect(result).toBeTruthy();
+    sinon.assert.calledWithExactly(isUserContractValidOnEventDates, event);
+    sinon.assert.notCalled(isCustomerSubscriptionValid);
   });
 });
 

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -8,7 +8,7 @@ const EventRepository = require('../../../src/repositories/EventRepository');
 const { INTERVENTION, ABSENCE, INTERNAL_HOUR } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 
-describe('isCustomerSubscriptionValid #tag', () => {
+describe('isCustomerSubscriptionValid', () => {
   let findOne;
   beforeEach(() => {
     findOne = sinon.stub(Customer, 'findOne');
@@ -69,7 +69,7 @@ describe('isCustomerSubscriptionValid #tag', () => {
   });
 });
 
-describe('isUserContractValidOnEventDates #tag', () => {
+describe('isUserContractValidOnEventDates', () => {
   let findOne;
   beforeEach(() => {
     findOne = sinon.stub(User, 'findOne');
@@ -81,6 +81,25 @@ describe('isUserContractValidOnEventDates #tag', () => {
   it('should return false as user has no contract', async () => {
     const event = { auxiliary: (new ObjectID()).toHexString() };
     const user = { _id: event.auxiliary };
+
+    findOne.returns(SinonMongoose.stubChainedQueries([user]));
+
+    const result = await EventsValidationHelper.isUserContractValidOnEventDates(event);
+
+    expect(result).toBe(false);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: event.auxiliary }] },
+        { query: 'populate', args: ['contracts'] },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should return false as user contracts are empty', async () => {
+    const event = { auxiliary: (new ObjectID()).toHexString() };
+    const user = { _id: event.auxiliary, contracts: [] };
 
     findOne.returns(SinonMongoose.stubChainedQueries([user]));
 
@@ -279,7 +298,7 @@ describe('hasConflicts', () => {
   });
 });
 
-describe('isEditionAllowed #tag', () => {
+describe('isEditionAllowed', () => {
   let isUserContractValidOnEventDates;
   let isCustomerSubscriptionValid;
   beforeEach(() => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement
- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation~~ :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp~~ :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES UTILISÉS PAR LES APPS MOBILE
- J'ai changé un modèle :
  - J'ai ajoutê un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (Sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Coach / auxiliaire

- Cas d'usage : Refacto de la creation / edition d'un evenement sur le planning
Intervention en a affecter, Intervention affecté, heures internes, absence, indispo, repetition affecté, repetition en a affecter
