### PR TITLE
COM-2041: allow title edition

### DIFF
--- a/src/routes/preHandlers/activities.js
+++ b/src/routes/preHandlers/activities.js
@@ -6,7 +6,7 @@ const { PUBLISHED } = require('../../helpers/constants');
 exports.authorizeActivityUpdate = async (req) => {
   const activity = await Activity.findOne({ _id: req.params._id }).lean();
   if (!activity) throw Boom.notFound();
-  if (activity.status === PUBLISHED) throw Boom.forbidden();
+  if (activity.status === PUBLISHED && Object.keys(req.payload).some(key => key !== 'name')) throw Boom.forbidden();
 
   const { cards } = req.payload;
   if (cards) {

--- a/src/routes/preHandlers/steps.js
+++ b/src/routes/preHandlers/steps.js
@@ -6,7 +6,7 @@ const { PUBLISHED } = require('../../helpers/constants');
 exports.authorizeStepUpdate = async (req) => {
   const step = await Step.findOne({ _id: req.params._id }).lean();
   if (!step) throw Boom.notFound();
-  if (step.status === PUBLISHED) throw Boom.forbidden();
+  if (step.status === PUBLISHED && Object.keys(req.payload).some(key => key !== 'name')) throw Boom.forbidden();
 
   const { activities } = req.payload;
   if (activities) {

--- a/tests/integration/activities.test.js
+++ b/tests/integration/activities.test.js
@@ -118,10 +118,19 @@ describe('ACTIVITY ROUTES - PUT /activity/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      const activityUpdated = await Activity.findById(activityId).lean();
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should update activity\'s name if activity is published', async () => {
+      const payload = { name: 'rigoler' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/activities/${activitiesList[3]._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
 
       expect(response.statusCode).toBe(200);
-      expect(activityUpdated).toEqual(expect.objectContaining({ _id: activityId, name: 'rigoler' }));
     });
 
     it('should update cards', async () => {
@@ -193,7 +202,7 @@ describe('ACTIVITY ROUTES - PUT /activity/{_id}', () => {
     });
 
     it('should return a 403 if activity is published', async () => {
-      const payload = { name: 'rigoler' };
+      const payload = { type: 'quiz' };
       const response = await app.inject({
         method: 'PUT',
         url: `/activities/${activitiesList[3]._id.toHexString()}`,

--- a/tests/integration/steps.test.js
+++ b/tests/integration/steps.test.js
@@ -35,6 +35,18 @@ describe('STEPS ROUTES - PUT /steps/{_id}', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('should update step name if step is published', async () => {
+      const payload = { name: 'une nouvelle étape super innovant' };
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/steps/${stepsList[3]._id.toHexString()}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     it('should update activities', async () => {
       const payload = { activities: [stepsList[0].activities[1], stepsList[0].activities[0]] };
       const response = await app.inject({


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : je peux modifier le titre d'une étape publiée ou d'une activité publiée
