### PR TITLE
Com 2001

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -335,6 +335,7 @@ module.exports = {
   },
   // QUESTIONNAIRE_TYPES
   EXPECTATIONS: 'expectations',
+  END_OF_COURSE: 'end_of_course',
   // tests end2end
   PLANNING: 'planning',
   AUTHENTICATION: 'authentication',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -291,7 +291,7 @@ module.exports = {
     questionnairesFound: 'Questionnaires found.',
     questionnairesNotFound: 'Questionnaires not found.',
     questionnaireCreated: 'Questionnaire created.',
-    draftExpectationQuestionnaireAlreadyExists: 'A draft questionnaire with type \'expectations\' already exists.',
+    draftQuestionnaireAlreadyExists: 'A draft questionnaire with this type already exists.',
     publishedQuestionnaireWithSameTypeExists: 'A questionnaire with the same type is already published.',
     questionnaireUpdated: 'questionnaire updated.',
     /* PartnerOrganization */
@@ -590,8 +590,7 @@ module.exports = {
     questionnairesFound: 'Liste des questionnaires trouvée.',
     questionnairesNotFound: 'Liste des questionnaires non trouvée.',
     questionnaireCreated: 'Questionnaire créé.',
-    draftExpectationQuestionnaireAlreadyExists: `Il existe déjà un questionnaire en brouillon de type 'Recueil des
-    attentes'.`,
+    draftQuestionnaireAlreadyExists: 'Il existe déjà un questionnaire de ce type en brouillon.',
     publishedQuestionnaireWithSameTypeExists: 'Un questionnaire du même type est déjà publié.',
     questionnaireUpdated: 'Questionnaire mis à jour.',
     /* PartnerOrganization */

--- a/src/models/Questionnaire.js
+++ b/src/models/Questionnaire.js
@@ -1,9 +1,9 @@
 const mongoose = require('mongoose');
 const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
-const { DRAFT, PUBLISHED, EXPECTATIONS } = require('../helpers/constants');
+const { DRAFT, PUBLISHED, EXPECTATIONS, END_OF_COURSE } = require('../helpers/constants');
 
 const STATUS_TYPES = [DRAFT, PUBLISHED];
-const QUESTIONNAIRE_TYPES = [EXPECTATIONS];
+const QUESTIONNAIRE_TYPES = [EXPECTATIONS, END_OF_COURSE];
 
 const QuestionnaireSchema = mongoose.Schema({
   title: { type: String, required: true },

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -6,6 +6,7 @@ const {
   TRAINING_ORGANISATION_MANAGER,
   VENDOR_ADMIN,
   PUBLISHED,
+  END_OF_COURSE,
 } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
@@ -15,13 +16,14 @@ const { language } = translate;
 
 exports.authorizeQuestionnaireCreation = async (req) => {
   const { type } = req.payload;
-  if (type !== EXPECTATIONS) return null;
+  if (![EXPECTATIONS, END_OF_COURSE].includes(type)) return null;
 
   const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
-  if (draftQuestionnaires) throw Boom.conflict(translate[language].draftExpectationQuestionnaireAlreadyExists);
+  if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
 
   return null;
 };
+
 exports.authorizeQuestionnaireGet = async (req) => {
   const questionnaire = await Questionnaire.findOne({ _id: req.params._id }, { status: 1 }).lean();
   if (!questionnaire) throw Boom.notFound();

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,13 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const {
-  DRAFT,
-  EXPECTATIONS,
-  TRAINING_ORGANISATION_MANAGER,
-  VENDOR_ADMIN,
-  PUBLISHED,
-  END_OF_COURSE,
-} = require('../../helpers/constants');
+const { DRAFT, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN, PUBLISHED } = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
 const Card = require('../../models/Card');
@@ -16,9 +9,8 @@ const { language } = translate;
 
 exports.authorizeQuestionnaireCreation = async (req) => {
   const { type } = req.payload;
-  if (![EXPECTATIONS, END_OF_COURSE].includes(type)) return null;
-
   const draftQuestionnaires = await Questionnaire.countDocuments({ type, status: DRAFT });
+
   if (draftQuestionnaires) throw Boom.conflict(translate[language].draftQuestionnaireAlreadyExists);
 
   return null;

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -24,13 +24,11 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
     });
 
     it('should create questionnaire', async () => {
-      await Questionnaire.deleteMany({});
-
       const response = await app.inject({
         method: 'POST',
         url: '/questionnaires',
         headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { title: 'test', type: 'expectations' },
+        payload: { title: 'test', type: 'end_of_course' },
       });
 
       expect(response.statusCode).toBe(200);
@@ -58,23 +56,12 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 409 if already exists a draft questionnaire with type EXPECTATIONS', async () => {
+    it('should return 409 if already exists a draft questionnaire with same type', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/questionnaires',
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload: { title: 'test', type: 'expectations' },
-      });
-
-      expect(response.statusCode).toBe(409);
-    });
-
-    it('should return 409 if already exists a draft questionnaire with type END_OF_COURSE', async () => {
-      const response = await app.inject({
-        method: 'POST',
-        url: '/questionnaires',
-        headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { title: 'test', type: 'end_of_course' },
       });
 
       expect(response.statusCode).toBe(409);

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -68,6 +68,17 @@ describe('QUESTIONNAIRES ROUTES - POST /questionnaires', () => {
 
       expect(response.statusCode).toBe(409);
     });
+
+    it('should return 409 if already exists a draft questionnaire with type END_OF_COURSE', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/questionnaires',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { title: 'test', type: 'end_of_course' },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
   });
 
   describe('Other roles', () => {

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -26,13 +26,6 @@ const questionnairesList = [
     type: 'expectations',
     cards: [cardsList[2]._id, cardsList[3]._id],
   },
-  {
-    _id: new ObjectID(),
-    title: 'test',
-    status: 'draft',
-    type: 'end_of_course',
-    cards: [cardsList[2]._id, cardsList[3]._id],
-  },
 ];
 
 const populateDB = async () => {

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -26,6 +26,13 @@ const questionnairesList = [
     type: 'expectations',
     cards: [cardsList[2]._id, cardsList[3]._id],
   },
+  {
+    _id: new ObjectID(),
+    title: 'test',
+    status: 'draft',
+    type: 'end_of_course',
+    cards: [cardsList[2]._id, cardsList[3]._id],
+  },
 ];
 
 const populateDB = async () => {


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np
- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES UTILISÉS PAR LES APPS MOBILE -np
- J'ai changé un modèle :
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [x] Elle n'est pas utilisée sur les apps mobiles (Sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : admin/rof

- Cas d'usage : je peux créer un questionnaire de type 'Fin de formation' (sauf s'il en existe déjà un en brouillon)
