### PR TITLE
COM-2070: remove customer partner

### DIFF
--- a/src/controllers/customerPartnerController.js
+++ b/src/controllers/customerPartnerController.js
@@ -42,4 +42,15 @@ const update = async (req) => {
   }
 };
 
-module.exports = { create, list, update };
+const remove = async (req) => {
+  try {
+    await CustomerPartnerHelper.remove(req.params._id);
+
+    return { message: translate[language].customerPartnerRemoved };
+  } catch (e) {
+    req.log('error', e);
+    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
+  }
+};
+
+module.exports = { create, list, update, remove };

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -28,4 +28,4 @@ exports.update = async (customerPartnerId, payload) => {
   }
 };
 
-exports.remove = async id => CustomerPartner.deleteMany({ _id: id });
+exports.remove = async customerPartnerId => CustomerPartner.deleteOne({ _id: customerPartnerId });

--- a/src/helpers/customerPartners.js
+++ b/src/helpers/customerPartners.js
@@ -27,3 +27,5 @@ exports.update = async (customerPartnerId, payload) => {
     );
   }
 };
+
+exports.remove = async id => CustomerPartner.deleteMany({ _id: id });

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -315,6 +315,8 @@ module.exports = {
     customerPartnersNotFound: 'Customer partners not found.',
     customerPartnerAlreadyExists: 'Customer partner already exists.',
     customerPartnerUpdated: 'Customer partner updated.',
+    customerPartnerRemoved: 'Customer partner removed.',
+
   },
   'fr-FR': {
     /* Global errors */
@@ -629,6 +631,7 @@ module.exports = {
     customerPartnersNotFound: 'Liste des partenaires bénéficiaire non trouvée.',
     customerPartnerAlreadyExists: 'Ce partenaire existe déjà.',
     customerPartnerUpdated: 'Partenaire mis à jour.',
+    customerPartnerRemoved: 'Partenaire supprimé.',
 
   },
 };

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -316,7 +316,6 @@ module.exports = {
     customerPartnerAlreadyExists: 'Customer partner already exists.',
     customerPartnerUpdated: 'Customer partner updated.',
     customerPartnerRemoved: 'Customer partner removed.',
-
   },
   'fr-FR': {
     /* Global errors */
@@ -632,6 +631,5 @@ module.exports = {
     customerPartnerAlreadyExists: 'Ce partenaire existe déjà.',
     customerPartnerUpdated: 'Partenaire mis à jour.',
     customerPartnerRemoved: 'Partenaire supprimé.',
-
   },
 };

--- a/src/routes/customerPartners.js
+++ b/src/routes/customerPartners.js
@@ -57,9 +57,7 @@ exports.plugin = {
       path: '/{_id}',
       options: {
         auth: { scope: ['customerpartners:edit'] },
-        validate: {
-          params: Joi.object({ _id: Joi.objectId().required() }),
-        },
+        validate: { params: Joi.object({ _id: Joi.objectId().required() }) },
         pre: [{ method: authorizeCustomerPartnerEdit }],
       },
       handler: remove,

--- a/src/routes/customerPartners.js
+++ b/src/routes/customerPartners.js
@@ -1,9 +1,9 @@
 const Joi = require('joi');
-const { create, list, update } = require('../controllers/customerPartnerController');
+const { create, list, update, remove } = require('../controllers/customerPartnerController');
 const {
   authorizeCustomerPartnerCreation,
   authorizeCustomerPartnersGet,
-  authorizeCustomerPartnersUpdate,
+  authorizeCustomerPartnerEdit,
 } = require('./preHandlers/customerPartners');
 
 exports.plugin = {
@@ -47,9 +47,22 @@ exports.plugin = {
           payload: Joi.object({ prescriber: Joi.boolean().required() }),
         },
         auth: { scope: ['customerpartners:edit'] },
-        pre: [{ method: authorizeCustomerPartnersUpdate }],
+        pre: [{ method: authorizeCustomerPartnerEdit }],
       },
       handler: update,
+    });
+
+    server.route({
+      method: 'DELETE',
+      path: '/{_id}',
+      options: {
+        auth: { scope: ['customerpartners:edit'] },
+        validate: {
+          params: Joi.object({ _id: Joi.objectId().required() }),
+        },
+        pre: [{ method: authorizeCustomerPartnerEdit }],
+      },
+      handler: remove,
     });
   },
 };

--- a/src/routes/preHandlers/customerPartners.js
+++ b/src/routes/preHandlers/customerPartners.js
@@ -32,7 +32,7 @@ exports.authorizeCustomerPartnersGet = async (req) => {
   return null;
 };
 
-exports.authorizeCustomerPartnersUpdate = async (req) => {
+exports.authorizeCustomerPartnerEdit = async (req) => {
   const { credentials } = req.auth;
   const loggedUserCompany = get(credentials, 'company._id');
   const customerPartner = await CustomerPartner.countDocuments({ _id: req.params._id, company: loggedUserCompany });

--- a/tests/integration/customerPartners.test.js
+++ b/tests/integration/customerPartners.test.js
@@ -274,6 +274,7 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
     it('should return 404 if customer partner has wrong company', async () => {
       const customerPartnerId = customerPartnersList[0]._id;
       const response = await app.inject({
@@ -349,6 +350,7 @@ describe('CUSTOMER PARTNERS ROUTES - DELETE /customerpartners/{_id}', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
     it('should return 404 if customer partner has wrong company', async () => {
       const customerPartnerId = customerPartnersList[0]._id;
       const response = await app.inject({
@@ -365,6 +367,7 @@ describe('CUSTOMER PARTNERS ROUTES - DELETE /customerpartners/{_id}', () => {
     const roles = [
       { name: 'vendor_admin', expectedCode: 403 },
       { name: 'helper', expectedCode: 403 },
+      { name: 'auxiliary_without_company', expectedCode: 403 },
     ];
 
     roles.forEach((role) => {

--- a/tests/integration/customerPartners.test.js
+++ b/tests/integration/customerPartners.test.js
@@ -309,3 +309,77 @@ describe('CUSTOMER PARTNERS ROUTES - PUT /customerpartners/{_id}', () => {
     });
   });
 });
+
+describe('CUSTOMER PARTNERS ROUTES - DELETE /customerpartners/{_id}', () => {
+  let authToken = null;
+  beforeEach(populateDB);
+
+  describe('AUXILIARY', () => {
+    beforeEach(async () => {
+      authToken = await getToken('auxiliary');
+    });
+
+    it('should remove customer partner', async () => {
+      const customerPartnerId = customerPartnersList[1]._id;
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/customerpartners/${customerPartnerId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 400 if params is not an id', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/customerpartners/skusku',
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 if customer partner doesn\'t exist', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/customerpartners/${new ObjectID()}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+    it('should return 404 if customer partner has wrong company', async () => {
+      const customerPartnerId = customerPartnersList[0]._id;
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/customerpartners/${customerPartnerId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('Other roles', () => {
+    const roles = [
+      { name: 'vendor_admin', expectedCode: 403 },
+      { name: 'helper', expectedCode: 403 },
+    ];
+
+    roles.forEach((role) => {
+      it(`should return ${role.expectedCode} as user is ${role.name}`, async () => {
+        authToken = await getToken(role.name);
+        const customerPartnerId = customerPartnersList[1]._id;
+        const response = await app.inject({
+          method: 'DELETE',
+          url: `/customerpartners/${customerPartnerId}`,
+          headers: { Cookie: `alenvi_token=${authToken}` },
+          payload: { prescriber: true },
+        });
+
+        expect(response.statusCode).toBe(role.expectedCode);
+      });
+    });
+  });
+});

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -120,3 +120,21 @@ describe('update', () => {
     );
   });
 });
+
+describe('remove', () => {
+  let deleteMany;
+  beforeEach(() => {
+    deleteMany = sinon.stub(CustomerPartner, 'deleteMany');
+  });
+  afterEach(() => {
+    deleteMany.restore();
+  });
+
+  it('should delete a customer partner', async () => {
+    const id = new ObjectID();
+
+    await CustomerPartnersHelper.remove(id);
+
+    sinon.assert.calledOnceWithExactly(deleteMany, { _id: id });
+  });
+});

--- a/tests/unit/helpers/customerPartners.test.js
+++ b/tests/unit/helpers/customerPartners.test.js
@@ -122,19 +122,19 @@ describe('update', () => {
 });
 
 describe('remove', () => {
-  let deleteMany;
+  let deleteOne;
   beforeEach(() => {
-    deleteMany = sinon.stub(CustomerPartner, 'deleteMany');
+    deleteOne = sinon.stub(CustomerPartner, 'deleteOne');
   });
   afterEach(() => {
-    deleteMany.restore();
+    deleteOne.restore();
   });
 
   it('should delete a customer partner', async () => {
-    const id = new ObjectID();
+    const customerPartnerId = new ObjectID();
 
-    await CustomerPartnersHelper.remove(id);
+    await CustomerPartnersHelper.remove(customerPartnerId);
 
-    sinon.assert.calledOnceWithExactly(deleteMany, { _id: id });
+    sinon.assert.calledOnceWithExactly(deleteOne, { _id: customerPartnerId });
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : auxiliaire/coach/admin

- Cas d'usage : je peux retirer un partenaire sur la fiche bénéficiaire
