### PR TITLE
Com 2050

### DIFF
--- a/tests/unit/helpers/distanceMatrix.test.js
+++ b/tests/unit/helpers/distanceMatrix.test.js
@@ -32,10 +32,7 @@ describe('getDistanceMatrices', () => {
     const result = await DistanceMatrixHelper.getDistanceMatrices(credentials);
 
     expect(result).toEqual(distanceMatrix);
-    SinonMongoose.calledWithExactly(
-      find,
-      [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
-    );
+    SinonMongoose.calledWithExactly(find, [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]);
   });
 });
 

--- a/tests/unit/helpers/distanceMatrix.test.js
+++ b/tests/unit/helpers/distanceMatrix.test.js
@@ -6,8 +6,7 @@ const _ = require('lodash');
 const DistanceMatrixHelper = require('../../../src/helpers/distanceMatrix');
 const DistanceMatrix = require('../../../src/models/DistanceMatrix');
 const maps = require('../../../src/models/Google/Maps');
-
-require('sinon-mongoose');
+const SinonMongoose = require('../sinonMongoose');
 
 describe('getDistanceMatrices', () => {
   const distanceMatrix = {
@@ -17,23 +16,26 @@ describe('getDistanceMatrices', () => {
     status: 200,
   };
   const companyId = new ObjectID();
-  let DistanceMatrixModel;
+  let find;
 
   beforeEach(() => {
-    DistanceMatrixModel = sinon.mock(DistanceMatrix);
+    find = sinon.stub(DistanceMatrix, 'find');
   });
   afterEach(() => {
-    DistanceMatrixModel.restore();
+    find.restore();
   });
 
   it('should return a distance matrix', async () => {
-    DistanceMatrixModel.expects('find').withExactArgs({ company: companyId }).chain('lean').returns(distanceMatrix);
+    find.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
 
     const credentials = { company: { _id: companyId } };
     const result = await DistanceMatrixHelper.getDistanceMatrices(credentials);
 
     expect(result).toEqual(distanceMatrix);
-    DistanceMatrixModel.verify();
+    SinonMongoose.calledWithExactly(
+      find,
+      [{ query: 'find', args: [{ company: companyId }] }, { query: 'lean' }]
+    );
   });
 });
 

--- a/tests/unit/helpers/mandates.test.js
+++ b/tests/unit/helpers/mandates.test.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const expect = require('expect');
 const flat = require('flat');
 const { ObjectID } = require('mongodb');
+const { fn: momentProto } = require('moment');
 const Customer = require('../../../src/models/Customer');
 const Drive = require('../../../src/models/Google/Drive');
 const ESign = require('../../../src/models/ESign');
@@ -9,72 +10,93 @@ const GDriveStorageHelper = require('../../../src/helpers/gDriveStorage');
 const MandatesHelper = require('../../../src/helpers/mandates');
 const ESignHelper = require('../../../src/helpers/eSign');
 const FileHelper = require('../../../src/helpers/file');
+const SinonMongoose = require('../sinonMongoose');
 
 require('sinon-mongoose');
 
 describe('getMandates', () => {
-  let CustomerMock;
+  let findOneCustomer;
   beforeEach(() => {
-    CustomerMock = sinon.mock(Customer);
+    findOneCustomer = sinon.stub(Customer, 'findOne');
   });
   afterEach(() => {
-    CustomerMock.restore();
+    findOneCustomer.restore();
   });
 
   it('should return customer mandates', async () => {
     const customerId = (new ObjectID()).toHexString();
-    CustomerMock.expects('findOne')
-      .withExactArgs(
-        { _id: customerId, 'payment.mandates': { $exists: true } },
-        { identity: 1, 'payment.mandates': 1 },
-        { autopopulate: false }
-      )
-      .chain('lean')
-      .once();
+    const mandate = { _id: new ObjectID() };
 
-    await MandatesHelper.getMandates(customerId);
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries([mandate], ['lean']));
 
-    CustomerMock.verify();
+    const result = await MandatesHelper.getMandates(customerId);
+
+    expect(result).toMatchObject(mandate);
+    SinonMongoose.calledWithExactly(
+      findOneCustomer,
+      [
+        {
+          query: 'findOne',
+          args: [
+            { _id: customerId, 'payment.mandates': { $exists: true } },
+            { identity: 1, 'payment.mandates': 1 },
+            { autopopulate: false },
+          ],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
 describe('updateMandate', () => {
-  let CustomerMock;
+  let findOneAndUpdateCustomer;
   beforeEach(() => {
-    CustomerMock = sinon.mock(Customer);
+    findOneAndUpdateCustomer = sinon.stub(Customer, 'findOneAndUpdate');
   });
   afterEach(() => {
-    CustomerMock.restore();
+    findOneAndUpdateCustomer.restore();
   });
 
   it('should update customer mandates', async () => {
     const customerId = (new ObjectID()).toHexString();
     const mandateId = '1234567890';
     const payload = { startDate: '2019-12-12T00:00:00' };
-    CustomerMock.expects('findOneAndUpdate')
-      .withExactArgs(
-        { _id: customerId, 'payment.mandates._id': mandateId },
-        { $set: flat({ 'payment.mandates.$': { ...payload } }) },
-        { new: true, select: { identity: 1, 'payment.mandates': 1 }, autopopulate: false }
-      )
-      .chain('lean')
-      .once();
 
-    await MandatesHelper.updateMandate(customerId, mandateId, payload);
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([{ ...payload, _id: mandateId }], ['lean']));
 
-    CustomerMock.verify();
+    const result = await MandatesHelper.updateMandate(customerId, mandateId, payload);
+
+    expect(result).toMatchObject({ ...payload, _id: mandateId });
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdateCustomer,
+      [
+        {
+          query: 'findOneAndUpdate',
+          args: [
+            { _id: customerId, 'payment.mandates._id': mandateId },
+            { $set: flat({ 'payment.mandates.$': { ...payload } }) },
+            { new: true, select: { identity: 1, 'payment.mandates': 1 }, autopopulate: false },
+          ],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
 describe('getSignatureRequest', () => {
-  let CustomerMock;
+  let findOneCustomer;
+  let updateOneCustomer;
   let generateSignatureRequest;
   beforeEach(() => {
-    CustomerMock = sinon.mock(Customer);
+    findOneCustomer = sinon.stub(Customer, 'findOne');
+    updateOneCustomer = sinon.stub(Customer, 'updateOne');
     generateSignatureRequest = sinon.stub(ESignHelper, 'generateSignatureRequest');
   });
   afterEach(() => {
-    CustomerMock.restore();
+    findOneCustomer.restore();
+    updateOneCustomer.restore();
     generateSignatureRequest.restore();
   });
 
@@ -93,32 +115,35 @@ describe('getSignatureRequest', () => {
       _id: customerId,
       payment: { mandates: [{ _id: new ObjectID() }, { _id: mandateId, rum: 'rum' }] },
     };
-
-    CustomerMock.expects('findOne')
-      .withExactArgs({ _id: customerId, 'payment.mandates._id': mandateId.toHexString() }, { payment: 1 })
-      .chain('lean')
-      .once()
-      .returns(customer);
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
     generateSignatureRequest.returns({
       data: { document_hash: 'document_hash', signers: [{ embedded_signing_url: 'embedded_signing_url' }] },
     });
-    CustomerMock.expects('updateOne')
-      .withExactArgs(
-        { _id: customerId, 'payment.mandates._id': mandateId.toHexString() },
-        { $set: flat({ 'payment.mandates.$.everSignId': 'document_hash' }) }
-      )
-      .once();
 
     const result = await MandatesHelper.getSignatureRequest(customerId, mandateId.toHexString(), payload);
 
     expect(result).toEqual({ embeddedUrl: 'embedded_signing_url' });
-    CustomerMock.verify();
+    sinon.assert.calledOnceWithExactly(
+      updateOneCustomer,
+      { _id: customerId, 'payment.mandates._id': mandateId.toHexString() },
+      { $set: flat({ 'payment.mandates.$.everSignId': 'document_hash' }) }
+    );
+    SinonMongoose.calledWithExactly(
+      findOneCustomer,
+      [
+        {
+          query: 'findOne',
+          args: [{ _id: customerId, 'payment.mandates._id': mandateId.toHexString() }, { payment: 1 }],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should throw error if error on generate', async () => {
+    const customerId = (new ObjectID()).toHexString();
+    const mandateId = new ObjectID();
     try {
-      const customerId = (new ObjectID()).toHexString();
-      const mandateId = new ObjectID();
       const payload = {
         fileId: 'fileId',
         fields: 'fields',
@@ -132,45 +157,56 @@ describe('getSignatureRequest', () => {
         payment: { mandates: [{ _id: new ObjectID() }, { _id: mandateId, rum: 'rum' }] },
       };
 
-      CustomerMock.expects('findOne')
-        .withExactArgs({ _id: customerId, 'payment.mandates._id': mandateId.toHexString() }, { payment: 1 })
-        .chain('lean')
-        .once()
-        .returns(customer);
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
       generateSignatureRequest.returns({ data: { error: 'error' } });
-      CustomerMock.expects('updateOne').never();
 
       await MandatesHelper.getSignatureRequest(customerId, mandateId.toHexString(), payload);
     } catch (e) {
       expect(e.output.statusCode).toEqual(400);
     } finally {
-      CustomerMock.verify();
+      sinon.assert.notCalled(updateOneCustomer);
+      SinonMongoose.calledWithExactly(
+        findOneCustomer,
+        [
+          {
+            query: 'findOne',
+            args: [{ _id: customerId, 'payment.mandates._id': mandateId.toHexString() }, { payment: 1 }],
+          },
+          { query: 'lean' },
+        ]
+      );
     }
   });
 });
 
 describe('saveSignedMandate', () => {
-  let CustomerMock;
+  let findOneCustomer;
+  let findOneAndUpdateCustomer;
   let getDocument;
   let downloadFinalDocument;
   let createAndReadFile;
   let addFile;
   let getFileById;
+  let momentToDate;
   beforeEach(() => {
-    CustomerMock = sinon.mock(Customer);
+    findOneCustomer = sinon.stub(Customer, 'findOne');
+    findOneAndUpdateCustomer = sinon.stub(Customer, 'findOneAndUpdate');
     getDocument = sinon.stub(ESign, 'getDocument');
     downloadFinalDocument = sinon.stub(ESign, 'downloadFinalDocument');
     createAndReadFile = sinon.stub(FileHelper, 'createAndReadFile');
     addFile = sinon.stub(GDriveStorageHelper, 'addFile');
     getFileById = sinon.stub(Drive, 'getFileById');
+    momentToDate = sinon.stub(momentProto, 'toDate');
   });
   afterEach(() => {
-    CustomerMock.restore();
+    findOneCustomer.restore();
+    findOneAndUpdateCustomer.restore();
     getDocument.restore();
     downloadFinalDocument.restore();
     createAndReadFile.restore();
     addFile.restore();
     getFileById.restore();
+    momentToDate.restore();
   });
 
   it('should save signed mandate', async () => {
@@ -181,20 +217,16 @@ describe('saveSignedMandate', () => {
       payment: { mandates: [{ _id: mandateId, everSignId: 'everSignId', rum: 'rum' }] },
       driveFolder: { driveId: 'driveFolder' },
     };
-    CustomerMock.expects('findOne')
-      .withExactArgs({ _id: customerId })
-      .chain('lean')
-      .once()
-      .returns(customer);
+    const drive = { driveId: 'fileId', link: 'webViewLink' };
+
+    findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([], ['lean']));
     getDocument.returns({ data: { log: [{ event: 'document_signed' }] } });
     downloadFinalDocument.returns({ data: 'data' });
     createAndReadFile.returns('file');
     addFile.returns({ id: 'fileId' });
     getFileById.returns({ webViewLink: 'webViewLink' });
-    CustomerMock.expects('findOneAndUpdate')
-      .chain('lean')
-      .once()
-      .returns(customer);
+    momentToDate.returns('2020-12-08T13:45:25.437Z');
 
     await MandatesHelper.saveSignedMandate(customerId, mandateId.toHexString());
 
@@ -206,25 +238,37 @@ describe('saveSignedMandate', () => {
       { driveFolderId: 'driveFolder', name: 'rum', type: 'application/pdf', body: 'file' }
     );
     sinon.assert.calledWithExactly(getFileById, { fileId: 'fileId' });
-    CustomerMock.verify();
+    SinonMongoose.calledWithExactly(
+      findOneCustomer,
+      [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdateCustomer,
+      [
+        {
+          query: 'findOneAndUpdate',
+          args: [
+            { _id: customerId, 'payment.mandates._id': mandateId.toHexString() },
+            { $set: flat({ 'payment.mandates.$': { drive, signedAt: '2020-12-08T13:45:25.437Z' } }) },
+          ],
+        },
+        { query: 'lean' },
+      ]
+    );
   });
 
   it('should throw an error if esign returns an error', async () => {
+    const customerId = '1234567890';
     try {
-      const customerId = '1234567890';
       const mandateId = new ObjectID();
       const customer = {
         _id: customerId,
         payment: { mandates: [{ _id: mandateId, everSignId: 'everSignId', rum: 'rum' }] },
         driveFolder: { driveId: 'driveFolder' },
       };
-      CustomerMock.expects('findOne')
-        .withExactArgs({ _id: customerId })
-        .chain('lean')
-        .once()
-        .returns(customer);
+
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
       getDocument.returns({ data: { error: 'error', log: [{ event: 'document_signed' }] } });
-      CustomerMock.expects('findOneAndUpdate').never();
 
       await MandatesHelper.saveSignedMandate(customerId, mandateId.toHexString());
     } catch (e) {
@@ -235,26 +279,26 @@ describe('saveSignedMandate', () => {
       sinon.assert.notCalled(createAndReadFile);
       sinon.assert.notCalled(addFile);
       sinon.assert.notCalled(getFileById);
-      CustomerMock.verify();
+      sinon.assert.notCalled(findOneAndUpdateCustomer);
+      SinonMongoose.calledWithExactly(
+        findOneCustomer,
+        [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
+      );
     }
   });
 
   it('should throw an error if no signed doc in esign response', async () => {
+    const customerId = '1234567890';
     try {
-      const customerId = '1234567890';
       const mandateId = new ObjectID();
       const customer = {
         _id: customerId,
         payment: { mandates: [{ _id: mandateId, everSignId: 'everSignId', rum: 'rum' }] },
         driveFolder: { driveId: 'driveFolder' },
       };
-      CustomerMock.expects('findOne')
-        .withExactArgs({ _id: customerId })
-        .chain('lean')
-        .once()
-        .returns(customer);
+
+      findOneCustomer.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
       getDocument.returns({ data: { log: [{ event: 'document_not_signed' }] } });
-      CustomerMock.expects('findOneAndUpdate').never();
 
       await MandatesHelper.saveSignedMandate(customerId, mandateId.toHexString());
     } catch (e) {
@@ -265,7 +309,11 @@ describe('saveSignedMandate', () => {
       sinon.assert.notCalled(createAndReadFile);
       sinon.assert.notCalled(addFile);
       sinon.assert.notCalled(getFileById);
-      CustomerMock.verify();
+      sinon.assert.notCalled(findOneAndUpdateCustomer);
+      SinonMongoose.calledWithExactly(
+        findOneCustomer,
+        [{ query: 'findOne', args: [{ _id: customerId }] }, { query: 'lean' }]
+      );
     }
   });
 });

--- a/tests/unit/helpers/mandates.test.js
+++ b/tests/unit/helpers/mandates.test.js
@@ -12,8 +12,6 @@ const ESignHelper = require('../../../src/helpers/eSign');
 const FileHelper = require('../../../src/helpers/file');
 const SinonMongoose = require('../sinonMongoose');
 
-require('sinon-mongoose');
-
 describe('getMandates', () => {
   let findOneCustomer;
   beforeEach(() => {

--- a/tests/unit/helpers/taxCertificates.test.js
+++ b/tests/unit/helpers/taxCertificates.test.js
@@ -21,11 +21,9 @@ describe('list', () => {
   afterEach(() => {
     find.restore();
   });
+
   it('should return tax certificates list', async () => {
-    const taxCertificates = [
-      { _id: new ObjectID() },
-      { _id: new ObjectID() },
-    ];
+    const taxCertificates = [{ _id: new ObjectID() }, { _id: new ObjectID() }];
     const companyId = new ObjectID();
     const customer = new ObjectID();
 
@@ -215,8 +213,8 @@ describe('generateTaxCertificatePdf', () => {
     const companyId = new ObjectID();
     const credentials = { company: { _id: companyId } };
     const taxCertificate = { _id: taxCertificateId, year: '2019' };
-    generatePdf.returns('pdf');
 
+    generatePdf.returns('pdf');
     findOne.returns(SinonMongoose.stubChainedQueries([taxCertificate]));
     formatPdf.returns('data');
     getTaxCertificateInterventions.returns(['interventions']);

--- a/tests/unit/helpers/thirdPartyPayers.test.js
+++ b/tests/unit/helpers/thirdPartyPayers.test.js
@@ -106,6 +106,6 @@ describe('delete', () => {
 
     await ThirdPartyPayersHelper.delete(tppId);
 
-    sinon.assert.calledWithExactly(deleteOne, { _id: tppId });
+    sinon.assert.calledOnceWithExactly(deleteOne, { _id: tppId });
   });
 });

--- a/tests/unit/helpers/thirdPartyPayers.test.js
+++ b/tests/unit/helpers/thirdPartyPayers.test.js
@@ -3,10 +3,17 @@ const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const ThirdPartyPayer = require('../../../src/models/ThirdPartyPayer');
 const ThirdPartyPayersHelper = require('../../../src/helpers/thirdPartyPayers');
-
-require('sinon-mongoose');
+const SinonMongoose = require('../sinonMongoose');
 
 describe('create', () => {
+  let create;
+  beforeEach(() => {
+    create = sinon.stub(ThirdPartyPayer, 'create');
+  });
+  afterEach(() => {
+    create.restore();
+  });
+
   it('should create a new thirdPartyPayer', async () => {
     const payload = {
       _id: new ObjectID(),
@@ -23,60 +30,79 @@ describe('create', () => {
     };
     const credentials = { company: { _id: new ObjectID() } };
     const payloadWithCompany = { ...payload, company: credentials.company._id };
-    const newThirdPartyPayer = new ThirdPartyPayer(payloadWithCompany);
-    const newThirdPartyPayerMock = sinon.mock(newThirdPartyPayer);
-    const ThirdPartyPayerMock = sinon.mock(ThirdPartyPayer);
 
-    ThirdPartyPayerMock.expects('create')
-      .withExactArgs(payloadWithCompany)
-      .once()
-      .returns(newThirdPartyPayer);
-    newThirdPartyPayerMock.expects('toObject').once().returns(payloadWithCompany);
+    create.returns(SinonMongoose.stubChainedQueries([payloadWithCompany], ['toObject']));
 
     const result = await ThirdPartyPayersHelper.create(payload, credentials);
 
     expect(result).toMatchObject(payloadWithCompany);
-    ThirdPartyPayerMock.verify();
-    newThirdPartyPayerMock.verify();
+    SinonMongoose.calledWithExactly(create, [{ query: 'create', args: [payloadWithCompany] }, { query: 'toObject' }]);
   });
 });
 
 describe('list', () => {
+  let find;
+  beforeEach(() => {
+    find = sinon.stub(ThirdPartyPayer, 'find');
+  });
+  afterEach(() => {
+    find.restore();
+  });
+
   it('should list tpp', async () => {
     const credentials = { company: { _id: new ObjectID() } };
-    const ThirdPartyPayerMock = sinon.mock(ThirdPartyPayer);
+    const tppList = [{ _id: new ObjectID() }, { _id: new ObjectID() }];
 
-    ThirdPartyPayerMock.expects('find')
-      .withExactArgs({ company: credentials.company._id })
-      .chain('lean');
+    find.returns(SinonMongoose.stubChainedQueries([tppList], ['lean']));
 
-    await ThirdPartyPayersHelper.list(credentials);
+    const result = await ThirdPartyPayersHelper.list(credentials);
 
-    ThirdPartyPayerMock.verify();
+    expect(result).toMatchObject(tppList);
+    SinonMongoose.calledWithExactly(
+      find,
+      [{ query: 'find', args: [{ company: credentials.company._id }] }, { query: 'lean' }]
+    );
   });
 });
 
 describe('update', () => {
+  let findOneAndUpdate;
+  beforeEach(() => {
+    findOneAndUpdate = sinon.stub(ThirdPartyPayer, 'findOneAndUpdate');
+  });
+  afterEach(() => {
+    findOneAndUpdate.restore();
+  });
+
   it('should update a tpp', async () => {
     const payload = { siret: '13605658901234' };
     const tppId = new ObjectID();
-    const ThirdPartyPayerMock = sinon.mock(ThirdPartyPayer);
 
-    ThirdPartyPayerMock.expects('findOneAndUpdate')
-      .withExactArgs({ _id: tppId }, { $set: payload }, { new: true })
-      .chain('lean')
-      .once();
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([{ _id: tppId }], ['lean']));
 
-    await ThirdPartyPayersHelper.update(tppId, payload);
+    const result = await ThirdPartyPayersHelper.update(tppId, payload);
 
-    ThirdPartyPayerMock.verify();
+    expect(result).toMatchObject({ _id: tppId });
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOneAndUpdate', args: [{ _id: tppId }, { $set: payload }, { new: true }] },
+        { query: 'lean' },
+      ]
+    );
   });
 });
 
 describe('delete', () => {
+  let deleteOne;
+  beforeEach(() => {
+    deleteOne = sinon.stub(ThirdPartyPayer, 'deleteOne');
+  });
+  afterEach(() => {
+    deleteOne.restore();
+  });
   it('should remove an tpp', async () => {
     const tppId = new ObjectID();
-    const deleteOne = sinon.stub(ThirdPartyPayer, 'deleteOne');
 
     await ThirdPartyPayersHelper.delete(tppId);
 


### PR DESCRIPTION
SinonMongoose : 

### distanceMatrix
- getDistanceMatrices

### thirdPartyPayer
- create
- list
- update

### taxCertificates
- list
- generateTaxCertificatePdf
- create
- remove

### mandates
- getMandates
- updateMandate
- getSignatureRequest
- saveSignedMandate

### billDispatch (jobs)
- method

Et c'en est fini des tickets sinon-mongoose (juste un dernier ticket de vérif pour virer les oublis)