### PR TITLE
COM-2037: return end of course questionnaire

### DIFF
--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -80,7 +80,7 @@ const removeCard = async (req) => {
 
 const getUserQuestionnaires = async (req) => {
   try {
-    const questionnaires = await QuestionnaireHelper.getUserQuestionnaires(req.pre.course, req.auth.credentials);
+    const questionnaires = await QuestionnaireHelper.getUserQuestionnaires(req.query.course, req.auth.credentials);
 
     return {
       message: questionnaires.length

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -1,5 +1,6 @@
 const get = require('lodash/get');
 const Questionnaire = require('../models/Questionnaire');
+const Course = require('../models/Course');
 const CardHelper = require('./cards');
 const { EXPECTATIONS, PUBLISHED, STRICTLY_E_LEARNING, END_OF_COURSE } = require('./constants');
 const DatesHelper = require('./dates');
@@ -29,7 +30,12 @@ exports.findQuestionnaire = async (course, credentials, type) => Questionnaire
   .populate({ path: 'histories', match: { course: course._id, user: credentials._id } })
   .lean({ virtuals: true });
 
-exports.getUserQuestionnaires = async (course, credentials) => {
+exports.getUserQuestionnaires = async (courseId, credentials) => {
+  const course = await Course.findOne({ _id: courseId })
+    .populate({ path: 'slots', select: '-__v -createdAt -updatedAt' })
+    .populate({ path: 'slotsToPlan', select: '_id' })
+    .lean({ virtuals: true });
+
   if (course.format === STRICTLY_E_LEARNING) return [];
 
   const isCourseStarted = get(course, 'slots.length') && DatesHelper.isAfter(Date.now(), course.slots[0].startDate);

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -33,6 +33,7 @@ exports.authorizeQuestionnaireGet = async (req) => {
 exports.authorizeUserQuestionnairesGet = async (req) => {
   const course = await Course.findOne({ _id: req.query.course })
     .populate({ path: 'slots', select: '-__v -createdAt -updatedAt' })
+    .populate({ path: 'slotsToPlan', select: '_id' })
     .lean({ virtuals: true });
 
   if (!course) throw Boom.notFound();

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -31,11 +31,7 @@ exports.authorizeQuestionnaireGet = async (req) => {
 };
 
 exports.authorizeUserQuestionnairesGet = async (req) => {
-  const course = await Course.findOne({ _id: req.query.course })
-    .populate({ path: 'slots', select: '-__v -createdAt -updatedAt' })
-    .populate({ path: 'slotsToPlan', select: '_id' })
-    .lean({ virtuals: true });
-
+  const course = await Course.countDocuments({ _id: req.query.course });
   if (!course) throw Boom.notFound();
 
   return course;

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -54,7 +54,7 @@ exports.plugin = {
           query: Joi.object({ course: Joi.objectId().required() }),
         },
         auth: { mode: 'required' },
-        pre: [{ method: authorizeUserQuestionnairesGet, assign: 'course' }],
+        pre: [{ method: authorizeUserQuestionnairesGet }],
       },
       handler: getUserQuestionnaires,
     });

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -153,16 +153,16 @@ describe('removeCard', () => {
 });
 
 describe('getUserQuestionnaires', () => {
-  let findOne;
+  let findOneQuestionnaire;
   let nowStub;
   let findOneCourse;
   beforeEach(() => {
-    findOne = sinon.stub(Questionnaire, 'findOne');
+    findOneQuestionnaire = sinon.stub(Questionnaire, 'findOne');
     nowStub = sinon.stub(Date, 'now');
     findOneCourse = sinon.stub(Course, 'findOne');
   });
   afterEach(() => {
-    findOne.restore();
+    findOneQuestionnaire.restore();
     nowStub.restore();
     findOneCourse.restore();
   });
@@ -178,7 +178,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    sinon.assert.notCalled(findOne);
+    sinon.assert.notCalled(findOneQuestionnaire);
     SinonMongoose.calledWithExactly(
       findOneCourse,
       [
@@ -190,7 +190,7 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return an empty array if no expectations questionnaire', async () => {
+  it('should return an empty array if not started and no expectations questionnaire', async () => {
     const courseId = new ObjectID();
     const credentials = { _id: new ObjectID() };
     const course = {
@@ -200,7 +200,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([null]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([null]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -215,7 +215,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -239,7 +239,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -254,7 +254,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -274,7 +274,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -289,7 +289,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -306,7 +306,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -321,7 +321,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -330,7 +330,7 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return an empty array if course has slots to plan', async () => {
+  it('should return an empty array if course is started and has slots to plan', async () => {
     const courseId = new ObjectID();
     const credentials = { _id: new ObjectID() };
     const course = {
@@ -345,7 +345,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    sinon.assert.notCalled(findOne);
+    sinon.assert.notCalled(findOneQuestionnaire);
     SinonMongoose.calledWithExactly(
       findOneCourse,
       [
@@ -357,7 +357,7 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return an empty array if no end of course questionnaire', async () => {
+  it('should return an empty array if is ended and no end of course questionnaire', async () => {
     const courseId = new ObjectID();
     const credentials = { _id: new ObjectID() };
     const course = {
@@ -367,7 +367,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([null]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([null]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -382,7 +382,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -406,7 +406,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -421,7 +421,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -441,7 +441,7 @@ describe('getUserQuestionnaires', () => {
 
     findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOneQuestionnaire.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
@@ -456,7 +456,7 @@ describe('getUserQuestionnaires', () => {
       ]
     );
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneQuestionnaire,
       [
         { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
         { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
@@ -483,7 +483,7 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
-    sinon.assert.notCalled(findOne);
+    sinon.assert.notCalled(findOneQuestionnaire);
     SinonMongoose.calledWithExactly(
       findOneCourse,
       [

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const Questionnaire = require('../../../src/models/Questionnaire');
+const Course = require('../../../src/models/Course');
 const QuestionnaireHelper = require('../../../src/helpers/questionnaires');
 const CardHelper = require('../../../src/helpers/cards');
 const { EXPECTATIONS, PUBLISHED, END_OF_COURSE } = require('../../../src/helpers/constants');
@@ -154,40 +155,65 @@ describe('removeCard', () => {
 describe('getUserQuestionnaires', () => {
   let findOne;
   let nowStub;
+  let findOneCourse;
   beforeEach(() => {
     findOne = sinon.stub(Questionnaire, 'findOne');
     nowStub = sinon.stub(Date, 'now');
+    findOneCourse = sinon.stub(Course, 'findOne');
   });
   afterEach(() => {
     findOne.restore();
     nowStub.restore();
+    findOneCourse.restore();
   });
 
   it('should return an empty array if course is strictly e-learning', async () => {
-    const course = { _id: new ObjectID(), format: 'strictly_e_learning' };
+    const courseId = new ObjectID();
     const credentials = { _id: new ObjectID() };
+    const course = { _id: courseId, format: 'strictly_e_learning' };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOne);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 
-  it('should return an empty array if no questionnaire', async () => {
+  it('should return an empty array if no expectations questionnaire', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
-    const credentials = { _id: new ObjectID() };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
     findOne.returns(SinonMongoose.stubChainedQueries([null]));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -198,24 +224,35 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return an empty array if questionnaire is already answered', async () => {
+  it('should return an empty array if expectations questionnaire is already answered', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
-    const credentials = { _id: new ObjectID() };
     const questionnaire = {
       _id: new ObjectID(),
       name: 'test',
       histories: [{ _id: new ObjectID(), course: course._id, user: credentials._id }],
     };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
     findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -226,20 +263,31 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return expectations questionnaire', async () => {
+  it('should return expectations questionnaire if course not started and questionnaire not answered', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
-    const credentials = { _id: new ObjectID() };
     const questionnaire = { _id: new ObjectID(), name: 'test', type: 'expectations', histories: [] };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
     findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -251,64 +299,27 @@ describe('getUserQuestionnaires', () => {
   });
 
   it('should return expectations questionnaire if no slots', async () => {
-    const course = { _id: new ObjectID(), slots: [] };
-    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
+    const courseId = new ObjectID();
     const credentials = { _id: new ObjectID() };
+    const course = { _id: courseId, slots: [] };
+    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-13T15:00:00'));
     findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
     SinonMongoose.calledWithExactly(
-      findOne,
+      findOneCourse,
       [
-        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
-        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
         { query: 'lean', args: [{ virtuals: true }] },
       ]
     );
-  });
-
-  it('should return questionnaire if questionnaire is not answered for this course', async () => {
-    const course = {
-      _id: new ObjectID(),
-      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
-    };
-    const credentials = { _id: new ObjectID() };
-    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
-
-    nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
-        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]
-    );
-  });
-
-  it('should return questionnaire if questionnaire is not answered by this user', async () => {
-    const course = {
-      _id: new ObjectID(),
-      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
-    };
-    const credentials = { _id: new ObjectID() };
-    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
-
-    nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([questionnaire]);
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -320,35 +331,130 @@ describe('getUserQuestionnaires', () => {
   });
 
   it('should return an empty array if course has slots to plan', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
       slotsToPlan: [{ _id: new ObjectID() }],
     };
-    const credentials = { _id: new ObjectID() };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOne);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 
-  it('should return end of course questionnaire', async () => {
+  it('should return an empty array if no end of course questionnaire', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
-    const credentials = { _id: new ObjectID() };
-    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'end_of_course', histories: [] };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    nowStub.returns(new Date('2021-04-23T15:00:00'));
+    findOne.returns(SinonMongoose.stubChainedQueries([null]));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
+
+    expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
+        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+  });
+
+  it('should return an empty array if end of course questionnaire is already answered', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
+    const course = {
+      _id: courseId,
+      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
+    };
+    const questionnaire = {
+      _id: new ObjectID(),
+      name: 'test',
+      histories: [{ _id: new ObjectID(), course: course._id, user: credentials._id }],
+    };
+
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
     findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
+
+    expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
+        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+  });
+
+  it('should return end of course questionnaire if course ended and questionnaire not answered', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
+    const course = {
+      _id: courseId,
+      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
+    };
+    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'end_of_course', histories: [] };
+
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
+    nowStub.returns(new Date('2021-04-23T15:00:00'));
+    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([questionnaire]);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -360,21 +466,32 @@ describe('getUserQuestionnaires', () => {
   });
 
   it('should return an empty array if first slot is passed but last slot isn\'t', async () => {
+    const courseId = new ObjectID();
+    const credentials = { _id: new ObjectID() };
     const course = {
-      _id: new ObjectID(),
+      _id: courseId,
       format: 'blended',
       slots: [
         { startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') },
         { startDate: new Date('2021-04-24T09:00:00'), endDate: new Date('2021-04-24T11:00:00') },
       ],
     };
-    const credentials = { _id: new ObjectID() };
 
+    findOneCourse.returns(SinonMongoose.stubChainedQueries([course]));
     nowStub.returns(new Date('2021-04-23T15:00:00'));
 
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+    const result = await QuestionnaireHelper.getUserQuestionnaires(courseId, credentials);
 
     expect(result).toMatchObject([]);
     sinon.assert.notCalled(findOne);
+    SinonMongoose.calledWithExactly(
+      findOneCourse,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'populate', args: [{ path: 'slots', select: '-__v -createdAt -updatedAt' }] },
+        { query: 'populate', args: [{ path: 'slotsToPlan', select: '_id' }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
   });
 });

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -163,65 +163,31 @@ describe('getUserQuestionnaires', () => {
     nowStub.restore();
   });
 
-  it('should return expectations questionnaire', async () => {
+  it('should return an empty array if course is strictly e-learning', async () => {
+    const course = { _id: new ObjectID(), format: 'strictly_e_learning' };
+    const credentials = { _id: new ObjectID() };
+
+    nowStub.returns(new Date('2021-04-13T15:00:00'));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+
+    expect(result).toMatchObject([]);
+    sinon.assert.notCalled(findOne);
+  });
+
+  it('should return an empty array if no questionnaire', async () => {
     const course = {
       _id: new ObjectID(),
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
     };
     const credentials = { _id: new ObjectID() };
-    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'expectations', histories: [] };
 
     nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+    findOne.returns(SinonMongoose.stubChainedQueries([null]));
 
     const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
 
-    expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
-        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]
-    );
-  });
-
-  it('should return end of course questionnaire', async () => {
-    const course = {
-      _id: new ObjectID(),
-      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
-    };
-    const credentials = { _id: new ObjectID() };
-    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'end_of_course', histories: [] };
-
-    nowStub.returns(new Date('2021-04-23T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([questionnaire]);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
-        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]
-    );
-  });
-
-  it('should return expectations questionnaire if no slots', async () => {
-    const course = { _id: new ObjectID(), slots: [] };
-    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
-    const credentials = { _id: new ObjectID() };
-
-    nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([questionnaire]);
+    expect(result).toMatchObject([]);
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -250,6 +216,51 @@ describe('getUserQuestionnaires', () => {
     const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
 
     expect(result).toMatchObject([]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
+        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+  });
+
+  it('should return expectations questionnaire', async () => {
+    const course = {
+      _id: new ObjectID(),
+      slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
+    };
+    const credentials = { _id: new ObjectID() };
+    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'expectations', histories: [] };
+
+    nowStub.returns(new Date('2021-04-13T15:00:00'));
+    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+
+    expect(result).toMatchObject([questionnaire]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
+        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+  });
+
+  it('should return expectations questionnaire if no slots', async () => {
+    const course = { _id: new ObjectID(), slots: [] };
+    const questionnaire = { _id: new ObjectID(), name: 'test', histories: [] };
+    const credentials = { _id: new ObjectID() };
+
+    nowStub.returns(new Date('2021-04-13T15:00:00'));
+    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+
+    expect(result).toMatchObject([questionnaire]);
     SinonMongoose.calledWithExactly(
       findOne,
       [
@@ -308,37 +319,11 @@ describe('getUserQuestionnaires', () => {
     );
   });
 
-  it('should return an empty array if no questionnaire', async () => {
+  it('should return an empty array if course has slots to plan', async () => {
     const course = {
       _id: new ObjectID(),
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
-    };
-    const credentials = { _id: new ObjectID() };
-
-    nowStub.returns(new Date('2021-04-13T15:00:00'));
-    findOne.returns(SinonMongoose.stubChainedQueries([null]));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([]);
-    SinonMongoose.calledWithExactly(
-      findOne,
-      [
-        { query: 'findOne', args: [{ type: EXPECTATIONS, status: PUBLISHED }, { type: 1, name: 1 }] },
-        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
-        { query: 'lean', args: [{ virtuals: true }] },
-      ]
-    );
-  });
-
-  it('should return an empty array if first slot is passed', async () => {
-    const course = {
-      _id: new ObjectID(),
-      format: 'blended',
-      slots: [
-        { startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') },
-        { startDate: new Date('2021-04-24T09:00:00'), endDate: new Date('2021-04-24T11:00:00') },
-      ],
+      slotsToPlan: [{ _id: new ObjectID() }],
     };
     const credentials = { _id: new ObjectID() };
 
@@ -350,23 +335,38 @@ describe('getUserQuestionnaires', () => {
     sinon.assert.notCalled(findOne);
   });
 
-  it('should return an empty array if course is strictly e-learning', async () => {
-    const course = { _id: new ObjectID(), format: 'strictly_e_learning' };
-    const credentials = { _id: new ObjectID() };
-
-    nowStub.returns(new Date('2021-04-13T15:00:00'));
-
-    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
-
-    expect(result).toMatchObject([]);
-    sinon.assert.notCalled(findOne);
-  });
-
-  it('should return an empty array if course has slots to plan', async () => {
+  it('should return end of course questionnaire', async () => {
     const course = {
       _id: new ObjectID(),
       slots: [{ startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') }],
-      slotsToPlan: [{ _id: new ObjectID() }],
+    };
+    const credentials = { _id: new ObjectID() };
+    const questionnaire = { _id: new ObjectID(), name: 'test', type: 'end_of_course', histories: [] };
+
+    nowStub.returns(new Date('2021-04-23T15:00:00'));
+    findOne.returns(SinonMongoose.stubChainedQueries([questionnaire]));
+
+    const result = await QuestionnaireHelper.getUserQuestionnaires(course, credentials);
+
+    expect(result).toMatchObject([questionnaire]);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ type: END_OF_COURSE, status: PUBLISHED }, { type: 1, name: 1 }] },
+        { query: 'populate', args: [{ path: 'histories', match: { course: course._id, user: credentials._id } }] },
+        { query: 'lean', args: [{ virtuals: true }] },
+      ]
+    );
+  });
+
+  it('should return an empty array if first slot is passed but last slot isn\'t', async () => {
+    const course = {
+      _id: new ObjectID(),
+      format: 'blended',
+      slots: [
+        { startDate: new Date('2021-04-20T09:00:00'), endDate: new Date('2021-04-20T11:00:00') },
+        { startDate: new Date('2021-04-24T09:00:00'), endDate: new Date('2021-04-24T11:00:00') },
+      ],
     };
     const credentials = { _id: new ObjectID() };
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- ~~Tests intégrations : ~~
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : mobile

- Périmetre roles : tous

- Cas d'usage : 
  - publier un questionnaire début de formation et fin de formation
  - créer une formation blended et s'y inscrire: 
    - sans slots : je reçois le questionnaire de début de formation
    - dont le premier slot n'est pas encore passé : je reçois le questionnaire de début de formation
    - dont le premier slot est passé (mais pas les suivants) : je ne reçois aucun questionnaire
    - dont tous les slots sont passés mais avec une date à plannifier  : je ne reçois aucun questionnaire
    - dont tous les slots sont passés : je reçois le questionnaire de fin de formation
  - s'inscrire à une formation e-learning : 
    - je ne reçois aucun questionnaire 
