### PR TITLE
Com 2069

### DIFF
--- a/src/controllers/customerPartnerController.js
+++ b/src/controllers/customerPartnerController.js
@@ -31,4 +31,15 @@ const list = async (req) => {
   }
 };
 
-module.exports = { create, list };
+const update = async (req) => {
+  try {
+    await CustomerPartnerHelper.update(req.params._id, req.payload);
+
+    return { message: translate[language].customerPartnerUpdated };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { create, list, update };

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -12,15 +12,13 @@ exports.list = async (customer, credentials) => {
     })
     .lean();
 
-  return customerPartners.map(customerPartner => customerPartner.partner);
+  return customerPartners;
 };
 
 exports.update = async (customerPartnerId, payload) => {
   const customerPartner = await CustomerPartner.findOneAndUpdate({ _id: customerPartnerId }, { $set: payload }).lean();
-
-  const { partner, customer } = customerPartner;
   await CustomerPartner.updateOne(
-    { _id: { $ne: customerPartnerId }, partner, customer, prescriber: true },
+    { _id: { $ne: customerPartnerId }, customer: customerPartner.customer, prescriber: true },
     { $set: { prescriber: false } }
   );
 };

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -14,3 +14,13 @@ exports.list = async (customer, credentials) => {
 
   return customerPartners.map(customerPartner => customerPartner.partner);
 };
+
+exports.update = async (customerPartnerId, payload) => {
+  const customerPartner = await CustomerPartner.findOneAndUpdate({ _id: customerPartnerId }, { $set: payload }).lean();
+
+  const { partner, customer } = customerPartner;
+  await CustomerPartner.updateOne(
+    { _id: { $ne: customerPartnerId }, partner, customer, prescriber: true },
+    { $set: { prescriber: false } }
+  );
+};

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -16,7 +16,10 @@ exports.list = async (customer, credentials) => {
 };
 
 exports.update = async (customerPartnerId, payload) => {
-  const customerPartner = await CustomerPartner.findOneAndUpdate({ _id: customerPartnerId }, { $set: payload }).lean();
+  const customerPartner = await CustomerPartner
+    .findOneAndUpdate({ _id: customerPartnerId }, { $set: payload }, { fields: { customer: 1 } })
+    .lean();
+
   await CustomerPartner.updateOne(
     { _id: { $ne: customerPartnerId }, customer: customerPartner.customer, prescriber: true },
     { $set: { prescriber: false } }

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -20,8 +20,10 @@ exports.update = async (customerPartnerId, payload) => {
     .findOneAndUpdate({ _id: customerPartnerId }, { $set: payload }, { fields: { customer: 1 } })
     .lean();
 
-  await CustomerPartner.updateOne(
-    { _id: { $ne: customerPartnerId }, customer: customerPartner.customer, prescriber: true },
-    { $set: { prescriber: false } }
-  );
+  if (payload.prescriber) {
+    await CustomerPartner.updateOne(
+      { _id: { $ne: customerPartnerId }, customer: customerPartner.customer, prescriber: true },
+      { $set: { prescriber: false } }
+    );
+  }
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -314,6 +314,7 @@ module.exports = {
     customerPartnersFound: 'Customer partners found.',
     customerPartnersNotFound: 'Customer partners not found.',
     customerPartnerAlreadyExists: 'Customer partner already exists.',
+    customerPartnerUpdated: 'Customer partner updated.',
   },
   'fr-FR': {
     /* Global errors */
@@ -627,6 +628,7 @@ module.exports = {
     customerPartnersFound: 'Liste des partenaires bénéficiaire trouvée.',
     customerPartnersNotFound: 'Liste des partenaires bénéficiaire non trouvée.',
     customerPartnerAlreadyExists: 'Ce partenaire existe déjà.',
+    customerPartnerUpdated: 'Partenaire mis à jour.',
 
   },
 };

--- a/src/models/CustomerPartner.js
+++ b/src/models/CustomerPartner.js
@@ -5,7 +5,7 @@ const CustomerPartnerSchema = mongoose.Schema({
   partner: { type: mongoose.Schema.Types.ObjectId, ref: 'Partner', required: true },
   customer: { type: mongoose.Schema.Types.ObjectId, ref: 'Customer', required: true },
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
-  prescriber: { type: Boolean, default: false },
+  prescriber: { type: Boolean, default: false, required: true },
 }, { timestamps: true });
 
 CustomerPartnerSchema.pre('find', validateQuery);

--- a/src/models/CustomerPartner.js
+++ b/src/models/CustomerPartner.js
@@ -5,6 +5,7 @@ const CustomerPartnerSchema = mongoose.Schema({
   partner: { type: mongoose.Schema.Types.ObjectId, ref: 'Partner', required: true },
   customer: { type: mongoose.Schema.Types.ObjectId, ref: 'Customer', required: true },
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
+  prescriber: { type: Boolean, default: false },
 }, { timestamps: true });
 
 CustomerPartnerSchema.pre('find', validateQuery);

--- a/src/routes/customerPartners.js
+++ b/src/routes/customerPartners.js
@@ -1,5 +1,5 @@
 const Joi = require('joi');
-const { create, list } = require('../controllers/customerPartnerController');
+const { create, list, update } = require('../controllers/customerPartnerController');
 const { authorizeCustomerPartnerCreation, authorizeCustomerPartnersGet } = require('./preHandlers/customerPartners');
 
 exports.plugin = {
@@ -32,6 +32,19 @@ exports.plugin = {
         pre: [{ method: authorizeCustomerPartnersGet }],
       },
       handler: list,
+    });
+
+    server.route({
+      method: 'PUT',
+      path: '/{_id}',
+      options: {
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+          payload: Joi.object({ prescriber: Joi.boolean().required() }),
+        },
+        auth: { scope: ['customerpartners:edit'] },
+      },
+      handler: update,
     });
   },
 };

--- a/src/routes/customerPartners.js
+++ b/src/routes/customerPartners.js
@@ -1,6 +1,10 @@
 const Joi = require('joi');
 const { create, list, update } = require('../controllers/customerPartnerController');
-const { authorizeCustomerPartnerCreation, authorizeCustomerPartnersGet } = require('./preHandlers/customerPartners');
+const {
+  authorizeCustomerPartnerCreation,
+  authorizeCustomerPartnersGet,
+  authorizeCustomerPartnersUpdate,
+} = require('./preHandlers/customerPartners');
 
 exports.plugin = {
   name: 'routes-customer-partners',
@@ -43,6 +47,7 @@ exports.plugin = {
           payload: Joi.object({ prescriber: Joi.boolean().required() }),
         },
         auth: { scope: ['customerpartners:edit'] },
+        pre: [{ method: authorizeCustomerPartnersUpdate }],
       },
       handler: update,
     });

--- a/src/routes/preHandlers/customerPartners.js
+++ b/src/routes/preHandlers/customerPartners.js
@@ -33,7 +33,9 @@ exports.authorizeCustomerPartnersGet = async (req) => {
 };
 
 exports.authorizeCustomerPartnersUpdate = async (req) => {
-  const customerPartner = await CustomerPartner.countDocuments({ _id: req.params._id });
+  const { credentials } = req.auth;
+  const loggedUserCompany = get(credentials, 'company._id');
+  const customerPartner = await CustomerPartner.countDocuments({ _id: req.params._id, company: loggedUserCompany });
   if (!customerPartner) throw Boom.notFound();
 
   return null;

--- a/src/routes/preHandlers/customerPartners.js
+++ b/src/routes/preHandlers/customerPartners.js
@@ -31,3 +31,10 @@ exports.authorizeCustomerPartnersGet = async (req) => {
   if (!customer) throw Boom.notFound();
   return null;
 };
+
+exports.authorizeCustomerPartnersUpdate = async (req) => {
+  const customerPartner = await CustomerPartner.countDocuments({ _id: req.params._id });
+  if (!customerPartner) throw Boom.notFound();
+
+  return null;
+};

--- a/tests/integration/customerPartners.test.js
+++ b/tests/integration/customerPartners.test.js
@@ -263,6 +263,17 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    it('should return 404 if customer partner doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/customerpartners/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { prescriber: true },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
   });
 
   describe('Other roles', () => {

--- a/tests/integration/customerPartners.test.js
+++ b/tests/integration/customerPartners.test.js
@@ -230,7 +230,7 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
     });
 
     it('should update prescriber of customer partner', async () => {
-      const customerPartnerId = customerPartnersList[0]._id;
+      const customerPartnerId = customerPartnersList[1]._id;
       const response = await app.inject({
         method: 'PUT',
         url: `/customerpartners/${customerPartnerId}`,
@@ -253,7 +253,7 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
     });
 
     it('should return 400 if payload is not a boolean', async () => {
-      const customerPartnerId = customerPartnersList[0]._id;
+      const customerPartnerId = customerPartnersList[1]._id;
       const response = await app.inject({
         method: 'PUT',
         url: `/customerpartners/${customerPartnerId}`,
@@ -274,6 +274,17 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
 
       expect(response.statusCode).toBe(404);
     });
+    it('should return 404 if customer partner has wrong company', async () => {
+      const customerPartnerId = customerPartnersList[0]._id;
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/customerpartners/${customerPartnerId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { prescriber: true },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
   });
 
   describe('Other roles', () => {
@@ -285,7 +296,7 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
     roles.forEach((role) => {
       it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
         authToken = await getToken(role.name);
-        const customerPartnerId = customerPartnersList[0]._id;
+        const customerPartnerId = customerPartnersList[1]._id;
         const response = await app.inject({
           method: 'PUT',
           url: `/customerpartners/${customerPartnerId}`,

--- a/tests/integration/seed/customerPartnersSeed.js
+++ b/tests/integration/seed/customerPartnersSeed.js
@@ -76,4 +76,5 @@ module.exports = {
   customersList,
   partnersList,
   auxiliaryFromOtherCompany,
+  customerPartnersList,
 };

--- a/tests/integration/seed/customerPartnersSeed.js
+++ b/tests/integration/seed/customerPartnersSeed.js
@@ -49,14 +49,28 @@ const partnersList = [
     company: otherCompany._id,
     partnerOrganization: new ObjectID(),
   },
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'Alain', lastname: 'Terrieur' },
+    company: authCompany._id,
+    partnerOrganization: new ObjectID(),
+  },
 ];
 
-const customerPartnersList = [{
-  _id: new ObjectID(),
-  partner: partnersList[1]._id,
-  customer: customersList[1],
-  company: otherCompany._id,
-}];
+const customerPartnersList = [
+  {
+    _id: new ObjectID(),
+    partner: partnersList[1]._id,
+    customer: customersList[1],
+    company: otherCompany._id,
+  },
+  {
+    _id: new ObjectID(),
+    partner: partnersList[2]._id,
+    customer: customersList[0],
+    company: authCompany._id,
+  },
+];
 
 const populateDB = async () => {
   await User.deleteMany({});

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -44,7 +44,7 @@ describe('list', () => {
 
     const result = await CustomerPartnersHelper.list(customer, credentials);
 
-    expect(result).toMatchObject(customerPartners.map(customerPartner => customerPartner.partner));
+    expect(result).toMatchObject(customerPartners);
     SinonMongoose.calledWithExactly(
       find,
       [
@@ -92,12 +92,7 @@ describe('update', () => {
     );
     sinon.assert.calledOnceWithExactly(
       updateOne,
-      {
-        _id: { $ne: customerPartnerId },
-        customer: customerPartner.customer,
-        partner: customerPartner.partner,
-        prescriber: true,
-      },
+      { _id: { $ne: customerPartnerId }, customer: customerPartner.customer, prescriber: true },
       { $set: { prescriber: false } }
     );
   });

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -77,7 +77,7 @@ describe('update', () => {
 
   it('should update the prescriber partner', async () => {
     const customerPartnerId = new ObjectID();
-    const customerPartner = { _id: customerPartnerId, customer: new ObjectID(), partner: new ObjectID() };
+    const customerPartner = { _id: customerPartnerId, customer: new ObjectID() };
 
     findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customerPartner], ['lean']));
 
@@ -86,7 +86,10 @@ describe('update', () => {
     SinonMongoose.calledWithExactly(
       findOneAndUpdate,
       [
-        { query: 'findOneAndUpdate', args: [{ _id: customerPartnerId }, { $set: { prescriber: true } }] },
+        {
+          query: 'findOneAndUpdate',
+          args: [{ _id: customerPartnerId }, { $set: { prescriber: true } }, { fields: { customer: 1 } }],
+        },
         { query: 'lean' },
       ]
     );

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -62,3 +62,43 @@ describe('list', () => {
     );
   });
 });
+
+describe('update', () => {
+  let findOneAndUpdate;
+  let updateOne;
+  beforeEach(() => {
+    findOneAndUpdate = sinon.stub(CustomerPartner, 'findOneAndUpdate');
+    updateOne = sinon.stub(CustomerPartner, 'updateOne');
+  });
+  afterEach(() => {
+    findOneAndUpdate.restore();
+    updateOne.restore();
+  });
+
+  it('should update the prescriber partner', async () => {
+    const customerPartnerId = new ObjectID();
+    const customerPartner = { _id: customerPartnerId, customer: new ObjectID(), partner: new ObjectID() };
+
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customerPartner], ['lean']));
+
+    await CustomerPartnersHelper.update(customerPartnerId, { prescriber: true });
+
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        { query: 'findOneAndUpdate', args: [{ _id: customerPartnerId }, { $set: { prescriber: true } }] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.calledOnceWithExactly(
+      updateOne,
+      {
+        _id: { $ne: customerPartnerId },
+        customer: customerPartner.customer,
+        partner: customerPartner.partner,
+        prescriber: true,
+      },
+      { $set: { prescriber: false } }
+    );
+  });
+});

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -99,4 +99,24 @@ describe('update', () => {
       { $set: { prescriber: false } }
     );
   });
+  it('should remove the prescriber partner', async () => {
+    const customerPartnerId = new ObjectID();
+    const customerPartner = { _id: customerPartnerId, customer: new ObjectID() };
+
+    findOneAndUpdate.returns(SinonMongoose.stubChainedQueries([customerPartner], ['lean']));
+
+    await CustomerPartnersHelper.update(customerPartnerId, { prescriber: false });
+
+    sinon.assert.notCalled(updateOne);
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdate,
+      [
+        {
+          query: 'findOneAndUpdate',
+          args: [{ _id: customerPartnerId }, { $set: { prescriber: false } }, { fields: { customer: 1 } }],
+        },
+        { query: 'lean' },
+      ]
+    );
+  });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : auxiliaire/admin/coach

- Cas d'usage : sur la fiche bénéficiaire je peux définir un partenaire prescripteur
