### PR TITLE
Com 2036

### DIFF
--- a/src/controllers/questionnaireController.js
+++ b/src/controllers/questionnaireController.js
@@ -94,4 +94,15 @@ const getUserQuestionnaires = async (req) => {
   }
 };
 
-module.exports = { list, create, getById, update, addCard, removeCard, getUserQuestionnaires };
+const getFollowUp = async (req) => {
+  try {
+    const followUp = await QuestionnaireHelper.getFollowUp(req.params._id, req.query.course);
+
+    return { message: translate[language].questionnaireFound, data: { followUp } };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { list, create, getById, update, addCard, removeCard, getUserQuestionnaires, getFollowUp };

--- a/src/helpers/courses.js
+++ b/src/helpers/courses.js
@@ -540,7 +540,7 @@ exports.generateConvocationPdf = async (courseId) => {
 exports.getQuestionnaires = async (courseId) => {
   const questionnaires = await Questionnaire.find({ status: { $ne: DRAFT } })
     .select('type name')
-    .populate({ path: 'historiesCount', match: { course: courseId } })
+    .populate({ path: 'historiesCount', match: { course: courseId, questionnaireAnswersList: { $ne: [] } } })
     .lean();
 
   return questionnaires.filter(questionnaire => questionnaire.historiesCount);

--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -39,12 +39,7 @@ exports.getUserQuestionnaires = async (course, credentials) => {
 exports.getFollowUp = async (id, courseId) => {
   const course = await Course.findOne({ _id: courseId })
     .select('subProgram company misc')
-    .populate({
-      path: 'subProgram',
-      select: 'program',
-      populate: [
-        { path: 'program', select: 'name' }],
-    })
+    .populate({ path: 'subProgram', select: 'program', populate: [{ path: 'program', select: 'name' }] })
     .populate({ path: 'company', select: 'name' })
     .lean();
 
@@ -69,9 +64,11 @@ exports.getFollowUp = async (id, courseId) => {
   }
 
   return {
-    programName: course.subProgram.program.name,
-    companyName: course.company.name,
-    misc: course.misc,
+    course: {
+      programName: course.subProgram.program.name,
+      companyName: course.company.name,
+      misc: course.misc,
+    },
     questionnaire: { type: questionnaire.type, name: questionnaire.name },
     followUp: Object.values(followUp),
   };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -1,6 +1,13 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const { DRAFT, TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN, PUBLISHED } = require('../../helpers/constants');
+const {
+  DRAFT,
+  TRAINING_ORGANISATION_MANAGER,
+  VENDOR_ADMIN,
+  PUBLISHED,
+  TRAINER,
+  BLENDED,
+} = require('../../helpers/constants');
 const translate = require('../../helpers/translate');
 const Questionnaire = require('../../models/Questionnaire');
 const Card = require('../../models/Card');
@@ -67,6 +74,17 @@ exports.authorizeCardDeletion = async (req) => {
 
   const questionnaire = await Questionnaire.countDocuments({ cards: req.params.cardId, status: PUBLISHED });
   if (questionnaire) throw Boom.forbidden();
+
+  return null;
+};
+
+exports.authorizeGetFollowUp = async (req) => {
+  const credentials = get(req, 'auth.credentials');
+  const countQuery = get(credentials, 'role.vendor.name') === TRAINER
+    ? { _id: req.query.course, format: BLENDED, trainer: credentials._id }
+    : { _id: req.query.course, format: BLENDED };
+  const course = await Course.countDocuments(countQuery);
+  if (!course) throw Boom.notFound();
 
   return null;
 };

--- a/src/routes/preHandlers/questionnaires.js
+++ b/src/routes/preHandlers/questionnaires.js
@@ -84,7 +84,8 @@ exports.authorizeGetFollowUp = async (req) => {
     ? { _id: req.query.course, format: BLENDED, trainer: credentials._id }
     : { _id: req.query.course, format: BLENDED };
   const course = await Course.countDocuments(countQuery);
-  if (!course) throw Boom.notFound();
+  const questionnaire = await Questionnaire.countDocuments({ _id: req.params._id });
+  if (!course || !questionnaire) throw Boom.notFound();
 
   return null;
 };

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -10,6 +10,7 @@ const {
   addCard,
   removeCard,
   getUserQuestionnaires,
+  getFollowUp,
 } = require('../controllers/questionnaireController');
 const {
   authorizeQuestionnaireGet,
@@ -17,6 +18,7 @@ const {
   authorizeQuestionnaireEdit,
   authorizeCardDeletion,
   authorizeUserQuestionnairesGet,
+  authorizeGetFollowUp,
 } = require('./preHandlers/questionnaires');
 const { CARD_TEMPLATES } = require('../models/Card');
 const { PUBLISHED } = require('../helpers/constants');
@@ -57,6 +59,19 @@ exports.plugin = {
         pre: [{ method: authorizeUserQuestionnairesGet, assign: 'course' }],
       },
       handler: getUserQuestionnaires,
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/{_id}/follow-up',
+      options: {
+        validate: {
+          query: Joi.object({ course: Joi.objectId().required() }),
+        },
+        auth: { scope: ['questionnaires:read'] },
+        pre: [{ method: authorizeGetFollowUp }],
+      },
+      handler: getFollowUp,
     });
 
     server.route({

--- a/src/routes/questionnaires.js
+++ b/src/routes/questionnaires.js
@@ -66,6 +66,7 @@ exports.plugin = {
       path: '/{_id}/follow-up',
       options: {
         validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
           query: Joi.object({ course: Joi.objectId().required() }),
         },
         auth: { scope: ['questionnaires:read'] },

--- a/tests/integration/questionnaires.test.js
+++ b/tests/integration/questionnaires.test.js
@@ -270,6 +270,127 @@ describe('QUESTIONNAIRES ROUTES - GET /questionnaires/user', () => {
   });
 });
 
+describe('QUESTIONNAIRE ROUTES - GET /questionnaires/{_id}/follow-up', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('TRAINER', () => {
+    beforeEach(async () => {
+      authToken = await getToken('trainer');
+    });
+
+    it('should get questionnaire answers', async () => {
+      const questionnaireId = questionnairesList[0]._id;
+      const courseId = coursesList[0]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=${courseId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 400 if questionnaire has invalid type', async () => {
+      const courseId = coursesList[0]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/test/follow-up?course=${courseId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if course has invalid type', async () => {
+      const questionnaireId = questionnairesList[0]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=test`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 if questionnaire doesn\'t exist', async () => {
+      const courseId = coursesList[0]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${new ObjectID()}/follow-up?course=${courseId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 404 if course doesn\'t exist', async () => {
+      const questionnaireId = questionnairesList[0]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 404 if course is strictly e-learning', async () => {
+      const questionnaireId = questionnairesList[0]._id;
+      const courseId = coursesList[1]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=${courseId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 404 as user is trainer, but not course trainer', async () => {
+      const questionnaireId = questionnairesList[0]._id;
+      const courseId = coursesList[2]._id;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=${courseId.toHexString()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary', expectedCode: 403 },
+      { name: 'coach', expectedCode: 403 },
+    ];
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const questionnaireId = questionnairesList[0]._id;
+        const courseId = coursesList[0]._id;
+
+        const response = await app.inject({
+          method: 'GET',
+          url: `/questionnaires/${questionnaireId.toHexString()}/follow-up?course=${courseId.toHexString()}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});
+
 describe('QUESTIONNAIRES ROUTES - PUT /questionnaires/{_id}', () => {
   let authToken = null;
   beforeEach(populateDB);

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -34,21 +34,9 @@ const questionnairesList = [
 
 const courseTrainer = userList.find(user => user.role.vendor === rolesList.find(role => role.name === 'trainer')._id);
 
-const subProgramsList = [
-  {
-    _id: new ObjectID(),
-    name: 'sous-programme',
-    steps: [new ObjectID()],
-  },
-];
+const subProgramsList = [{ _id: new ObjectID(), name: 'sous-programme', steps: [new ObjectID()] }];
 
-const programsList = [
-  {
-    _id: new ObjectID(),
-    name: 'test',
-    subPrograms: [subProgramsList[0]._id],
-  },
-];
+const programsList = [{ _id: new ObjectID(), name: 'test', subPrograms: [subProgramsList[0]._id] }];
 
 const coursesList = [
   {

--- a/tests/integration/seed/questionnairesSeed.js
+++ b/tests/integration/seed/questionnairesSeed.js
@@ -3,7 +3,9 @@ const Questionnaire = require('../../../src/models/Questionnaire');
 const Card = require('../../../src/models/Card');
 const Course = require('../../../src/models/Course');
 const CourseSlot = require('../../../src/models/CourseSlot');
-const { populateDBForAuthentication } = require('./authenticationSeed');
+const SubProgram = require('../../../src/models/SubProgram');
+const Program = require('../../../src/models/Program');
+const { populateDBForAuthentication, rolesList, userList, authCompany } = require('./authenticationSeed');
 const { TRANSITION, OPEN_QUESTION } = require('../../../src/helpers/constants');
 
 const cardsList = [
@@ -30,13 +32,51 @@ const questionnairesList = [
   },
 ];
 
-const coursesList = [{
-  _id: new ObjectID(),
-  format: 'blended',
-  subProgram: new ObjectID(),
-  type: 'inter_b2b',
-  salesRepresentative: new ObjectID(),
-}];
+const courseTrainer = userList.find(user => user.role.vendor === rolesList.find(role => role.name === 'trainer')._id);
+
+const subProgramsList = [
+  {
+    _id: new ObjectID(),
+    name: 'sous-programme',
+    steps: [new ObjectID()],
+  },
+];
+
+const programsList = [
+  {
+    _id: new ObjectID(),
+    name: 'test',
+    subPrograms: [subProgramsList[0]._id],
+  },
+];
+
+const coursesList = [
+  {
+    _id: new ObjectID(),
+    format: 'blended',
+    subProgram: subProgramsList[0]._id,
+    type: 'inter_b2b',
+    salesRepresentative: new ObjectID(),
+    trainer: courseTrainer._id,
+    company: authCompany._id,
+  },
+  {
+    _id: new ObjectID(),
+    format: 'strictly_e_learning',
+    subProgram: new ObjectID(),
+    type: 'inter_b2b',
+    salesRepresentative: new ObjectID(),
+    trainer: courseTrainer._id,
+  },
+  {
+    _id: new ObjectID(),
+    format: 'blended',
+    subProgram: new ObjectID(),
+    type: 'inter_b2b',
+    salesRepresentative: new ObjectID(),
+    trainer: new ObjectID(),
+  },
+];
 
 const slots = [{
   startDate: new Date('2021-04-20T09:00:00'),
@@ -50,6 +90,8 @@ const populateDB = async () => {
   await Card.deleteMany({});
   await Course.deleteMany({});
   await CourseSlot.deleteMany({});
+  await SubProgram.deleteMany({});
+  await Program.deleteMany({});
 
   await populateDBForAuthentication();
 
@@ -57,6 +99,8 @@ const populateDB = async () => {
   await Card.insertMany(cardsList);
   await Course.insertMany(coursesList);
   await CourseSlot.insertMany(slots);
+  await SubProgram.insertMany(subProgramsList);
+  await Program.insertMany(programsList);
 };
 
 module.exports = {

--- a/tests/unit/helpers/courses.test.js
+++ b/tests/unit/helpers/courses.test.js
@@ -2086,7 +2086,10 @@ describe('getQuestionnaires', () => {
       [
         { query: 'find', args: [{ status: { $ne: DRAFT } }] },
         { query: 'select', args: ['type name'] },
-        { query: 'populate', args: [{ path: 'historiesCount', match: { course: courseId } }] },
+        {
+          query: 'populate',
+          args: [{ path: 'historiesCount', match: { course: courseId, questionnaireAnswersList: { $ne: [] } } }],
+        },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -365,9 +365,107 @@ describe('getFollowUp', () => {
       histories: [{
         _id: new ObjectID(),
         course: course._id,
+        questionnaireAnswersList: [
+          {
+            card: {
+              _id: new ObjectID(),
+              template: 'open_question',
+              isMandatory: true,
+              question: 'aimez-vous ce test ?',
+            },
+            answerList: ['blabla'],
+          },
+          {
+            card: {
+              _id: new ObjectID(),
+              template: 'survey',
+              isMandatory: true,
+              question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
+              label: { left: '1', right: '5' },
+            },
+            answerList: ['3'],
+          },
+        ],
+      }],
+    };
+
+    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+
+    const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
+
+    expect(result).toMatchObject({
+      course: {
+        programName: 'test',
+        companyName: 'company',
+        misc: 'infos',
+      },
+      questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
+      followUp: [
+        {
+          answers: ['blabla'],
+          isMandatory: true,
+          question: 'aimez-vous ce test ?',
+          template: 'open_question',
+        },
+        {
+          answers: ['3'],
+          isMandatory: true,
+          question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
+          template: 'survey',
+          label: { left: '1', right: '5' },
+        },
+      ],
+    });
+    SinonMongoose.calledWithExactly(
+      courseFindOne,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'select', args: ['subProgram company misc'] },
+        {
+          query: 'populate',
+          args: [{ path: 'subProgram', select: 'program', populate: [{ path: 'program', select: 'name' }] }],
+        },
+        { query: 'populate', args: [{ path: 'company', select: 'name' }] },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      questionnaireFindOne,
+      [
+        { query: 'findOne', args: [{ _id: questionnaireId }] },
+        { query: 'select', args: ['type name'] },
+        {
+          query: 'populate',
+          args: [{
+            path: 'histories',
+            match: { course: courseId },
+            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+          }],
+        },
+        { query: 'lean' },
+      ]
+    );
+  });
+  it('should return an empty array for followUp if answer is empty', async () => {
+    const questionnaireId = new ObjectID();
+    const courseId = new ObjectID();
+    const course = {
+      _id: courseId,
+      company: { name: 'company' },
+      subProgram: { program: { name: 'test' } },
+      misc: 'infos',
+    };
+    const questionnaire = {
+      _id: questionnaireId,
+      type: EXPECTATIONS,
+      name: 'questionnaire',
+      histories: [{
+        _id: new ObjectID(),
+        course: course._id,
         questionnaireAnswersList: [{
           card: { _id: new ObjectID(), template: 'open_question', isMandatory: true, question: 'aimez-vous ce test ?' },
-          answerList: ['blabla'],
+          answerList: [''],
         }],
       }],
     };
@@ -378,18 +476,13 @@ describe('getFollowUp', () => {
     const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
 
     expect(result).toMatchObject({
-      programName: 'test',
-      companyName: 'company',
-      misc: 'infos',
+      course: {
+        programName: 'test',
+        companyName: 'company',
+        misc: 'infos',
+      },
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
-      followUp: [
-        {
-          answers: ['blabla'],
-          isMandatory: true,
-          question: 'aimez-vous ce test ?',
-          template: 'open_question',
-        },
-      ],
+      followUp: [],
     });
     SinonMongoose.calledWithExactly(
       courseFindOne,


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : ROF/admin/formateur

- Cas d'usage : je peux consulter les réponses au questionnaire de recueil des attentes
Pour tester : créer un questionnaire avec des cartes SURVEY, QUESTION_ANSWERS, OPEN_QUESTION et répondre pour 2-3 utilisateurs
