### PR TITLE
Com 2079

### DIFF
--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -31,6 +31,7 @@ exports.getListQuery = (query, credentials) => {
 exports.createEventHistory = async (payload, credentials, action) => {
   const { _id: createdBy } = credentials;
   const {
+    _id: eventId,
     customer,
     startDate,
     endDate,
@@ -46,16 +47,7 @@ exports.createEventHistory = async (payload, credentials, action) => {
     company: get(credentials, 'company._id', null),
     createdBy,
     action,
-    event: pickBy({
-      type,
-      startDate,
-      endDate,
-      customer,
-      absence,
-      internalHour,
-      misc,
-      repetition,
-    }),
+    event: pickBy({ eventId, type, startDate, endDate, customer, absence, internalHour, misc, repetition }),
   };
 
   if (address && Object.keys(address).length) eventHistory.event.address = address;
@@ -103,7 +95,7 @@ exports.createEventHistoryOnUpdate = async (payload, event, credentials) => {
     company: companyId,
     createdBy,
     action: EVENT_UPDATE,
-    event: { type, startDate, endDate, customer, misc },
+    event: { eventId: event._id, type, startDate, endDate, customer, misc },
   };
   if (payload.shouldUpdateRepetition) history.event.repetition = repetition;
   if (event.type === INTERNAL_HOUR) history.event.internalHour = payload.internalHour || event.internalHour;

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -132,22 +132,27 @@ exports.formatHistoryForAuxiliaryUpdate = async (mainInfo, payload, event, compa
     const auxiliaryList = await User.find({ _id: { $in: [event.auxiliary, payload.auxiliary] } })
       .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
       .lean({ autopopulate: true, virtuals: true });
+
     for (const aux of auxiliaryList) {
-      if (!UtilsHelper.doesArrayIncludeId(sectors, aux.sector._id)) sectors.push(aux.sector);
+      if (!UtilsHelper.doesArrayIncludeId(sectors, aux.sector._id)) sectors.push(aux.sector._id);
     }
   } else if (event.auxiliary) {
     auxiliaries = [event.auxiliary];
     update = { auxiliary: { from: event.auxiliary } };
+
     const aux = await User.findOne({ _id: event.auxiliary })
       .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
       .lean({ autopopulate: true, virtuals: true });
+
     if (!UtilsHelper.doesArrayIncludeId(sectors, aux.sector)) sectors.push(aux.sector);
   } else if (payload.auxiliary) {
     auxiliaries = [payload.auxiliary];
     update = { auxiliary: { to: payload.auxiliary } };
+
     const aux = await User.findOne({ _id: payload.auxiliary })
       .populate({ path: 'sector', select: '_id sector', match: { company: companyId } })
       .lean({ autopopulate: true, virtuals: true });
+
     if (!UtilsHelper.doesArrayIncludeId(sectors, aux.sector)) sectors.push(aux.sector);
   }
 

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -72,14 +72,24 @@ exports.createEvent = async (payload, credentials) => {
   const isRepeatedEvent = exports.isRepetition(eventPayload);
   const hasConflicts = await EventsValidationHelper.hasConflicts(eventPayload);
   if (eventPayload.type === INTERVENTION && eventPayload.auxiliary && isRepeatedEvent && hasConflicts) {
-    eventPayload = exports.detachAuxiliaryFromEvent(eventPayload, companyId);
+    eventPayload = await exports.detachAuxiliaryFromEvent(eventPayload, companyId);
   }
 
-  const event = await Event.create(eventPayload);
-
-  await EventHistoriesHelper.createEventHistoryOnCreate(event, credentials);
-
+  const event = (await Event.create(eventPayload)).toObject();
   const populatedEvent = await EventRepository.getEvent(event._id, credentials);
+
+  if (!isRepeatedEvent) await EventHistoriesHelper.createEventHistoryOnCreate(event, credentials);
+  else {
+    const repetition = { ...payload.repetition, parentId: populatedEvent._id };
+    await EventsRepetitionHelper.createRepetitions(
+      populatedEvent,
+      { ...payload, company: companyId, repetition },
+      credentials
+    );
+
+    await EventHistoriesHelper.createEventHistoryOnCreate({ ...event, repetition }, credentials);
+  }
+
   if (payload.type === ABSENCE) {
     const { startDate, endDate } = populatedEvent;
     const dates = { startDate, endDate };
@@ -88,14 +98,6 @@ exports.createEvent = async (payload, credentials) => {
       .lean({ autopopulate: true, virtuals: true });
     await exports.deleteConflictInternalHoursAndUnavailabilities(populatedEvent, auxiliary, credentials);
     await exports.unassignConflictInterventions(dates, auxiliary, credentials);
-  }
-
-  if (isRepeatedEvent) {
-    await EventsRepetitionHelper.createRepetitions(
-      populatedEvent,
-      { ...payload, company: companyId, repetition: { ...payload.repetition, parentId: populatedEvent._id } },
-      credentials
-    );
   }
 
   return exports.populateEventSubscription(populatedEvent);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -87,7 +87,7 @@ exports.createEvent = async (payload, credentials) => {
       credentials
     );
 
-    await EventHistoriesHelper.createEventHistoryOnCreate({ ...event, repetition }, credentials);
+    await EventHistoriesHelper.createEventHistoryOnCreate({ ...payload, _id: event._id, repetition }, credentials);
   }
 
   if (payload.type === ABSENCE) {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -69,8 +69,6 @@ exports.createEvent = async (payload, credentials) => {
   let eventPayload = { ...cloneDeep(payload), company: companyId };
   if (!await EventsValidationHelper.isCreationAllowed(eventPayload, credentials)) throw Boom.badData();
 
-  await EventHistoriesHelper.createEventHistoryOnCreate(payload, credentials);
-
   const isRepeatedEvent = exports.isRepetition(eventPayload);
   const hasConflicts = await EventsValidationHelper.hasConflicts(eventPayload);
   if (eventPayload.type === INTERVENTION && eventPayload.auxiliary && isRepeatedEvent && hasConflicts) {
@@ -78,6 +76,9 @@ exports.createEvent = async (payload, credentials) => {
   }
 
   const event = await Event.create(eventPayload);
+
+  await EventHistoriesHelper.createEventHistoryOnCreate(event, credentials);
+
   const populatedEvent = await EventRepository.getEvent(event._id, credentials);
   if (payload.type === ABSENCE) {
     const { startDate, endDate } = populatedEvent;

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -171,6 +171,8 @@ exports.formatDuration = (duration) => {
 exports.areObjectIdsEquals = (id1, id2) => !!id1 && !!id2 &&
   new ObjectID(id1).toHexString() === new ObjectID(id2).toHexString();
 
+exports.doesArrayIncludeId = (array, id) => array.some(item => exports.areObjectIdsEquals(item, id));
+
 exports.formatPhoneNumber = phoneNumber => (phoneNumber
   ? phoneNumber.replace(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1 $2 $3 $4 $5')
   : '');

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -44,6 +44,7 @@ const EventHistorySchema = mongoose.Schema({
     },
   },
   event: {
+    eventId: { type: mongoose.Schema.Types.ObjectId, ref: 'Event', required: true, immutable: true },
     type: { type: String, enum: EVENT_TYPES },
     startDate: Date,
     endDate: Date,

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -44,6 +44,7 @@ const EventHistorySchema = mongoose.Schema({
     misc: { type: String },
     repetition: {
       frequency: { type: String, enum: REPETITION_FREQUENCIES },
+      parentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Event' },
     },
   },
   auxiliaries: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -22,22 +22,10 @@ const EventHistorySchema = mongoose.Schema({
       from: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
       to: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     },
-    startDate: {
-      from: Date,
-      to: Date,
-    },
-    endDate: {
-      from: Date,
-      to: Date,
-    },
-    startHour: {
-      from: Date,
-      to: Date,
-    },
-    endHour: {
-      from: Date,
-      to: Date,
-    },
+    startDate: { from: { type: Date }, to: { type: Date } },
+    endDate: { from: { type: Date }, to: { type: Date } },
+    startHour: { from: { type: Date }, to: { type: Date } },
+    endHour: { from: { type: Date }, to: { type: Date } },
     cancel: {
       condition: { type: String, enum: EVENT_CANCELLATION_CONDITIONS },
       reason: { type: String, enum: EVENT_CANCELLATION_REASONS },
@@ -46,8 +34,8 @@ const EventHistorySchema = mongoose.Schema({
   event: {
     eventId: { type: mongoose.Schema.Types.ObjectId, ref: 'Event', required: true, immutable: true },
     type: { type: String, enum: EVENT_TYPES },
-    startDate: Date,
-    endDate: Date,
+    startDate: { type: Date },
+    endDate: { type: Date },
     customer: { type: mongoose.Schema.Types.ObjectId, ref: 'Customer' },
     auxiliary: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     absence: { type: String, enum: ABSENCE_TYPES },

--- a/tests/integration/eventHistories.test.js
+++ b/tests/integration/eventHistories.test.js
@@ -3,7 +3,7 @@ const app = require('../../server');
 const {
   populateDB,
   eventHistoryList,
-  eventHistoryAuxiliaries,
+  auxiliaries,
   auxiliaryFromOtherCompany,
   sectorFromOtherCompany,
   sectors,
@@ -36,7 +36,7 @@ describe('GET /eventhistories', () => {
   });
 
   it('should return a list of event histories from auxiliaries ids', async () => {
-    const auxiliaryIds = [eventHistoryAuxiliaries[0]._id.toHexString(), eventHistoryAuxiliaries[1]._id.toHexString()];
+    const auxiliaryIds = [auxiliaries[0]._id.toHexString(), auxiliaries[1]._id.toHexString()];
     const response = await app.inject({
       method: 'GET',
       url: `/eventhistories?auxiliaries=${auxiliaryIds[0]}&auxiliaries=${auxiliaryIds[1]}`,
@@ -68,7 +68,7 @@ describe('GET /eventhistories', () => {
   it('should return a 400 if invalid query', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/eventhistories?auxiliary=${eventHistoryAuxiliaries[0]._id.toHexString()}`,
+      url: `/eventhistories?auxiliary=${auxiliaries[0]._id.toHexString()}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -1,4 +1,4 @@
-const { ObjectID, ObjectId } = require('mongodb');
+const { ObjectID } = require('mongodb');
 const { v4: uuidv4 } = require('uuid');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -188,7 +188,7 @@ const populateDB = async () => {
   await (new Customer(customer)).save();
   await Sector.create(sectors);
   await (new Sector(sectorFromOtherCompany)).save();
-  Event.insertMany(events);
+  await Event.insertMany(events);
 };
 
 module.exports = {

--- a/tests/integration/seed/eventHistoriesSeed.js
+++ b/tests/integration/seed/eventHistoriesSeed.js
@@ -1,9 +1,10 @@
-const { ObjectID } = require('mongodb');
+const { ObjectID, ObjectId } = require('mongodb');
 const { v4: uuidv4 } = require('uuid');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
 const Sector = require('../../../src/models/Sector');
 const EventHistory = require('../../../src/models/EventHistory');
+const Event = require('../../../src/models/Event');
 const {
   INTERNAL_HOUR,
   INTERVENTION,
@@ -26,36 +27,30 @@ const user = {
   origin: WEBAPP,
 };
 
-const eventHistoryAuxiliaries = [{
-  _id: new ObjectID(),
-  identity: { firstname: 'Mimi', lastname: 'Mita' },
-  local: { email: 'lili@alenvi.io', password: '123456!eR' },
-  role: { client: rolesList[2]._id },
-  company: authCompany._id,
-  refreshToken: uuidv4(),
-  origin: WEBAPP,
-}, {
-  _id: new ObjectID(),
-  identity: { firstname: 'Joséphine', lastname: 'Mita' },
-  local: { email: 'lili2@alenvi.io', password: '123456!eR' },
-  role: { client: rolesList[2]._id },
-  company: authCompany._id,
-  refreshToken: uuidv4(),
-  origin: WEBAPP,
-}];
+const auxiliaries = [
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'Mimi', lastname: 'Mita' },
+    local: { email: 'lili@alenvi.io', password: '123456!eR' },
+    role: { client: rolesList[2]._id },
+    company: authCompany._id,
+    refreshToken: uuidv4(),
+    origin: WEBAPP,
+  },
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'Joséphine', lastname: 'Mita' },
+    local: { email: 'lili2@alenvi.io', password: '123456!eR' },
+    role: { client: rolesList[2]._id },
+    company: authCompany._id,
+    refreshToken: uuidv4(),
+    origin: WEBAPP,
+  },
+];
 
-const sectors = [{
-  _id: new ObjectID(),
-  company: authCompany._id,
-}, {
-  _id: new ObjectID(),
-  company: authCompany._id,
-}];
+const sectors = [{ _id: new ObjectID(), company: authCompany._id }, { _id: new ObjectID(), company: authCompany._id }];
 
-const sectorFromOtherCompany = {
-  _id: new ObjectID(),
-  company: otherCompany._id,
-};
+const sectorFromOtherCompany = { _id: new ObjectID(), company: otherCompany._id };
 
 const customer = {
   _id: new ObjectID(),
@@ -73,6 +68,47 @@ const customer = {
   },
 };
 
+const events = [
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    type: INTERVENTION,
+    startDate: '2019-01-20T09:38:18',
+    endDate: '2019-01-20T11:38:18',
+    customer: customer._id,
+    auxiliary: auxiliaries[0]._id,
+    address: {
+      fullAddress: '37 rue de ponthieu 75008 Paris',
+      zipCode: '75008',
+      city: 'Paris',
+      street: '37 rue de Ponthieu',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+    subscription: new ObjectID(),
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    type: INTERNAL_HOUR,
+    startDate: '2019-01-20T09:38:18',
+    endDate: '2019-01-20T11:38:18',
+    internalHour: { name: 'Réunion', _id: new ObjectID() },
+    auxiliary: auxiliaries[0]._id,
+    misc: 'Je suis une note',
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    type: ABSENCE,
+    absenceNature: 'daily',
+    startDate: '2019-01-20T09:38:18',
+    endDate: '2019-01-20T11:38:18',
+    absence: PAID_LEAVE,
+    auxiliary: auxiliaries[0]._id,
+    misc: 'Je suis une note',
+  },
+];
+
 const eventHistoryList = [
   {
     _id: ObjectID(),
@@ -80,13 +116,14 @@ const eventHistoryList = [
     action: EVENT_CREATION,
     createdBy: user._id,
     sectors: [sectors[0]._id],
-    auxiliaries: [eventHistoryAuxiliaries[0]._id],
+    auxiliaries: [auxiliaries[0]._id],
     event: {
+      eventId: events[0]._id,
       type: INTERVENTION,
       startDate: '2019-01-20T09:38:18',
       endDate: '2019-01-20T11:38:18',
       customer: customer._id,
-      auxiliary: eventHistoryAuxiliaries[0]._id,
+      auxiliary: auxiliaries[0]._id,
     },
   },
   {
@@ -95,16 +132,14 @@ const eventHistoryList = [
     action: EVENT_DELETION,
     createdBy: user._id,
     sectors: [sectors[0]._id],
-    auxiliaries: [eventHistoryAuxiliaries[0]._id],
+    auxiliaries: [auxiliaries[0]._id],
     event: {
+      eventId: events[1]._id,
       type: INTERNAL_HOUR,
       startDate: '2019-01-20T09:38:18',
       endDate: '2019-01-20T11:38:18',
-      internalHour: {
-        name: 'Réunion',
-        _id: new ObjectID(),
-      },
-      auxiliary: eventHistoryAuxiliaries[0]._id,
+      internalHour: { name: 'Réunion', _id: new ObjectID() },
+      auxiliary: auxiliaries[0]._id,
       misc: 'Je suis une note',
     },
   },
@@ -114,13 +149,14 @@ const eventHistoryList = [
     action: EVENT_UPDATE,
     createdBy: user._id,
     sectors: [sectors[0]._id],
-    auxiliaries: [eventHistoryAuxiliaries[0]._id],
+    auxiliaries: [auxiliaries[0]._id],
     event: {
+      eventId: events[2]._id,
       type: ABSENCE,
       startDate: '2019-01-20T09:38:18',
       endDate: '2019-01-20T11:38:18',
       absence: PAID_LEAVE,
-      auxiliary: eventHistoryAuxiliaries[0]._id,
+      auxiliary: auxiliaries[0]._id,
       misc: 'Je suis une note',
     },
   },
@@ -141,22 +177,24 @@ const populateDB = async () => {
   await User.deleteMany({});
   await Sector.deleteMany({});
   await EventHistory.deleteMany({});
+  await Event.deleteMany({});
 
   await populateDBForAuthentication();
 
   await EventHistory.insertMany(eventHistoryList);
   await (new User(user)).save();
-  await User.create(eventHistoryAuxiliaries);
+  await User.create(auxiliaries);
   await (new User(auxiliaryFromOtherCompany)).save();
   await (new Customer(customer)).save();
   await Sector.create(sectors);
   await (new Sector(sectorFromOtherCompany)).save();
+  Event.insertMany(events);
 };
 
 module.exports = {
   populateDB,
   eventHistoryList,
-  eventHistoryAuxiliaries,
+  auxiliaries,
   auxiliaryFromOtherCompany,
   sectorFromOtherCompany,
   sectors,

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -620,27 +620,20 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const sectorId = new ObjectID();
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
-    const mainInfo = {
-      createdBy: 'james bond',
-      action: 'event_update',
-      event: { type: 'intervention' },
-    };
+    const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
     const payload = { auxiliary: 'qwertyuiop' };
     const event = { auxiliary: auxiliaryId };
     find.returns(SinonMongoose.stubChainedQueries([[{ _id: auxiliaryId, sector: sectorId }]]));
 
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
-    expect(result).toBeDefined();
     expect(result).toEqual({
       createdBy: 'james bond',
       action: 'event_update',
       event: { type: 'intervention' },
-      update: {
-        auxiliary: { from: auxiliaryId.toHexString(), to: 'qwertyuiop' },
-      },
+      update: { auxiliary: { from: auxiliaryId, to: 'qwertyuiop' } },
       sectors: [sectorId],
-      auxiliaries: [auxiliaryId.toHexString(), 'qwertyuiop'],
+      auxiliaries: [auxiliaryId, 'qwertyuiop'],
     });
     SinonMongoose.calledWithExactly(
       find,
@@ -657,24 +650,20 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const sectorId = new ObjectID();
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
-    const mainInfo = {
-      createdBy: 'james bond',
-      action: 'event_update',
-      event: { type: 'intervention' },
-    };
-    const payload = { sector: sectorId.toHexString() };
+    const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
+    const payload = { sector: sectorId };
     const event = { auxiliary: auxiliaryId };
     findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
+
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
-    expect(result).toBeDefined();
     expect(result).toEqual({
       createdBy: 'james bond',
       action: 'event_update',
       event: { type: 'intervention' },
-      update: { auxiliary: { from: auxiliaryId.toHexString() } },
-      sectors: [sectorId.toHexString()],
-      auxiliaries: [auxiliaryId.toHexString()],
+      update: { auxiliary: { from: auxiliaryId } },
+      sectors: [sectorId],
+      auxiliaries: [auxiliaryId],
     });
     SinonMongoose.calledWithExactly(
       findOne,
@@ -692,32 +681,25 @@ describe('formatHistoryForAuxiliaryUpdate', () => {
     const eventSectorId = new ObjectID();
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
-    const mainInfo = {
-      createdBy: 'james bond',
-      action: 'event_update',
-      event: { type: 'intervention' },
-    };
-    const payload = { auxiliary: auxiliaryId.toHexString() };
+    const mainInfo = { createdBy: 'james bond', action: 'event_update', event: { type: 'intervention' } };
+    const payload = { auxiliary: auxiliaryId };
     const event = { sector: eventSectorId };
     findOne.returns(SinonMongoose.stubChainedQueries([{ _id: auxiliaryId, sector: sectorId }]));
 
     const result = await EventHistoryHelper.formatHistoryForAuxiliaryUpdate(mainInfo, payload, event, companyId);
 
-    expect(result).toBeDefined();
     expect(result).toEqual({
       createdBy: 'james bond',
       action: 'event_update',
       event: { type: 'intervention' },
-      update: {
-        auxiliary: { to: auxiliaryId.toHexString() },
-      },
-      sectors: [sectorId.toHexString(), eventSectorId.toHexString()],
-      auxiliaries: [auxiliaryId.toHexString()],
+      update: { auxiliary: { to: auxiliaryId } },
+      sectors: [sectorId, eventSectorId],
+      auxiliaries: [auxiliaryId],
     });
     SinonMongoose.calledWithExactly(
       findOne,
       [
-        { query: 'findOne', args: [{ _id: auxiliaryId.toHexString() }] },
+        { query: 'findOne', args: [{ _id: auxiliaryId }] },
         { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -140,7 +140,7 @@ describe('createEventHistory', () => {
         company: companyId,
         auxiliaries: [auxiliaryId.toHexString()],
         sectors: [sectorId.toHexString()],
-        event: { auxiliary: auxiliaryId.toHexString() },
+        event: { eventId: payload._id, auxiliary: auxiliaryId.toHexString() },
       }
     );
     SinonMongoose.calledWithExactly(
@@ -171,7 +171,7 @@ describe('createEventHistory', () => {
         action: 'event_creation',
         company: companyId,
         sectors: [sectorId.toHexString()],
-        event: { type: 'intervention' },
+        event: { eventId: payload._id, type: 'intervention' },
       }
     );
     sinon.assert.notCalled(findOne);
@@ -243,6 +243,7 @@ describe('createEventHistoryOnUpdate', () => {
       misc: 'Toto',
     };
     const event = {
+      _id: new ObjectID(),
       auxiliary: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-22T09:38:18',
@@ -260,6 +261,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-22T09:38:18',
@@ -284,6 +286,7 @@ describe('createEventHistoryOnUpdate', () => {
       misc: 'Toto',
     };
     const event = {
+      _id: new ObjectID(),
       startDate: '2019-01-22T09:38:18',
       endDate: '2019-01-22T09:38:18',
       customer: customerId,
@@ -300,6 +303,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-21T11:38:18',
@@ -326,6 +330,7 @@ describe('createEventHistoryOnUpdate', () => {
       cancel: { reason: 'toto', condition: 'payé' },
     };
     const event = {
+      _id: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-21T11:38:18',
       customer: customerId,
@@ -342,6 +347,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-21T11:38:18',
@@ -365,6 +371,7 @@ describe('createEventHistoryOnUpdate', () => {
       misc: 'Toto',
     };
     const event = {
+      _id: new ObjectID(),
       startDate: '2019-01-21T10:38:18',
       endDate: '2019-01-21T11:38:18',
       customer: customerId,
@@ -381,6 +388,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-21T11:38:18',
@@ -407,6 +415,7 @@ describe('createEventHistoryOnUpdate', () => {
       cancel: { reason: 'toto', condition: 'payé' },
     };
     const event = {
+      _id: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-21T11:38:18',
       customer: customerId,
@@ -423,6 +432,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-20T09:38:18',
           endDate: '2019-01-21T11:38:18',
@@ -442,6 +452,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-20T09:38:18',
           endDate: '2019-01-21T11:38:18',
@@ -464,6 +475,7 @@ describe('createEventHistoryOnUpdate', () => {
       shouldUpdateRepetition: true,
     };
     const event = {
+      _id: new ObjectID(),
       auxiliary: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-22T09:38:18',
@@ -482,6 +494,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'intervention',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-22T09:38:18',
@@ -507,6 +520,7 @@ describe('createEventHistoryOnUpdate', () => {
       misc: 'Toto',
     };
     const event = {
+      _id: new ObjectID(),
       auxiliary: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-22T09:38:18',
@@ -525,6 +539,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: INTERNAL_HOUR,
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-22T09:38:18',
@@ -550,6 +565,7 @@ describe('createEventHistoryOnUpdate', () => {
       misc: 'Toto',
     };
     const event = {
+      _id: new ObjectID(),
       auxiliary: new ObjectID(),
       startDate: '2019-01-21T09:38:18',
       endDate: '2019-01-22T09:38:18',
@@ -568,6 +584,7 @@ describe('createEventHistoryOnUpdate', () => {
         createdBy: 'james bond',
         action: 'event_update',
         event: {
+          eventId: event._id,
           type: 'absence',
           startDate: '2019-01-21T09:38:18',
           endDate: '2019-01-22T09:38:18',

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1306,14 +1306,17 @@ describe('createEvent', () => {
     isCreationAllowed.returns(true);
     isRepetition.returns(false);
     getEvent.returns(event);
-    createEvent.returns(event);
+    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
 
     await EventHelper.createEvent(payload, credentials);
 
     sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, event, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, event._id, credentials);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
-    sinon.assert.calledOnceWithExactly(createEvent, { ...payload, company: companyId });
+    SinonMongoose.calledWithExactly(
+      createEvent,
+      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
+    );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...payload, company: companyId });
     sinon.assert.notCalled(findOneUser);
     sinon.assert.notCalled(createRepetitions);
@@ -1335,20 +1338,24 @@ describe('createEvent', () => {
     isRepetition.returns(true);
     detachAuxiliaryFromEvent.returns(detachedEvent);
     getEvent.returns(detachedEvent);
-    createEvent.returns(detachedEvent);
+    createEvent.returns(SinonMongoose.stubChainedQueries([detachedEvent], ['toObject']));
 
     await EventHelper.createEvent(newEvent, credentials);
 
-    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, detachedEvent, credentials);
+    const repetition = { ...newEvent.repetition, parentId: detachedEvent._id };
+    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, { ...detachedEvent, repetition }, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, detachedEvent._id, credentials);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, detachedEvent);
-    sinon.assert.calledOnceWithExactly(createEvent, detachedEvent);
+    SinonMongoose.calledWithExactly(
+      createEvent,
+      [{ query: 'createEvent', args: [detachedEvent] }, { query: 'toObject' }]
+    );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...newEvent, company: companyId });
     sinon.assert.calledOnceWithExactly(detachAuxiliaryFromEvent, { ...newEvent, company: companyId }, companyId);
     sinon.assert.calledOnceWithExactly(
       createRepetitions,
       detachedEvent,
-      { ...newEvent, company: companyId, repetition: { ...newEvent.repetition, parentId: detachedEvent._id } },
+      { ...newEvent, company: companyId, repetition },
       credentials
     );
     sinon.assert.notCalled(findOneUser);
@@ -1360,22 +1367,26 @@ describe('createEvent', () => {
 
     isCreationAllowed.returns(true);
     hasConflicts.returns(false);
-    createEvent.returns(event);
+    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
     getEvent.returns(event);
     isRepetition.returns(true);
 
     await EventHelper.createEvent(payload, credentials);
 
-    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, event, credentials);
+    const repetition = { ...payload.repetition, parentId: event._id };
+    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, { ...event, repetition }, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, event._id, credentials);
     sinon.assert.calledOnceWithExactly(
       createRepetitions,
       event,
-      { ...payload, company: companyId, repetition: { ...payload.repetition, parentId: event._id } },
+      { ...payload, company: companyId, repetition },
       credentials
     );
     sinon.assert.calledOnceWithExactly(populateEventSubscription, event);
-    sinon.assert.calledOnceWithExactly(createEvent, { ...payload, company: companyId });
+    SinonMongoose.calledWithExactly(
+      createEvent,
+      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
+    );
     sinon.assert.calledOnceWithExactly(isRepetition, { ...payload, company: companyId });
     sinon.assert.notCalled(findOneUser);
     sinon.assert.notCalled(detachAuxiliaryFromEvent);
@@ -1396,7 +1407,7 @@ describe('createEvent', () => {
 
     isCreationAllowed.returns(true);
     isRepetition.returns(false);
-    createEvent.returns(event);
+    createEvent.returns(SinonMongoose.stubChainedQueries([event], ['toObject']));
     getEvent.returns(payload);
     findOneUser.returns(SinonMongoose.stubChainedQueries([auxiliary]));
 
@@ -1422,6 +1433,10 @@ describe('createEvent', () => {
         { query: 'populate', args: [{ path: 'sector', select: '_id sector', match: { company: companyId } }] },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
+    );
+    SinonMongoose.calledWithExactly(
+      createEvent,
+      [{ query: 'createEvent', args: [{ ...payload, company: companyId }] }, { query: 'toObject' }]
     );
     sinon.assert.notCalled(detachAuxiliaryFromEvent);
   });

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1343,7 +1343,7 @@ describe('createEvent', () => {
     await EventHelper.createEvent(newEvent, credentials);
 
     const repetition = { ...newEvent.repetition, parentId: detachedEvent._id };
-    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, { ...detachedEvent, repetition }, credentials);
+    sinon.assert.calledOnceWithExactly(createEventHistoryOnCreate, { ...newEvent, repetition }, credentials);
     sinon.assert.calledOnceWithExactly(getEvent, detachedEvent._id, credentials);
     sinon.assert.calledOnceWithExactly(populateEventSubscription, detachedEvent);
     SinonMongoose.calledWithExactly(

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -312,3 +312,33 @@ describe('areObjectIdsEquals', () => {
     expect(result).toBe(false);
   });
 });
+
+describe('doesArrayIncludeId', () => {
+  let areObjectIdsEqualStub;
+
+  beforeEach(() => { areObjectIdsEqualStub = sinon.stub(UtilsHelper, 'areObjectIdsEquals'); });
+
+  afterEach(() => { areObjectIdsEqualStub.restore(); });
+
+  it('should return true if the array includes the id', () => {
+    const correctId = new ObjectID();
+    const incorrectId = new ObjectID();
+    areObjectIdsEqualStub.onCall(0).returns(false);
+    areObjectIdsEqualStub.onCall(1).returns(true);
+
+    const result = UtilsHelper.doesArrayIncludeId([incorrectId, correctId], correctId);
+
+    expect(result).toBe(true);
+    sinon.assert.calledWithExactly(areObjectIdsEqualStub.getCall(0), incorrectId, correctId);
+    sinon.assert.calledWithExactly(areObjectIdsEqualStub.getCall(1), correctId, correctId);
+  });
+
+  it('should return false if the array does not include the id', () => {
+    areObjectIdsEqualStub.onCall(0).returns(false);
+    areObjectIdsEqualStub.onCall(1).returns(false);
+
+    const result = UtilsHelper.doesArrayIncludeId([new ObjectID(), new ObjectID()], new ObjectID());
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests -np
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/auxiliaires

- Cas d'usage : Lorsque je cree un evenement, il y a l'id de l'evenement dans l'historique créé
Plusieurs cas a tester: 
-  Création d’intervention
- Modification d’une intervention
- Suppression d’une intervention 
- Création d’une répétition d’interventions
- Modification d’un événement lié a une répétition (détachement)
- Création d’une heure interne
- Creation absence
- Creation Indispo 
- Création d’une intervention sur le planning beneficiaire

Probleme pour la suite : Lorsque l'on cree/modifie une intervention, on ne cree qu'un seul historique d'evenement. L'eventId correspond donc a un des evenements cree/modifie. Du coup cela risque de poser probleme pour afficher toutes les modifications d'evenements sur la modale. 

EDIT: ajout de `parentId` dans repetition pour pouvoir gerer le cas des repetitions
EDIT 2: ajout de minis refactos : 
- Ajout d'un await manquant
- Refacto de `formatHistoryForAuxiliaryUpdate` : j'ai l'impression que quand on modifiait l'auxiliaire d'un evenement de deux secteurs differents, on ajoutait tout le secteur plutot que juste l'id au tableau. J'ai l'impression que mongoose le changeait ensuite pour n'avoir que l'id, mais j'ai prefere faire le changement pour plus de clareté.