### PR TITLE
Com 1999

### DIFF
--- a/src/controllers/establishmentController.js
+++ b/src/controllers/establishmentController.js
@@ -56,7 +56,7 @@ const list = async (req) => {
 
 const remove = async (req) => {
   try {
-    await EstablishmentsHelper.remove(req.params._id, req.auth.credentials);
+    await EstablishmentsHelper.remove(req.params._id);
 
     return { message: translate[language].establishmentRemoved };
   } catch (e) {

--- a/src/helpers/dataExport.js
+++ b/src/helpers/dataExport.js
@@ -379,7 +379,8 @@ exports.exportServices = async (credentials) => {
   const companyId = get(credentials, 'company._id', null);
   const services = await Service.find({ company: companyId })
     .populate('company')
-    .populate({ path: 'versions.surcharge', match: { company: companyId } });
+    .populate({ path: 'versions.surcharge', match: { company: companyId } })
+    .lean();
   const data = [serviceHeader];
 
   for (const service of services) {

--- a/src/helpers/establishments.js
+++ b/src/helpers/establishments.js
@@ -1,4 +1,3 @@
-const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const Establishment = require('../models/Establishment');
 
@@ -15,18 +14,10 @@ exports.update = async (id, establishmentPayload) => Establishment
 
 exports.list = async (credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  return Establishment
-    .find({ company: companyId })
+
+  return Establishment.find({ company: companyId })
     .populate({ path: 'usersCount', match: { company: companyId } })
     .lean({ virtuals: true });
 };
 
-exports.remove = async (id, credentials) => {
-  const establishment = await Establishment
-    .findById(id)
-    .populate({ path: 'usersCount', match: { company: get(credentials, 'company._id', null) } });
-
-  if (establishment.usersCount > 0) throw Boom.forbidden();
-
-  await establishment.remove();
-};
+exports.remove = async id => Establishment.deleteOne({ _id: id });

--- a/src/routes/establishments.js
+++ b/src/routes/establishments.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
 const { create, update, list, remove } = require('../controllers/establishmentController');
-const { getEstablishment, authorizeEstablishmentUpdate } = require('./preHandlers/establishments');
+const { authorizeEstablishmentUpdate, authorizeEstablishmentDeletion } = require('./preHandlers/establishments');
 const { workHealthServices } = require('../data/workHealthServices');
 const { urssafCodes } = require('../data/urssafCodes');
 const { addressValidation, phoneNumberValidation } = require('./validations/utils');
@@ -49,10 +49,7 @@ exports.plugin = {
             address: addressValidation,
           }),
         },
-        pre: [
-          { method: getEstablishment, assign: 'establishment' },
-          { method: authorizeEstablishmentUpdate },
-        ],
+        pre: [{ method: authorizeEstablishmentUpdate }],
       },
     });
 
@@ -75,8 +72,8 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
         pre: [
-          { method: getEstablishment, assign: 'establishment' },
-          { method: authorizeEstablishmentUpdate },
+          { method: authorizeEstablishmentUpdate, assign: 'establishment' },
+          { method: authorizeEstablishmentDeletion },
         ],
       },
     });

--- a/src/routes/preHandlers/establishments.js
+++ b/src/routes/preHandlers/establishments.js
@@ -1,26 +1,26 @@
+const { get } = require('lodash');
 const Boom = require('@hapi/boom');
 const Establishment = require('../../models/Establishment');
 const translate = require('../../helpers/translate');
 
 const { language } = translate;
 
-exports.getEstablishment = async (req) => {
-  try {
-    const establishment = await Establishment.findOne({ _id: req.params._id }).lean();
-    if (!establishment) throw Boom.notFound(translate[language].establishmentNotFound);
-
-    return establishment;
-  } catch (e) {
-    req.log('error', e);
-    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
-  }
-};
-
 exports.authorizeEstablishmentUpdate = async (req) => {
   const { credentials } = req.auth;
-  const { establishment } = req.pre;
+  const establishment = await Establishment.findOne({ _id: req.params._id })
+    .populate({ path: 'usersCount', match: { company: get(credentials, 'company._id', null) } })
+    .lean();
+
+  if (!establishment) throw Boom.notFound(translate[language].establishmentNotFound);
 
   if (credentials.company._id.toHexString() !== establishment.company.toHexString()) throw Boom.forbidden();
+
+  return establishment;
+};
+
+exports.authorizeEstablishmentDeletion = async (req) => {
+  const { establishment } = req.pre;
+  if (establishment.usersCount > 0) throw Boom.forbidden();
 
   return null;
 };

--- a/tests/unit/helpers/dataExport.test.js
+++ b/tests/unit/helpers/dataExport.test.js
@@ -14,9 +14,6 @@ const ContractRepository = require('../../../src/repositories/ContractRepository
 const CustomerRepository = require('../../../src/repositories/CustomerRepository');
 const SinonMongoose = require('../sinonMongoose');
 
-require('sinon-mongoose');
-const SinonMongoose = require('../sinonMongoose');
-
 describe('exportCustomers', () => {
   let findCustomer;
   let getLastVersion;
@@ -399,30 +396,18 @@ describe('exportAuxiliaries', () => {
 });
 
 describe('exportHelpers', () => {
-<<<<<<< HEAD
-  let find;
-=======
   let findUser;
->>>>>>> COM-1999: sinonmongoose dataexport
   let findOneRole;
   let getLastVersion;
 
   beforeEach(() => {
-<<<<<<< HEAD
-    find = sinon.stub(User, 'find');
-=======
     findUser = sinon.stub(User, 'find');
->>>>>>> COM-1999: sinonmongoose dataexport
     findOneRole = sinon.stub(Role, 'findOne');
     getLastVersion = sinon.stub(UtilsHelper, 'getLastVersion').returns(this[0]);
   });
 
   afterEach(() => {
-<<<<<<< HEAD
-    find.restore();
-=======
     findUser.restore();
->>>>>>> COM-1999: sinonmongoose dataexport
     findOneRole.restore();
     getLastVersion.restore();
   });
@@ -433,11 +418,7 @@ describe('exportHelpers', () => {
     const helpers = [];
 
     findOneRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleId }], ['lean']));
-<<<<<<< HEAD
-    find.returns(SinonMongoose.stubChainedQueries([helpers]));
-=======
     findUser.returns(SinonMongoose.stubChainedQueries([helpers]));
->>>>>>> COM-1999: sinonmongoose dataexport
 
     const result = await ExportHelper.exportHelpers(credentials);
 
@@ -458,39 +439,26 @@ describe('exportHelpers', () => {
       'Bénéficiaire - Statut',
       'Date de création',
     ]);
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(
-      find,
-=======
     SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
     SinonMongoose.calledWithExactly(
       findUser,
->>>>>>> COM-1999: sinonmongoose dataexport
       [
         { query: 'find', args: [{ 'role.client': roleId, company: credentials.company._id }] },
         {
           query: 'populate',
           args: [{
             path: 'customers',
-<<<<<<< HEAD
             populate: {
               path: 'customer',
               select: 'identity contact',
               populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
             },
             match: { company: credentials.company._id },
-=======
-            populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
->>>>>>> COM-1999: sinonmongoose dataexport
           }],
         },
         { query: 'lean' },
       ]
     );
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
-=======
->>>>>>> COM-1999: sinonmongoose dataexport
   });
 
   it('should return helper info', async () => {
@@ -505,11 +473,7 @@ describe('exportHelpers', () => {
     }];
 
     findOneRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleId }], ['lean']));
-<<<<<<< HEAD
-    find.returns(SinonMongoose.stubChainedQueries([helpers]));
-=======
     findUser.returns(SinonMongoose.stubChainedQueries([helpers]));
->>>>>>> COM-1999: sinonmongoose dataexport
 
     const result = await ExportHelper.exportHelpers(credentials);
 
@@ -533,39 +497,26 @@ describe('exportHelpers', () => {
         '01/02/2019',
       ]
     );
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(
-      find,
-=======
     SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
     SinonMongoose.calledWithExactly(
       findUser,
->>>>>>> COM-1999: sinonmongoose dataexport
       [
         { query: 'find', args: [{ 'role.client': roleId, company: credentials.company._id }] },
         {
           query: 'populate',
           args: [{
             path: 'customers',
-<<<<<<< HEAD
             populate: {
               path: 'customer',
               select: 'identity contact',
               populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
             },
             match: { company: credentials.company._id },
-=======
-            populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
->>>>>>> COM-1999: sinonmongoose dataexport
           }],
         },
         { query: 'lean' },
       ]
     );
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
-=======
->>>>>>> COM-1999: sinonmongoose dataexport
   });
 
   it('should return customer helper info', async () => {
@@ -591,11 +542,7 @@ describe('exportHelpers', () => {
     }];
 
     findOneRole.returns(SinonMongoose.stubChainedQueries([{ _id: roleId }], ['lean']));
-<<<<<<< HEAD
-    find.returns(SinonMongoose.stubChainedQueries([helpers]));
-=======
     findUser.returns(SinonMongoose.stubChainedQueries([helpers]));
->>>>>>> COM-1999: sinonmongoose dataexport
 
     const result = await ExportHelper.exportHelpers(credentials);
 
@@ -617,39 +564,26 @@ describe('exportHelpers', () => {
       'Actif',
       '',
     ]);
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(
-      find,
-=======
     SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
     SinonMongoose.calledWithExactly(
       findUser,
->>>>>>> COM-1999: sinonmongoose dataexport
       [
         { query: 'find', args: [{ 'role.client': roleId, company: credentials.company._id }] },
         {
           query: 'populate',
           args: [{
             path: 'customers',
-<<<<<<< HEAD
             populate: {
               path: 'customer',
               select: 'identity contact',
               populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
             },
             match: { company: credentials.company._id },
-=======
-            populate: { path: 'firstIntervention', select: 'startDate', match: { company: credentials.company._id } },
->>>>>>> COM-1999: sinonmongoose dataexport
           }],
         },
         { query: 'lean' },
       ]
     );
-<<<<<<< HEAD
-    SinonMongoose.calledWithExactly(findOneRole, [{ query: 'findOne', args: [{ name: 'helper' }] }, { query: 'lean' }]);
-=======
->>>>>>> COM-1999: sinonmongoose dataexport
   });
 });
 

--- a/tests/unit/helpers/dataExport.test.js
+++ b/tests/unit/helpers/dataExport.test.js
@@ -69,11 +69,7 @@ describe('exportCustomers', () => {
         { query: 'populate', args: [{ path: 'subscriptions.service' }] },
         {
           query: 'populate',
-          args: [{
-            path: 'firstIntervention',
-            select: 'startDate',
-            match: { company: companyId },
-          }],
+          args: [{ path: 'firstIntervention', select: 'startDate', match: { company: companyId } }],
         },
         { query: 'populate', args: [{ path: 'referent', match: { company: companyId } }] },
         { query: 'lean', args: [{ autopopulate: true }] },
@@ -95,13 +91,7 @@ describe('exportCustomers', () => {
         contact: { primaryAddress: { fullAddress: '9 rue du paradis 70015 Paris' } },
         followUp: { situation: 'home', misc: 'Lala', objectives: 'Savate et charentaises', environment: 'Père Castor' },
         firstIntervention: { _id: new ObjectID(), startDate: '2019-08-08T10:00:00' },
-        referent: {
-          _id: new ObjectID(),
-          identity: {
-            firstname: 'Toto',
-            lastname: 'Test',
-          },
-        },
+        referent: { _id: new ObjectID(), identity: { firstname: 'Toto', lastname: 'Test' } },
         payment: {
           bankAccountOwner: 'Lui',
           iban: 'Boom Ba Da Boom',
@@ -158,11 +148,7 @@ describe('exportCustomers', () => {
         { query: 'populate', args: [{ path: 'subscriptions.service' }] },
         {
           query: 'populate',
-          args: [{
-            path: 'firstIntervention',
-            select: 'startDate',
-            match: { company: companyId },
-          }],
+          args: [{ path: 'firstIntervention', select: 'startDate', match: { company: companyId } }],
         },
         { query: 'populate', args: [{ path: 'referent', match: { company: companyId } }] },
         { query: 'lean', args: [{ autopopulate: true }] },
@@ -191,11 +177,7 @@ describe('exportCustomers', () => {
         { query: 'populate', args: [{ path: 'subscriptions.service' }] },
         {
           query: 'populate',
-          args: [{
-            path: 'firstIntervention',
-            select: 'startDate',
-            match: { company: companyId },
-          }],
+          args: [{ path: 'firstIntervention', select: 'startDate', match: { company: companyId } }],
         },
         { query: 'populate', args: [{ path: 'referent', match: { company: companyId } }] },
         { query: 'lean', args: [{ autopopulate: true }] },
@@ -348,10 +330,7 @@ describe('exportAuxiliaries', () => {
     const auxiliaries = [
       {
         _id: new ObjectID(),
-        contracts: [
-          { _id: 1, startDate: '2019-11-10', endDate: '2019-12-01' },
-          { _id: 1, startDate: '2019-12-02' },
-        ],
+        contracts: [{ _id: 1, startDate: '2019-11-10', endDate: '2019-12-01' }, { _id: 1, startDate: '2019-12-02' }],
       },
     ];
 
@@ -628,18 +607,12 @@ describe('exportSectors', () => {
     const credentials = { company: { _id: new ObjectID() } };
     const sectorHistories = [{
       sector: { name: 'test' },
-      auxiliary: {
-        _id: new ObjectID(),
-        identity: { firstname: 'toto', lastname: 'Tutu' },
-      },
+      auxiliary: { _id: new ObjectID(), identity: { firstname: 'toto', lastname: 'Tutu' } },
       startDate: '2019-11-10',
     },
     {
       sector: { name: 'test2' },
-      auxiliary: {
-        _id: new ObjectID(),
-        identity: { firstname: 'toto2', lastname: 'Tutu2' },
-      },
+      auxiliary: { _id: new ObjectID(), identity: { firstname: 'toto2', lastname: 'Tutu2' } },
       startDate: '2019-11-10',
       endDate: '2019-12-10',
     }];
@@ -708,7 +681,8 @@ describe('exportReferents', () => {
       'Date de fin',
     ]);
     SinonMongoose.calledWithExactly(
-      findReferentHistory, [
+      findReferentHistory,
+      [
         { query: 'find', args: [{ company: credentials.company._id }] },
         { query: 'populate', args: ['auxiliary'] },
         { query: 'populate', args: ['customer'] },
@@ -764,7 +738,8 @@ describe('exportReferents', () => {
       '',
     ]);
     SinonMongoose.calledWithExactly(
-      findReferentHistory, [
+      findReferentHistory,
+      [
         { query: 'find', args: [{ company: credentials.company._id }] },
         { query: 'populate', args: ['auxiliary'] },
         { query: 'populate', args: ['customer'] },

--- a/tests/unit/helpers/establishments.test.js
+++ b/tests/unit/helpers/establishments.test.js
@@ -10,7 +10,6 @@ describe('create', () => {
   beforeEach(() => {
     create = sinon.stub(Establishment, 'create');
   });
-
   afterEach(() => {
     create.restore();
   });
@@ -51,7 +50,6 @@ describe('update', () => {
   beforeEach(() => {
     findOneAndUpdate = sinon.stub(Establishment, 'findOneAndUpdate');
   });
-
   afterEach(() => {
     findOneAndUpdate.restore();
   });
@@ -80,7 +78,6 @@ describe('list', () => {
   beforeEach(() => {
     find = sinon.stub(Establishment, 'find');
   });
-
   afterEach(() => {
     find.restore();
   });
@@ -109,7 +106,6 @@ describe('remove', () => {
   beforeEach(() => {
     deleteOne = sinon.stub(Establishment, 'deleteOne');
   });
-
   afterEach(() => {
     deleteOne.restore();
   });


### PR DESCRIPTION
SinonMongoose :
  ### dataExport ###

- [x] exportCustomers
- [x] exportAuxiliaries
- [x] exportHelpers
- [x] exportSectors
- [x] exportReferents
- [x] exportServices
- [x] exportSubscriptions

  ### establishments ###

- [x] create
- [x] update
- [x] list
- [x] remove

+ refacto de la route remove pour les establishments et une simplification des prehandler

J'ai rempli le doc https://alenvi.slite.com/app/channels/~Kmqtdbscs/notes/8N9l89kbNY