### PR TITLE
Com 2034

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -224,8 +224,8 @@ const formatUpdatePayload = async (updatedUser) => {
 exports.updateUser = async (userId, userPayload, credentials, canEditWithoutCompany = false) => {
   const companyId = get(credentials, 'company._id', null);
 
-  const query = { _id: userId };
-  if (!canEditWithoutCompany) query.company = companyId;
+  const filterQuery = { _id: userId };
+  if (!canEditWithoutCompany) filterQuery.company = companyId;
 
   const payload = await formatUpdatePayload(userPayload);
 
@@ -235,7 +235,11 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
     await SectorHistoriesHelper.updateHistoryOnSectorUpdate(userId, payload.sector, companyId);
   }
 
-  await User.updateOne(query, { $set: flat(payload) });
+  const updateQuery = userPayload.expoToken
+    ? { $push: { expoTokens: userPayload.expoToken } }
+    : { $set: flat(payload) };
+
+  await User.updateOne(filterQuery, updateQuery);
 };
 
 exports.updateUserCertificates = async (userId, userPayload, credentials) => {

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -235,8 +235,8 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
     await SectorHistoriesHelper.updateHistoryOnSectorUpdate(userId, payload.sector, companyId);
   }
 
-  const updateQuery = userPayload.expoToken
-    ? { $push: { expoTokens: userPayload.expoToken } }
+  const updateQuery = userPayload.formationExpoToken
+    ? { $push: { formationExpoTokens: userPayload.formationExpoToken } }
     : { $set: flat(payload) };
 
   await User.updateOne(filterQuery, updateQuery);

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -236,7 +236,7 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
   }
 
   const updatePayload = userPayload.formationExpoToken
-    ? { $push: { formationExpoTokenList: userPayload.formationExpoToken } }
+    ? { $addToSet: { formationExpoTokenList: userPayload.formationExpoToken } }
     : { $set: flat(payload) };
 
   await User.updateOne(filterQuery, updatePayload);

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -235,11 +235,11 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
     await SectorHistoriesHelper.updateHistoryOnSectorUpdate(userId, payload.sector, companyId);
   }
 
-  const updateQuery = userPayload.formationExpoToken
-    ? { $push: { formationExpoTokens: userPayload.formationExpoToken } }
+  const updatePayload = userPayload.formationExpoToken
+    ? { $push: { formationExpoTokenList: userPayload.formationExpoToken } }
     : { $set: flat(payload) };
 
-  await User.updateOne(filterQuery, updateQuery);
+  await User.updateOne(filterQuery, updatePayload);
 };
 
 exports.updateUserCertificates = async (userId, userPayload, credentials) => {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -134,6 +134,7 @@ const UserSchema = mongoose.Schema({
   biography: { type: String },
   firstMobileConnection: { type: Date },
   origin: { type: String, enum: ORIGIN_OPTIONS, required: true, immutable: true },
+  expoTokens: [{ type: String }],
 }, {
   timestamps: true,
   toObject: { virtuals: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -134,7 +134,7 @@ const UserSchema = mongoose.Schema({
   biography: { type: String },
   firstMobileConnection: { type: Date },
   origin: { type: String, enum: ORIGIN_OPTIONS, required: true, immutable: true },
-  formationExpoTokens: [{ type: String }],
+  formationExpoTokenList: [{ type: String }],
 }, {
   timestamps: true,
   toObject: { virtuals: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -134,7 +134,7 @@ const UserSchema = mongoose.Schema({
   biography: { type: String },
   firstMobileConnection: { type: Date },
   origin: { type: String, enum: ORIGIN_OPTIONS, required: true, immutable: true },
-  expoTokens: [{ type: String }],
+  formationExpoTokens: [{ type: String }],
 }, {
   timestamps: true,
   toObject: { virtuals: true },

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -46,7 +46,7 @@ exports.authorizeUserUpdate = async (req) => {
   if (get(req, 'payload.establishment')) await checkEstablishment(userCompany, req.payload);
   if (get(req, 'payload.role')) await checkRole(userFromDB, req.payload);
   if (get(req, 'payload.customer')) await checkCustomer(userCompany, req.payload);
-  if (get(req, 'payload.expoToken')) await checkExpoToken(req.payload);
+  if (get(req, 'payload.formationExpoToken')) await checkExpoToken(req.payload);
   if (!isLoggedUserVendor && (!loggedUserClientRole || loggedUserClientRole === AUXILIARY_WITHOUT_COMPANY)) {
     checkUpdateRestrictions(req.payload);
   }
@@ -105,7 +105,7 @@ const checkCustomer = async (userCompany, payload) => {
 };
 
 const checkExpoToken = async (payload) => {
-  const expoTokenAlreadyExists = await User.countDocuments({ expoTokens: payload.expoToken });
+  const expoTokenAlreadyExists = await User.countDocuments({ formationExpoTokens: payload.formationExpoToken });
   if (expoTokenAlreadyExists) throw Boom.forbidden();
 };
 

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -46,7 +46,7 @@ exports.authorizeUserUpdate = async (req) => {
   if (get(req, 'payload.establishment')) await checkEstablishment(userCompany, req.payload);
   if (get(req, 'payload.role')) await checkRole(userFromDB, req.payload);
   if (get(req, 'payload.customer')) await checkCustomer(userCompany, req.payload);
-  if (get(req, 'payload.formationExpoToken')) await checkExpoToken(req.payload);
+  if (get(req, 'payload.formationExpoToken')) await checkExpoToken(req);
   if (!isLoggedUserVendor && (!loggedUserClientRole || loggedUserClientRole === AUXILIARY_WITHOUT_COMPANY)) {
     checkUpdateRestrictions(req.payload);
   }
@@ -104,9 +104,15 @@ const checkCustomer = async (userCompany, payload) => {
   if (!customerCount) throw Boom.forbidden();
 };
 
-const checkExpoToken = async (payload) => {
-  const expoTokenAlreadyExists = await User.countDocuments({ formationExpoTokenList: payload.formationExpoToken });
+const checkExpoToken = async (req) => {
+  const { params, payload } = req;
+  const expoTokenAlreadyExists = await User.countDocuments({
+    _id: { $ne: params._id },
+    formationExpoTokenList: payload.formationExpoToken,
+  });
   if (expoTokenAlreadyExists) throw Boom.forbidden();
+
+  return null;
 };
 
 const checkUpdateRestrictions = (payload) => {

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -105,7 +105,7 @@ const checkCustomer = async (userCompany, payload) => {
 };
 
 const checkExpoToken = async (payload) => {
-  const expoTokenAlreadyExists = await User.countDocuments({ formationExpoTokens: payload.formationExpoToken });
+  const expoTokenAlreadyExists = await User.countDocuments({ formationExpoTokenList: payload.formationExpoToken });
   if (expoTokenAlreadyExists) throw Boom.forbidden();
 };
 

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -46,6 +46,7 @@ exports.authorizeUserUpdate = async (req) => {
   if (get(req, 'payload.establishment')) await checkEstablishment(userCompany, req.payload);
   if (get(req, 'payload.role')) await checkRole(userFromDB, req.payload);
   if (get(req, 'payload.customer')) await checkCustomer(userCompany, req.payload);
+  if (get(req, 'payload.expoToken')) await checkExpoToken(req.payload);
   if (!isLoggedUserVendor && (!loggedUserClientRole || loggedUserClientRole === AUXILIARY_WITHOUT_COMPANY)) {
     checkUpdateRestrictions(req.payload);
   }
@@ -101,6 +102,11 @@ const checkCustomer = async (userCompany, payload) => {
   const customerCount = await Customer.countDocuments({ _id: payload.customer, company: userCompany });
 
   if (!customerCount) throw Boom.forbidden();
+};
+
+const checkExpoToken = async (payload) => {
+  const expoTokenAlreadyExists = await User.countDocuments({ expoTokens: payload.expoToken });
+  if (expoTokenAlreadyExists) throw Boom.forbidden();
 };
 
 const checkUpdateRestrictions = (payload) => {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -187,6 +187,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
+            expoToken: Joi.string(),
             emergencyPhone: Joi.string(),
             sector: Joi.objectId(),
             'local.email': Joi.string().email(), // bot special case

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -32,7 +32,7 @@ const {
   authorizeLearnersGet,
   getPicturePublicId,
 } = require('./preHandlers/users');
-const { addressValidation, phoneNumberValidation } = require('./validations/utils');
+const { addressValidation, phoneNumberValidation, expoTokenValidation } = require('./validations/utils');
 const { formDataPayload } = require('./validations/utils');
 
 const driveUploadKeys = [
@@ -187,11 +187,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            formationExpoToken: Joi.string().custom((value, helper) => (
-              value.substring(0, 18) === 'ExponentPushToken['
-                ? true
-                : helper.message('Wrong ExponentPushToken type')
-            )),
+            formationExpoToken: expoTokenValidation,
             emergencyPhone: Joi.string(),
             sector: Joi.objectId(),
             'local.email': Joi.string().email(), // bot special case

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -187,7 +187,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            expoToken: Joi.string(),
+            formationExpoToken: Joi.string(),
             emergencyPhone: Joi.string(),
             sector: Joi.objectId(),
             'local.email': Joi.string().email(), // bot special case

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -187,7 +187,11 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            formationExpoToken: Joi.string(),
+            formationExpoToken: Joi.string().custom((value, helper) => (
+              value.substring(0, 18) === 'ExponentPushToken['
+                ? true
+                : helper.message('Wrong ExponentPushToken type')
+            )),
             emergencyPhone: Joi.string(),
             sector: Joi.objectId(),
             'local.email': Joi.string().email(), // bot special case

--- a/src/routes/validations/utils.js
+++ b/src/routes/validations/utils.js
@@ -17,6 +17,12 @@ const addressValidation = Joi.object().keys({
 
 const objectIdOrArray = Joi.alternatives().try(Joi.objectId(), Joi.array().items(Joi.objectId()));
 
+const expoTokenValidation = Joi.string().custom((value, helper) => (
+  value.substring(0, 18) === 'ExponentPushToken['
+    ? true
+    : helper.message('Wrong ExponentPushToken type')
+));
+
 const formDataPayload = (maxSize = 5242880) => ({
   output: 'stream',
   parse: true,
@@ -30,5 +36,6 @@ module.exports = {
   phoneNumberValidation,
   addressValidation,
   objectIdOrArray,
+  expoTokenValidation,
   formDataPayload,
 };

--- a/src/routes/validations/utils.js
+++ b/src/routes/validations/utils.js
@@ -19,7 +19,7 @@ const objectIdOrArray = Joi.alternatives().try(Joi.objectId(), Joi.array().items
 
 const expoTokenValidation = Joi.string().custom((value, helper) => (
   value.substring(0, 18) === 'ExponentPushToken['
-    ? true
+    ? value
     : helper.message('Wrong ExponentPushToken type')
 ));
 

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -135,6 +135,7 @@ const usersSeedList = [
     establishment: establishmentList[0]._id,
     picture: { publicId: 'a/public/id', link: 'https://the.complete.com/link/to/the/picture/storage/location' },
     origin: WEBAPP,
+    formationExpoTokenList: ['ExponentPushToken[jeSuisUnIdExpo]'],
   },
   {
     _id: new ObjectID(),
@@ -150,6 +151,7 @@ const usersSeedList = [
     },
     inactivityDate: null,
     origin: WEBAPP,
+    formationExpoTokenList: ['ExponentPushToken[jeSuisUnAutreIdExpo]'],
   },
   {
     _id: new ObjectID(),

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1268,6 +1268,17 @@ describe('PUT /users/:id/', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    it('should return a 400 if ExponentPushToken has wrong type', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/users/${usersSeedList[0]._id}`,
+        payload: { formationExpoToken: 'skusku' },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
   });
 
   describe('VENDOR_ADMIN', () => {

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1269,7 +1269,18 @@ describe('PUT /users/:id/', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return a 400 if ExponentPushToken has wrong type', async () => {
+    it('should return a 200 but not update if formationExpoToken already exists on user', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/users/${usersSeedList[0]._id}`,
+        payload: { formationExpoToken: 'ExponentPushToken[jeSuisUnIdExpo]' },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return a 400 if formationExpoToken has wrong type', async () => {
       const response = await app.inject({
         method: 'PUT',
         url: `/users/${usersSeedList[0]._id}`,
@@ -1278,6 +1289,17 @@ describe('PUT /users/:id/', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 403 if formationExpoToken already exists on another user', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/users/${usersSeedList[0]._id}`,
+        payload: { formationExpoToken: 'ExponentPushToken[jeSuisUnAutreIdExpo]' },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1113,7 +1113,7 @@ describe('updateUser', () => {
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);
   });
 
-  it('should push an expoToken to expoTokens', async () => {
+  it('should push an expoToken to formationExpoTokenList', async () => {
     const payload = { formationExpoToken: 'ExponentPushToken[skusku]' };
 
     await UsersHelper.updateUser(userId, payload, credentials, true);
@@ -1121,7 +1121,7 @@ describe('updateUser', () => {
     sinon.assert.calledOnceWithExactly(
       userUpdateOne,
       { _id: userId },
-      { $push: { formationExpoTokens: 'ExponentPushToken[skusku]' } }
+      { $push: { formationExpoTokenList: 'ExponentPushToken[skusku]' } }
     );
     sinon.assert.notCalled(createHelper);
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1121,7 +1121,7 @@ describe('updateUser', () => {
     sinon.assert.calledOnceWithExactly(
       userUpdateOne,
       { _id: userId },
-      { $push: { formationExpoTokenList: 'ExponentPushToken[skusku]' } }
+      { $addToSet: { formationExpoTokenList: 'ExponentPushToken[skusku]' } }
     );
     sinon.assert.notCalled(createHelper);
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1116,11 +1116,11 @@ describe('updateUser', () => {
   it('should push an expoToken to expoTokens', async () => {
     const payload = { formationExpoToken: 'ExponentPushToken[skusku]' };
 
-    await UsersHelper.updateUser(userId, payload, credentials);
+    await UsersHelper.updateUser(userId, payload, credentials, true);
 
     sinon.assert.calledOnceWithExactly(
       userUpdateOne,
-      { _id: userId, company: credentials.company._id },
+      { _id: userId },
       { $push: { formationExpoTokens: 'ExponentPushToken[skusku]' } }
     );
     sinon.assert.notCalled(createHelper);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1114,14 +1114,14 @@ describe('updateUser', () => {
   });
 
   it('should push an expoToken to expoTokens', async () => {
-    const payload = { expoToken: 'ExponentPushToken[skusku]' };
+    const payload = { formationExpoToken: 'ExponentPushToken[skusku]' };
 
     await UsersHelper.updateUser(userId, payload, credentials);
 
     sinon.assert.calledOnceWithExactly(
       userUpdateOne,
       { _id: userId, company: credentials.company._id },
-      { $push: { expoTokens: 'ExponentPushToken[skusku]' } }
+      { $push: { formationExpoTokens: 'ExponentPushToken[skusku]' } }
     );
     sinon.assert.notCalled(createHelper);
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -1113,6 +1113,21 @@ describe('updateUser', () => {
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);
   });
 
+  it('should push an expoToken to expoTokens', async () => {
+    const payload = { expoToken: 'ExponentPushToken[skusku]' };
+
+    await UsersHelper.updateUser(userId, payload, credentials);
+
+    sinon.assert.calledOnceWithExactly(
+      userUpdateOne,
+      { _id: userId, company: credentials.company._id },
+      { $push: { expoTokens: 'ExponentPushToken[skusku]' } }
+    );
+    sinon.assert.notCalled(createHelper);
+    sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);
+    sinon.assert.notCalled(roleFindById);
+  });
+
   it('should return a 400 error if role does not exists', async () => {
     const payload = { role: new ObjectID() };
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
    - Les modifications du preHandler ne sont pas des breakings changes. On passe un nouveau champ formationExpoToken à la route PUT /users/_id (seule la dernière version de l'app envoie ce champ). Le preHandler ne fait de nouvelle vérification que si le payload contient ce champ. Donc chaque version de l'app peut fonctionner avec cette version de l'API. (ce n'est pas le cas dans l'autre sens: envoyer formationExpoToken sur une ancienne version du back va renvoyer une 400.)
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [x] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [x] J'ai géré le cas où l'application ne l'envoie pas
  - ~~J'ai rendu obligatoire un champs :~~
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - ~~J'ai retiré un champ possible :~~
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : mobile

- Périmetre roles : tous

- Cas d'usage : 
Ajout des notifications sur l'app mobile formation.
On vient stocker l'expoToken, qui est un token **unique** par téléphone pour l'application formation. Ainsi, on vient stocker le nouveau token dans une array, car un utilisateur peut avoir plusieurs expoToken (s'il a 2 téléphones).
