### PR TITLE
COM-2074 can timestamp end of intervention

### DIFF
--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -228,7 +228,7 @@ exports.formatHistoryForCancelUpdate = async (mainInfo, payload, companyId) => {
 
 exports.createTimeStampHistory = async (event, payload, credentials) => {
   const { startDate, endDate } = payload;
-  const eventPayload = { ...omit(event, ['_id', 'startDate']), eventId: event._id };
+  const eventPayload = { ...omit(event, ['_id']), eventId: event._id };
   const updatePayload = {};
 
   if (startDate) {

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -226,12 +226,28 @@ exports.formatHistoryForCancelUpdate = async (mainInfo, payload, companyId) => {
   return datesUpdateHistory;
 };
 
-exports.createTimeStampHistory = async (event, payload, credentials) => EventHistory.create({
-  event: { ...omit(event, ['_id', 'startDate']), eventId: event._id, startDate: payload.startDate },
-  company: event.company,
-  action: payload.action,
-  manualTimeStampingReason: payload.reason,
-  auxiliaries: [event.auxiliary],
-  update: { startHour: { from: event.startDate, to: payload.startDate } },
-  createdBy: credentials._id,
-});
+exports.createTimeStampHistory = async (event, payload, credentials) => {
+  const { startDate, endDate } = payload;
+  const eventPayload = { ...omit(event, ['_id', 'startDate']), eventId: event._id };
+  const updatePayload = {};
+
+  if (startDate) {
+    eventPayload.startDate = startDate;
+    updatePayload.startHour = { from: event.startDate, to: startDate };
+  }
+
+  if (endDate) {
+    eventPayload.endDate = endDate;
+    updatePayload.endHour = { from: event.endDate, to: endDate };
+  }
+
+  await EventHistory.create({
+    event: eventPayload,
+    company: event.company,
+    action: payload.action,
+    manualTimeStampingReason: payload.reason,
+    auxiliaries: [event.auxiliary],
+    update: updatePayload,
+    createdBy: credentials._id,
+  });
+};

--- a/src/helpers/eventTimeStamping.js
+++ b/src/helpers/eventTimeStamping.js
@@ -17,6 +17,7 @@ exports.isStartDateTimeStampAllowed = async (event, startDate) => {
 };
 
 exports.isEndDateTimeStampAllowed = async (event, endDate) => {
+  if (DatesHelper.isSameOrAfter(event.startDate, endDate)) throw Boom.badData(translate[language].timeStampTooEarly);
   if (await EventValidationHelper.hasConflicts({ ...event, endDate })) {
     throw Boom.conflict(translate[language].timeStampConflict);
   }
@@ -28,7 +29,7 @@ exports.addTimeStamp = async (event, payload, credentials) => {
   if (payload.startDate && !(await exports.isStartDateTimeStampAllowed(event, payload.startDate))) {
     throw Boom.conflict(translate[language].timeStampOtherConflict);
   }
-  if (payload.endDate && !(await exports.isEndDateTimeStampAllowed(event, payload.startDate))) {
+  if (payload.endDate && !(await exports.isEndDateTimeStampAllowed(event, payload.endDate))) {
     throw Boom.conflict(translate[language].timeStampOtherConflict);
   }
 

--- a/src/helpers/eventTimeStamping.js
+++ b/src/helpers/eventTimeStamping.js
@@ -28,8 +28,7 @@ exports.isEndDateTimeStampAllowed = async (event, endDate) => {
 exports.addTimeStamp = async (event, payload, credentials) => {
   if (payload.startDate && !(await exports.isStartDateTimeStampAllowed(event, payload.startDate))) {
     throw Boom.conflict(translate[language].timeStampOtherConflict);
-  }
-  if (payload.endDate && !(await exports.isEndDateTimeStampAllowed(event, payload.endDate))) {
+  } else if (payload.endDate && !(await exports.isEndDateTimeStampAllowed(event, payload.endDate))) {
     throw Boom.conflict(translate[language].timeStampOtherConflict);
   }
 

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -144,6 +144,7 @@ module.exports = {
     timeStampConflict: 'The timestamp is in conflict with an event.',
     timeStampOtherConflict: 'Timestamp error. Contact technical support.',
     timeStampTooLate: 'Can\'t timestamp startDate after event ends.',
+    timeStampTooEarly: 'Can\'t timestamp endDate before event starts.',
     /* Sectors */
     sectorCreated: 'Sector created.',
     sectorUpdated: 'Sector updated.',
@@ -465,6 +466,7 @@ module.exports = {
     timeStampConflict: 'L\'horodatage est en conflit avec un évènement.',
     timeStampOtherConflict: 'Problème lors de l\'horodatage. Contactez le support technique.',
     timeStampTooLate: 'Vous ne pouvez pas horodater le début d\'un évènement terminé.',
+    timeStampTooEarly: 'Vous ne pouvez pas horodater la fin d\'un évènement avant son commencement.',
     /* Sectors */
     sectorCreated: 'Équipe créée.',
     sectorUpdated: 'Équipe modifiée.',

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -295,9 +295,10 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
             action: Joi.string().required().valid(...TIMESTAMPING_ACTIONS),
-            startDate: Joi.date().required(),
+            startDate: Joi.date(),
+            endDate: Joi.date(),
             reason: Joi.string().required().valid(...MANUAL_TIME_STAMPING_REASONS),
-          }),
+          }).xor('startDate', 'endDate'),
         },
         pre: [{ method: getEvent, assign: 'event' }, { method: authorizeTimeStamping }],
       },

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -204,11 +204,11 @@ exports.authorizeTimeStamping = async (req) => {
   });
   if (!eventCount) throw Boom.notFound();
 
-  const alreadyTimeStamped = await EventHistory.countDocuments({
-    'event.eventId': req.params._id,
-    action: MANUAL_TIME_STAMPING,
-    'update.startHour': { $exists: true },
-  });
+  const timeStampPayload = { 'event.eventId': req.params._id, action: MANUAL_TIME_STAMPING };
+  if (req.payload.startDate) timeStampPayload['update.startHour'] = { $exists: true };
+  else timeStampPayload['update.endHour'] = { $exists: true };
+
+  const alreadyTimeStamped = await EventHistory.countDocuments(timeStampPayload);
   if (alreadyTimeStamped) throw Boom.conflict(translate[language].alreadyTimeStamped);
 
   return null;

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1762,7 +1762,7 @@ describe('DELETE /{_id}/repetition', () => {
   });
 });
 
-describe('PUT /{_id}/timestamping #tag', () => {
+describe('PUT /{_id}/timestamping', () => {
   let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
@@ -1784,7 +1784,6 @@ describe('PUT /{_id}/timestamping #tag', () => {
         'event.startDate': startDate,
         action: 'manual_time_stamping',
         manualTimeStampingReason: 'camera_error',
-
       });
       expect(timestamp).toBe(1);
     });
@@ -1801,14 +1800,6 @@ describe('PUT /{_id}/timestamping #tag', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const timestamp = await EventHistory.countDocuments({
-        'event.eventId': eventsList[21]._id,
-        'event.endDate': endDate,
-        action: 'manual_time_stamping',
-        manualTimeStampingReason: 'camera_error',
-
-      });
-      expect(timestamp).toBe(1);
     });
 
     it('should return a 404 if event does not exist', async () => {
@@ -1879,14 +1870,14 @@ describe('PUT /{_id}/timestamping #tag', () => {
     });
 
     it('should return a 409 if event is already endDate timestamped', async () => {
-      authToken = await getTokenByCredentials(auxiliaries[2].local);
-      const startDate = new Date();
+      authToken = await getTokenByCredentials(auxiliaries[3].local);
+      const endDate = new Date();
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/events/${eventsList[23]._id}/timestamping`,
+        url: `/events/${eventsList[24]._id}/timestamping`,
         headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { startDate, action: 'manual_time_stamping', reason: 'camera_error' },
+        payload: { endDate, action: 'manual_time_stamping', reason: 'camera_error' },
       });
 
       expect(response.statusCode).toBe(409);

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1762,7 +1762,7 @@ describe('DELETE /{_id}/repetition', () => {
   });
 });
 
-describe('PUT /{_id}/timestamping', () => {
+describe('PUT /{_id}/timestamping #tag', () => {
   let authToken;
   describe('AUXILIARY', () => {
     beforeEach(populateDB);
@@ -1864,7 +1864,21 @@ describe('PUT /{_id}/timestamping', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it('should return a 409 if event is already timestamped', async () => {
+    it('should return a 409 if event is already startDate timestamped', async () => {
+      authToken = await getTokenByCredentials(auxiliaries[2].local);
+      const startDate = new Date();
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[23]._id}/timestamping`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { startDate, action: 'manual_time_stamping', reason: 'camera_error' },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+
+    it('should return a 409 if event is already endDate timestamped', async () => {
       authToken = await getTokenByCredentials(auxiliaries[2].local);
       const startDate = new Date();
 

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -27,7 +27,7 @@ const {
   PARENTAL_LEAVE,
 } = require('../../../src/helpers/constants');
 
-const auxiliariesIds = [new ObjectID(), new ObjectID(), new ObjectID()];
+const auxiliariesIds = [new ObjectID(), new ObjectID(), new ObjectID(), new ObjectID()];
 
 const contracts = [
   {
@@ -58,6 +58,18 @@ const contracts = [
     _id: new ObjectID(),
     serialNumber: 'dskfajdksjfkjhg',
     user: auxiliariesIds[2],
+    company: authCompany._id,
+    startDate: '2010-09-03T00:00:00',
+    versions: [{
+      startDate: '2010-09-03T00:00:00',
+      grossHourlyRate: 10.43,
+      weeklyHours: 12,
+    }],
+  },
+  {
+    _id: new ObjectID(),
+    serialNumber: 'dskfajdksjwefkjhg',
+    user: auxiliariesIds[3],
     company: authCompany._id,
     startDate: '2010-09-03T00:00:00',
     versions: [{
@@ -111,6 +123,17 @@ const auxiliaries = [
     _id: auxiliariesIds[2],
     identity: { firstname: 'Philippe', lastname: 'Pinot' },
     local: { email: 'p@p.com', password: '123456!eR' },
+    administrative: { driveFolder: { driveId: '1234567890123456' }, transportInvoice: { transportType: 'public' } },
+    refreshToken: uuidv4(),
+    role: { client: rolesList.find(role => role.name === 'auxiliary')._id },
+    contracts: [contracts[2]._id],
+    company: authCompany._id,
+    origin: WEBAPP,
+  },
+  {
+    _id: auxiliariesIds[3],
+    identity: { firstname: 'Qertyui', lastname: 'Pinot' },
+    local: { email: 'qwerty@p.com', password: '123456!eR' },
     administrative: { driveFolder: { driveId: '1234567890123456' }, transportInvoice: { transportType: 'public' } },
     refreshToken: uuidv4(),
     role: { client: rolesList.find(role => role.name === 'auxiliary')._id },
@@ -781,6 +804,25 @@ const eventsList = [
       location: { type: 'Point', coordinates: [2.377133, 48.801389] },
     },
   },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    type: INTERVENTION,
+    repetition: { frequency: NEVER },
+    startDate: (new Date()).setHours((new Date()).getHours() - 2),
+    endDate: (new Date()),
+    auxiliary: auxiliaries[3]._id,
+    customer: customerAuxiliary._id,
+    subscription: customerAuxiliary.subscriptions[2]._id,
+    createdAt: '2019-01-05T15:24:18.653Z',
+    address: {
+      fullAddress: '4 rue du test 92160 Antony',
+      street: '4 rue du test',
+      zipCode: '92160',
+      city: 'Antony',
+      location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+    },
+  },
 ];
 
 const eventFromOtherCompany = {
@@ -846,6 +888,14 @@ const eventHistoriesList = [
     auxiliaries: [eventsList[23].auxiliary],
     update: { startHour: { from: eventsList[23].startDate, to: timeStampingDate } },
   },
+  {
+    event: { eventId: eventsList[24]._id, endDate: timeStampingDate },
+    company: eventsList[24].company,
+    action: 'manual_time_stamping',
+    manualTimeStampingReason: 'qrcode_missing',
+    auxiliaries: [eventsList[24].auxiliary],
+    update: { endHour: { from: eventsList[24].endDate, to: timeStampingDate } },
+  },
 ];
 
 const populateDB = async () => {
@@ -873,6 +923,7 @@ const populateDB = async () => {
   await (new User(auxiliaries[0])).save();
   await (new User(auxiliaries[1])).save();
   await (new User(auxiliaries[2])).save();
+  await (new User(auxiliaries[3])).save();
   await (new User(helpersCustomer)).save();
   await (new User(auxiliaryFromOtherCompany)).save();
   await Contract.insertMany(contracts);

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -961,7 +961,7 @@ describe('createTimeStampHistory', () => {
 
   afterEach(() => { create.restore(); });
 
-  it('should create and event history of type timestamp', async () => {
+  it('should create and event history of type timestamp for startDate', async () => {
     const event = {
       _id: new ObjectID(),
       startDate: '2021-05-01T10:00:00',
@@ -985,6 +985,35 @@ describe('createTimeStampHistory', () => {
         manualTimeStampingReason: 'qrcode',
         auxiliaries: [event.auxiliary],
         update: { startHour: { from: '2021-05-01T10:00:00', to: '2021-05-01T10:02:00' } },
+        createdBy: credentials._id,
+      }
+    );
+  });
+
+  it('should create and event history of type timestamp for endDate', async () => {
+    const event = {
+      _id: new ObjectID(),
+      startDate: '2021-05-01T10:00:00',
+      endDate: '2021-05-01T12:00:00',
+      customer: new ObjectID(),
+      misc: 'test',
+      company: new ObjectID(),
+      repetition: { frequency: 'every_day', parentID: new ObjectID() },
+    };
+    const payload = { endDate: '2021-05-01T12:05:00', reason: 'qrcode', action: 'manual_time_stamping' };
+    const credentials = { _id: new ObjectID() };
+
+    await EventHistoryHelper.createTimeStampHistory(event, payload, credentials);
+
+    sinon.assert.calledOnceWithExactly(
+      create,
+      {
+        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00' },
+        company: event.company,
+        action: 'manual_time_stamping',
+        manualTimeStampingReason: 'qrcode',
+        auxiliaries: [event.auxiliary],
+        update: { endHour: { from: '2021-05-01T12:00:00', to: '2021-05-01T12:05:00' } },
         createdBy: credentials._id,
       }
     );

--- a/tests/unit/helpers/eventTimeStamping.test.js
+++ b/tests/unit/helpers/eventTimeStamping.test.js
@@ -7,7 +7,7 @@ const eventHistoryHelper = require('../../../src/helpers/eventHistories');
 const eventValidationHelper = require('../../../src/helpers/eventsValidation');
 const Event = require('../../../src/models/Event');
 
-describe('isTimeStampAllowed', () => {
+describe('isStartDateTimeStampAllowed', () => {
   let hasConflictsStub;
 
   beforeEach(() => { hasConflictsStub = sinon.stub(eventValidationHelper, 'hasConflicts'); });
@@ -20,7 +20,7 @@ describe('isTimeStampAllowed', () => {
 
     hasConflictsStub.returns(false);
 
-    const result = await eventTimeStampingHelper.isTimeStampAllowed(event, startDate);
+    const result = await eventTimeStampingHelper.isStartDateTimeStampAllowed(event, startDate);
 
     expect(result).toBe(true);
   });
@@ -29,7 +29,7 @@ describe('isTimeStampAllowed', () => {
     const event = { _id: new ObjectID(), startDate: '2021-05-01T10:00:00', endDate: '2021-05-01T12:00:00' };
     const startDate = '2021-05-01T12:30:00';
     try {
-      await eventTimeStampingHelper.isTimeStampAllowed(event, startDate);
+      await eventTimeStampingHelper.isStartDateTimeStampAllowed(event, startDate);
 
       expect(true).toBe(false);
     } catch (e) {
@@ -43,7 +43,7 @@ describe('isTimeStampAllowed', () => {
     try {
       hasConflictsStub.returns(true);
 
-      await eventTimeStampingHelper.isTimeStampAllowed(event, startDate);
+      await eventTimeStampingHelper.isStartDateTimeStampAllowed(event, startDate);
 
       expect(true).toBe(false);
     } catch (e) {
@@ -59,7 +59,7 @@ describe('addTimeStamp', () => {
   let updateOne;
 
   beforeEach(() => {
-    isTimeStampAllowedStub = sinon.stub(eventTimeStampingHelper, 'isTimeStampAllowed');
+    isTimeStampAllowedStub = sinon.stub(eventTimeStampingHelper, 'isStartDateTimeStampAllowed');
     createTimeStampHistoryStub = sinon.stub(eventHistoryHelper, 'createTimeStampHistory');
     updateOne = sinon.stub(Event, 'updateOne');
   });

--- a/tests/unit/helpers/eventTimeStamping.test.js
+++ b/tests/unit/helpers/eventTimeStamping.test.js
@@ -23,6 +23,7 @@ describe('isStartDateTimeStampAllowed', () => {
     const result = await eventTimeStampingHelper.isStartDateTimeStampAllowed(event, startDate);
 
     expect(result).toBe(true);
+    sinon.assert.calledOnceWithExactly(hasConflictsStub, { ...event, startDate });
   });
 
   it('should return a 422 if endDate is before timestamping date', async () => {
@@ -53,54 +54,142 @@ describe('isStartDateTimeStampAllowed', () => {
   });
 });
 
-describe('addTimeStamp', () => {
-  let isTimeStampAllowedStub;
+describe('isEndDateTimeStampAllowed', () => {
+  let hasConflictsStub;
+
+  beforeEach(() => { hasConflictsStub = sinon.stub(eventValidationHelper, 'hasConflicts'); });
+
+  afterEach(() => { hasConflictsStub.restore(); });
+
+  it('should return true if user is allowed to timestamp', async () => {
+    const event = { _id: new ObjectID(), startDate: '2021-05-01T10:00:00', endDate: '2021-05-01T12:00:00' };
+    const endDate = '2021-05-01T12:04:00';
+
+    hasConflictsStub.returns(false);
+
+    const result = await eventTimeStampingHelper.isEndDateTimeStampAllowed(event, endDate);
+
+    expect(result).toBe(true);
+    sinon.assert.calledOnceWithExactly(hasConflictsStub, { ...event, endDate });
+  });
+
+  it('should return a 422 if startDate is after timestamping date', async () => {
+    const event = { _id: new ObjectID(), startDate: '2021-05-01T10:00:00', endDate: '2021-05-01T12:00:00' };
+    const endDate = '2021-05-01T09:30:00';
+    try {
+      await eventTimeStampingHelper.isEndDateTimeStampAllowed(event, endDate);
+
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toEqual(Boom.badData('Vous ne pouvez pas horodater la fin d\'un évènement avant son commencement.'));
+    }
+  });
+
+  it('should return a 409 if new event is in conflict with other events', async () => {
+    const event = { _id: new ObjectID(), startDate: '2021-05-01T10:00:00', endDate: '2021-05-01T12:00:00' };
+    const endDate = '2021-05-01T12:45:00';
+    try {
+      hasConflictsStub.returns(true);
+
+      await eventTimeStampingHelper.isEndDateTimeStampAllowed(event, endDate);
+
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toEqual(Boom.conflict('L\'horodatage est en conflit avec un évènement.'));
+      sinon.assert.calledOnceWithExactly(hasConflictsStub, { ...event, endDate });
+    }
+  });
+});
+
+describe('addTimeStamp #tag', () => {
+  let isStartDateTimeStampAllowedStub;
+  let isEndDateTimeStampAllowedStub;
   let createTimeStampHistoryStub;
   let updateOne;
 
   beforeEach(() => {
-    isTimeStampAllowedStub = sinon.stub(eventTimeStampingHelper, 'isStartDateTimeStampAllowed');
+    isStartDateTimeStampAllowedStub = sinon.stub(eventTimeStampingHelper, 'isStartDateTimeStampAllowed');
+    isEndDateTimeStampAllowedStub = sinon.stub(eventTimeStampingHelper, 'isEndDateTimeStampAllowed');
     createTimeStampHistoryStub = sinon.stub(eventHistoryHelper, 'createTimeStampHistory');
     updateOne = sinon.stub(Event, 'updateOne');
   });
 
   afterEach(() => {
-    isTimeStampAllowedStub.restore();
+    isStartDateTimeStampAllowedStub.restore();
+    isEndDateTimeStampAllowedStub.restore();
     createTimeStampHistoryStub.restore();
     updateOne.restore();
   });
 
-  it('should add timestamp and updateEvent', async () => {
+  it('should add startDate timestamp and updateEvent', async () => {
     const event = { _id: new ObjectID() };
     const startDate = new Date();
     const payload = { action: 'manual_timestamping', reason: 'qrcode', startDate };
     const credentials = { _id: new ObjectID() };
 
-    isTimeStampAllowedStub.returns(true);
+    isStartDateTimeStampAllowedStub.returns(true);
 
     await eventTimeStampingHelper.addTimeStamp(event, payload, credentials);
 
-    sinon.assert.calledOnceWithExactly(isTimeStampAllowedStub, event, startDate);
+    sinon.assert.calledOnceWithExactly(isStartDateTimeStampAllowedStub, event, startDate);
     sinon.assert.calledOnceWithExactly(createTimeStampHistoryStub, event, payload, credentials);
     sinon.assert.calledOnceWithExactly(updateOne, { _id: event._id }, { startDate });
+    sinon.assert.notCalled(isEndDateTimeStampAllowedStub);
   });
 
-  it('should return a 409 if timestamp is not allowed', async () => {
+  it('should return a 409 if startDate timestamp is not allowed', async () => {
     const event = { _id: new ObjectID() };
     const startDate = new Date();
     const payload = { action: 'manual_timestamping', reason: 'qrcode', startDate };
     const credentials = { _id: new ObjectID() };
 
     try {
-      isTimeStampAllowedStub.returns(false);
+      isStartDateTimeStampAllowedStub.returns(false);
 
       await eventTimeStampingHelper.addTimeStamp(event, payload, credentials);
       expect(true).toBe(false);
     } catch (e) {
       expect(e).toEqual(Boom.conflict('Problème lors de l\'horodatage. Contactez le support technique.'));
-      sinon.assert.calledOnceWithExactly(isTimeStampAllowedStub, event, startDate);
+      sinon.assert.calledOnceWithExactly(isStartDateTimeStampAllowedStub, event, startDate);
       sinon.assert.notCalled(createTimeStampHistoryStub);
       sinon.assert.notCalled(updateOne);
+      sinon.assert.notCalled(isEndDateTimeStampAllowedStub);
+    }
+  });
+
+  it('should add startDate timestamp and updateEvent', async () => {
+    const event = { _id: new ObjectID() };
+    const endDate = new Date();
+    const payload = { action: 'manual_timestamping', reason: 'qrcode', endDate };
+    const credentials = { _id: new ObjectID() };
+
+    isEndDateTimeStampAllowedStub.returns(true);
+
+    await eventTimeStampingHelper.addTimeStamp(event, payload, credentials);
+
+    sinon.assert.calledOnceWithExactly(isEndDateTimeStampAllowedStub, event, endDate);
+    sinon.assert.calledOnceWithExactly(createTimeStampHistoryStub, event, payload, credentials);
+    sinon.assert.calledOnceWithExactly(updateOne, { _id: event._id }, { endDate });
+    sinon.assert.notCalled(isStartDateTimeStampAllowedStub);
+  });
+
+  it('should return a 409 if startDate timestamp is not allowed', async () => {
+    const event = { _id: new ObjectID() };
+    const endDate = new Date();
+    const payload = { action: 'manual_timestamping', reason: 'qrcode', endDate };
+    const credentials = { _id: new ObjectID() };
+
+    try {
+      isEndDateTimeStampAllowedStub.returns(false);
+
+      await eventTimeStampingHelper.addTimeStamp(event, payload, credentials);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toEqual(Boom.conflict('Problème lors de l\'horodatage. Contactez le support technique.'));
+      sinon.assert.calledOnceWithExactly(isEndDateTimeStampAllowedStub, event, endDate);
+      sinon.assert.notCalled(createTimeStampHistoryStub);
+      sinon.assert.notCalled(updateOne);
+      sinon.assert.notCalled(isStartDateTimeStampAllowedStub);
     }
   });
 });

--- a/tests/unit/helpers/eventTimeStamping.test.js
+++ b/tests/unit/helpers/eventTimeStamping.test.js
@@ -101,7 +101,7 @@ describe('isEndDateTimeStampAllowed', () => {
   });
 });
 
-describe('addTimeStamp #tag', () => {
+describe('addTimeStamp', () => {
   let isStartDateTimeStampAllowedStub;
   let isEndDateTimeStampAllowedStub;
   let createTimeStampHistoryStub;
@@ -157,7 +157,7 @@ describe('addTimeStamp #tag', () => {
     }
   });
 
-  it('should add startDate timestamp and updateEvent', async () => {
+  it('should add endDate timestamp and updateEvent', async () => {
     const event = { _id: new ObjectID() };
     const endDate = new Date();
     const payload = { action: 'manual_timestamping', reason: 'qrcode', endDate };


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES 
- Si mes changements impactent l'application formation : -np
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp : pas en prod
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement : -np
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : erp 

- Périmetre roles : auxilaire

- Cas d'usage : je peux horodater la fin d'une intervention
