### PR TITLE
COM-2081 fix bills for customer with 0 participationrate

### DIFF
--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -231,11 +231,12 @@ exports.formatDraftBillsForCustomer = (customerPrices, event, eventPrice, servic
     prices.thirdPartyPayer = eventPrice.thirdPartyPayer;
   }
 
-  const onlyFundingChargedTime = !funding || funding.customerParticipationRate > 0 ? 0 : eventPrice.chargedTime;
+  const cusParticipationRateIsZero = funding && funding.customerParticipationRate === 0;
+  const timeNotChargedToCustomer = cusParticipationRateIsZero ? eventPrice.chargedTime : 0;
 
   return {
     eventsList: [...customerPrices.eventsList, { ...prices }],
-    hours: customerPrices.hours + ((moment(endDate).diff(moment(startDate), 'm') - onlyFundingChargedTime) / 60),
+    hours: customerPrices.hours + ((moment(endDate).diff(moment(startDate), 'm') - timeNotChargedToCustomer) / 60),
     exclTaxes: customerPrices.exclTaxes + eventPrice.customerPrice,
     inclTaxes: customerPrices.inclTaxes + inclTaxesCustomer,
   };

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -44,7 +44,6 @@ describe('populateSurcharge', () => {
 
     const result = await DraftBillsHelper.populateSurcharge(subscription, companyId);
 
-    expect(result).toBeDefined();
     expect(result._id).toEqual('abc');
     expect(result.versions.length).toEqual(2);
     expect(result.versions[0]._id).toEqual(4);
@@ -94,8 +93,6 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result).toBeDefined();
-    expect(result[0].thirdPartyPayer).toBeDefined();
     expect(result[0].thirdPartyPayer._id).toEqual(tppId);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledWithExactly(findOneFundingHistory, [
@@ -122,8 +119,6 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result).toBeDefined();
-    expect(result[0].history).toBeDefined();
     expect(result[0].history).toMatchObject([{ careHours: 4, fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledWithExactly(findOneFundingHistory, [
@@ -149,8 +144,6 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result).toBeDefined();
-    expect(result[0].history).toBeDefined();
     expect(result[0].history).toMatchObject([{ careHours: 0, amountTTC: 0, fundingId }]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledWithExactly(findOneFundingHistory, [
@@ -180,11 +173,8 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date('2019/03/10'), tpps, companyId);
 
-    expect(result).toBeDefined();
-    expect(result[0].history).toBeDefined();
     expect(result[0].history.length).toEqual(3);
     const addedHistory = result[0].history.find(hist => hist.month === '03/2019');
-    expect(addedHistory).toBeDefined();
     expect(addedHistory).toMatchObject({ careHours: 0, amountTTC: 0, fundingId, month: '03/2019' });
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
     SinonMongoose.calledWithExactly(findFundingHistory, [
@@ -205,7 +195,6 @@ describe('populateFundings', () => {
 
     const result = await DraftBillsHelper.populateFundings(fundings, new Date(), tpps, companyId);
 
-    expect(result).toBeDefined();
     expect(result).toEqual([]);
     sinon.assert.called(mergeLastVersionWithBaseObjectStub);
   });
@@ -247,7 +236,7 @@ describe('getMatchingFunding', () => {
       { _id: 2, careDays: [1, 5, 6], startDate: '2019-04-23T09:00:00', createdAt: '2019-04-23T09:00:00' },
     ];
     const result = DraftBillsHelper.getMatchingFunding('2019-04-23T09:00:00', fundings);
-    expect(result).toBeDefined();
+
     expect(result._id).toEqual(2);
   });
 
@@ -257,7 +246,7 @@ describe('getMatchingFunding', () => {
       { _id: 3, careDays: [4, 7], startDate: '2019-04-23T09:00:00' },
     ];
     const result = DraftBillsHelper.getMatchingFunding('2022-05-01T09:00:00', fundings);
-    expect(result).toBeDefined();
+
     expect(result._id).toEqual(3);
   });
 
@@ -293,8 +282,9 @@ describe('getMatchingHistory', () => {
   it('should return history for once frequency', () => {
     const fundingId = new ObjectID();
     const funding = { _id: fundingId, frequency: 'once', history: [{ fundingId, careHours: 2 }] };
+
     const result = DraftBillsHelper.getMatchingHistory({}, funding);
-    expect(result).toBeDefined();
+
     expect(result.fundingId).toEqual(fundingId);
   });
 
@@ -306,8 +296,9 @@ describe('getMatchingHistory', () => {
       history: [{ fundingId, careHours: 2, month: '03/2019' }, { fundingId, careHours: 4, month: '02/2019' }],
     };
     const event = { startDate: new Date('2019/03/12') };
+
     const result = DraftBillsHelper.getMatchingHistory(event, funding);
-    expect(result).toBeDefined();
+
     expect(result).toMatchObject({ fundingId, careHours: 2, month: '03/2019' });
   });
 
@@ -319,8 +310,9 @@ describe('getMatchingHistory', () => {
       history: [{ fundingId, careHours: 2, month: '01/2019' }, { fundingId, careHours: 4, month: '02/2019' }],
     };
     const event = { startDate: new Date('2019/03/12') };
+
     const result = DraftBillsHelper.getMatchingHistory(event, funding);
-    expect(result).toBeDefined();
+
     expect(result).toMatchObject({ careHours: 0, amountTTC: 0, fundingId, month: '03/2019' });
   });
 });
@@ -361,10 +353,9 @@ describe('getHourlyFundingSplit', () => {
     getThirdPartyPayerPrice.returns(28);
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, service, price);
-    expect(result).toBeDefined();
+
     expect(result.customerPrice).toEqual(22);
     expect(result.thirdPartyPayerPrice).toEqual(28);
-    expect(result.history).toBeDefined();
     expect(result.history.careHours).toEqual(2);
     sinon.assert.calledWithExactly(
       getThirdPartyPayerPrice,
@@ -389,17 +380,11 @@ describe('getHourlyFundingSplit', () => {
     getThirdPartyPayerPrice.returns(14);
 
     const result = DraftBillsHelper.getHourlyFundingSplit(event, funding, service, price);
-    expect(result).toBeDefined();
+
     expect(result.customerPrice).toEqual(36);
     expect(result.thirdPartyPayerPrice).toEqual(14);
-    expect(result.history).toBeDefined();
     expect(result.history.careHours).toEqual(1);
-    sinon.assert.calledWithExactly(
-      getThirdPartyPayerPrice,
-      60,
-      17.5,
-      20
-    );
+    sinon.assert.calledWithExactly(getThirdPartyPayerPrice, 60, 17.5, 20);
   });
 });
 
@@ -427,10 +412,9 @@ describe('getFixedFundingSplit', () => {
     getExclTaxes.returns(50);
 
     const result = DraftBillsHelper.getFixedFundingSplit(event, funding, service, price);
-    expect(result).toBeDefined();
+
     expect(result.customerPrice).toEqual(0);
     expect(result.thirdPartyPayerPrice).toEqual(50);
-    expect(result.history).toBeDefined();
     expect(result.history.amountTTC).toEqual(60);
     sinon.assert.notCalled(getExclTaxes);
   });
@@ -444,10 +428,9 @@ describe('getFixedFundingSplit', () => {
     getExclTaxes.returns(17.5);
 
     const result = DraftBillsHelper.getFixedFundingSplit(event, funding, service, price);
-    expect(result).toBeDefined();
+
     expect(result.customerPrice).toEqual(32.5);
     expect(result.thirdPartyPayerPrice).toEqual(17.5);
-    expect(result.history).toBeDefined();
     expect(result.history.amountTTC).toEqual(21);
     sinon.assert.calledWithExactly(getExclTaxes, 21, 20);
   });
@@ -484,7 +467,7 @@ describe('getEventBilling', () => {
     getExclTaxes.returns(17.5);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
-    expect(result).toBeDefined();
+
     expect(result).toEqual({ customerPrice: 35, thirdPartyPayerPrice: 0 });
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.notCalled(getFixedFundingSplit);
@@ -499,12 +482,8 @@ describe('getEventBilling', () => {
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
-    expect(result).toBeDefined();
-    expect(result).toEqual({
-      customerPrice: 38.5,
-      thirdPartyPayerPrice: 0,
-      surcharges: [{ percentage: 10 }],
-    });
+
+    expect(result).toEqual({ customerPrice: 38.5, thirdPartyPayerPrice: 0, surcharges: [{ percentage: 10 }] });
     sinon.assert.calledOnce(getEventSurcharges);
     sinon.assert.calledWithExactly(getSurchargedPrice, event, [{ percentage: 10 }], 35);
     sinon.assert.notCalled(getHourlyFundingSplit);
@@ -526,7 +505,7 @@ describe('getEventBilling', () => {
     getHourlyFundingSplit.returns({ customerPrice: 10, thirdPartyPayerPrice: 25 });
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
-    expect(result).toBeDefined();
+
     expect(result).toEqual({ customerPrice: 10, thirdPartyPayerPrice: 25 });
     sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, service, 35);
     sinon.assert.notCalled(getFixedFundingSplit);
@@ -546,7 +525,7 @@ describe('getEventBilling', () => {
     getFixedFundingSplit.returns({ customerPrice: 0, thirdPartyPayerPrice: 35 });
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
-    expect(result).toBeDefined();
+
     expect(result).toEqual({ customerPrice: 0, thirdPartyPayerPrice: 35 });
     sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, service, 35);
     sinon.assert.notCalled(getHourlyFundingSplit);
@@ -571,12 +550,8 @@ describe('getEventBilling', () => {
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
-    expect(result).toBeDefined();
-    expect(result).toEqual({
-      customerPrice: 10,
-      thirdPartyPayerPrice: 25,
-      surcharges: [{ percentage: 10 }],
-    });
+
+    expect(result).toEqual({ customerPrice: 10, thirdPartyPayerPrice: 25, surcharges: [{ percentage: 10 }] });
     sinon.assert.calledWithExactly(getHourlyFundingSplit, event, funding, service, 38.5);
     sinon.assert.notCalled(getFixedFundingSplit);
     sinon.assert.calledOnce(getEventSurcharges);
@@ -597,12 +572,8 @@ describe('getEventBilling', () => {
     getEventSurcharges.returns([{ percentage: 10 }]);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service, funding);
-    expect(result).toBeDefined();
-    expect(result).toEqual({
-      customerPrice: 0,
-      thirdPartyPayerPrice: 35,
-      surcharges: [{ percentage: 10 }],
-    });
+
+    expect(result).toEqual({ customerPrice: 0, thirdPartyPayerPrice: 35, surcharges: [{ percentage: 10 }] });
     sinon.assert.calledWithExactly(getFixedFundingSplit, event, funding, service, 38.5);
     sinon.assert.notCalled(getHourlyFundingSplit);
     sinon.assert.calledOnce(getEventSurcharges);
@@ -614,7 +585,7 @@ describe('getEventBilling', () => {
     getExclTaxes.returns(17.5);
 
     const result = DraftBillsHelper.getEventBilling(event, unitTTCRate, service);
-    expect(result).toBeDefined();
+
     result.customerPrice = Number.parseFloat(result.customerPrice.toFixed(2));
     expect(result).toEqual({ customerPrice: 17.5, thirdPartyPayerPrice: 0 });
     sinon.assert.notCalled(getHourlyFundingSplit);
@@ -646,7 +617,7 @@ describe('formatDraftBillsForCustomer', () => {
     getInclTaxes.callsFake((exclTaxes, vat) => exclTaxes * (1 + (vat / 100)));
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service, null);
-    expect(result).toBeDefined();
+
     expect(result).toMatchObject({
       eventsList: [
         { event: '123456' },
@@ -671,7 +642,7 @@ describe('formatDraftBillsForCustomer', () => {
     getInclTaxes.callsFake((exclTaxes, vat) => exclTaxes * (1 + (vat / 100)));
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service, funding);
-    expect(result).toBeDefined();
+
     expect(result).toMatchObject({
       eventsList: [
         { event: '123456' },
@@ -703,7 +674,7 @@ describe('formatDraftBillsForCustomer', () => {
     getInclTaxes.callsFake((exclTaxes, vat) => exclTaxes * (1 + (vat / 100)));
 
     const result = DraftBillsHelper.formatDraftBillsForCustomer(customerPrices, event, eventPrice, service, funding);
-    expect(result).toBeDefined();
+
     expect(result).toMatchObject({
       eventsList: [
         {
@@ -753,8 +724,7 @@ describe('formatDraftBillsForTPP', () => {
     getInclTaxes.callsFake((exclTaxes, vat) => exclTaxes * (1 + (vat / 100)));
 
     const result = DraftBillsHelper.formatDraftBillsForTPP(tppPrices, tpp, event, eventPrice, service);
-    expect(result).toBeDefined();
-    expect(result[tppId]).toBeDefined();
+
     expect(result[tppId].exclTaxes).toEqual(32.5);
     expect(result[tppId].inclTaxes).toEqual(40);
     expect(result[tppId].hours).toEqual(5);
@@ -821,8 +791,7 @@ describe('getDraftBillsPerSubscription', () => {
     getExclTaxes.returns(70);
 
     const result = DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, fundings, query);
-    expect(result).toBeDefined();
-    expect(result.customer).toBeDefined();
+
     expect(moment(result.customer.startDate).format('DD/MM/YYYY')).toEqual('15/01/2019');
     expect(result.customer.exclTaxes).toEqual(70);
     expect(result.customer.inclTaxes).toEqual(84);
@@ -868,13 +837,11 @@ describe('getDraftBillsPerSubscription', () => {
     getExclTaxes.returns(17.5);
 
     const result = DraftBillsHelper.getDraftBillsPerSubscription(events, subscription, fundings, query);
-    expect(result).toBeDefined();
-    expect(result.customer).toBeDefined();
+
     expect(moment(result.customer.startDate).format('DD/MM/YYYY')).toEqual('15/01/2019');
     expect(result.customer.exclTaxes).toEqual(57.5);
     expect(result.customer.inclTaxes).toEqual(69);
     expect(result.customer.unitExclTaxes).toEqual(17.5);
-    expect(result.thirdPartyPayer).toBeDefined();
     expect(result.thirdPartyPayer[tppId].exclTaxes).toEqual(12.5);
     expect(result.thirdPartyPayer[tppId].inclTaxes).toEqual(15);
   });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests -np
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : Si un beneficiaire a une participation de 0% sur les heures prises en charge par le tiers payeurs : il n'y a pas de facture pour le beneficiaire si le nombre d'heures effectuées est inferieur au nombre d'heure pris en charge par le tpp; il y a une facture avec uniquement les heures en plus si le nombre d'heure effectuées est superieur au nombre d'heure pris en charge par le tpp.

Avant, il y avait un soucis pour les beneficiaires avec une participation de 0% lorsqu'une intervention etait en partie prise en charge et en partie non prise en charge (ex: 15h prise en charge, il y a deja 14h d'intervention, l'intervention suivante est de 2h : il y a donc une heure prise en charge par le tpp et une heure que le beneficiaire doit payer)