### PR TITLE
COM-2039: minor bug

### DIFF
--- a/src/helpers/questionnaires.js
+++ b/src/helpers/questionnaires.js
@@ -88,7 +88,7 @@ exports.getFollowUp = async (id, courseId) => {
   return {
     course: {
       programName: course.subProgram.program.name,
-      companyName: course.company.name,
+      companyName: get(course, 'company.name') || '',
       misc: course.misc,
     },
     questionnaire: { type: questionnaire.type, name: questionnaire.name },

--- a/tests/unit/helpers/questionnaires.test.js
+++ b/tests/unit/helpers/questionnaires.test.js
@@ -508,7 +508,7 @@ describe('getFollowUp', () => {
     questionnaireFindOne.restore();
   });
 
-  it('should return follow up', async () => {
+  it('should return follow up for intra course', async () => {
     const questionnaireId = new ObjectID();
     const courseId = new ObjectID();
     const course = {
@@ -585,6 +585,132 @@ describe('getFollowUp', () => {
       course: {
         programName: 'test',
         companyName: 'company',
+        misc: 'infos',
+      },
+      questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },
+      followUp: [
+        {
+          answers: ['blabla', 'test test'],
+          isMandatory: true,
+          question: 'aimez-vous ce test ?',
+          template: 'open_question',
+        },
+        {
+          answers: ['3', '2'],
+          isMandatory: true,
+          question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
+          template: 'survey',
+          label: { left: '1', right: '5' },
+        },
+      ],
+    });
+    SinonMongoose.calledWithExactly(
+      courseFindOne,
+      [
+        { query: 'findOne', args: [{ _id: courseId }] },
+        { query: 'select', args: ['subProgram company misc'] },
+        {
+          query: 'populate',
+          args: [{ path: 'subProgram', select: 'program', populate: [{ path: 'program', select: 'name' }] }],
+        },
+        { query: 'populate', args: [{ path: 'company', select: 'name' }] },
+        { query: 'lean' },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      questionnaireFindOne,
+      [
+        { query: 'findOne', args: [{ _id: questionnaireId }] },
+        { query: 'select', args: ['type name'] },
+        {
+          query: 'populate',
+          args: [{
+            path: 'histories',
+            match: { course: courseId },
+            populate: { path: 'questionnaireAnswersList.card', select: '-createdAt -updatedAt' },
+          }],
+        },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should return follow up for inter b2b course', async () => {
+    const questionnaireId = new ObjectID();
+    const courseId = new ObjectID();
+    const course = {
+      _id: courseId,
+      subProgram: { program: { name: 'test' } },
+      misc: 'infos',
+    };
+    const cardsIds = [new ObjectID(), new ObjectID()];
+    const questionnaire = {
+      _id: questionnaireId,
+      type: EXPECTATIONS,
+      name: 'questionnaire',
+      histories: [
+        {
+          _id: new ObjectID(),
+          course: course._id,
+          questionnaireAnswersList: [
+            {
+              card: {
+                _id: cardsIds[0],
+                template: 'open_question',
+                isMandatory: true,
+                question: 'aimez-vous ce test ?',
+              },
+              answerList: ['blabla'],
+            },
+            {
+              card: {
+                _id: cardsIds[1],
+                template: 'survey',
+                isMandatory: true,
+                question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
+                label: { left: '1', right: '5' },
+              },
+              answerList: ['3'],
+            },
+          ],
+        },
+        {
+          _id: new ObjectID(),
+          course: course._id,
+          questionnaireAnswersList: [
+            {
+              card: {
+                _id: cardsIds[0],
+                template: 'open_question',
+                isMandatory: true,
+                question: 'aimez-vous ce test ?',
+              },
+              answerList: ['test test'],
+            },
+            {
+              card: {
+                _id: cardsIds[1],
+                template: 'survey',
+                isMandatory: true,
+                question: 'combien aimez vous ce test sur une échelle de 1 à 5 ?',
+                label: { left: '1', right: '5' },
+              },
+              answerList: ['2'],
+            },
+          ],
+        },
+      ],
+    };
+
+    courseFindOne.returns(SinonMongoose.stubChainedQueries([course], ['select', 'populate', 'lean']));
+    questionnaireFindOne.returns(SinonMongoose.stubChainedQueries([questionnaire], ['select', 'populate', 'lean']));
+
+    const result = await QuestionnaireHelper.getFollowUp(questionnaireId, courseId);
+
+    expect(result).toMatchObject({
+      course: {
+        programName: 'test',
+        companyName: '',
         misc: 'infos',
       },
       questionnaire: { type: EXPECTATIONS, name: 'questionnaire' },


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement 

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : formateur/admin

- Cas d'usage : bug dû à l'abscence de company pour les formations inter
Tester : réponse d'un questionnaire de début et de fin de formation sur une formation inter et intra 
