### PR TITLE
COM-2104 - replace googleapis by @googleapis/drive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,12 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         }
       }
     },
@@ -151,6 +157,14 @@
         "snakeize": "^0.1.0",
         "stream-events": "^1.0.1",
         "xdg-basedir": "^4.0.0"
+      }
+    },
+    "@googleapis/drive": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-0.3.1.tgz",
+      "integrity": "sha512-LYsxWMHFt2Z7kdO16EE6jVP07Qq141hmZHHuFvljWLVo7EBtiPCgzrkjJe03Q7wNs28rnFe0jlIDiBZYT0tnmA==",
+      "requires": {
+        "googleapis-common": "^5.0.1"
       }
     },
     "@hapi/accept": {
@@ -525,47 +539,47 @@
       }
     },
     "@sentry/core": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.6.tgz",
-      "integrity": "sha512-w6BRizAqh7BaiM9oeKzO6aACXwRijUPacYaVLX/OfhqCSueF9uDxpMRT7+4D/eCeDVqgJYhBJ4Vsu2NSstkk4A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/minimal": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.6.tgz",
-      "integrity": "sha512-foBZ3ilMnm9Gf9OolrAxYHK8jrA6IF72faDdJ3Al+1H27qcpnBaMdrdEp2/jzwu/dgmwuLmbBaMjEPXaGH/0JQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
       "requires": {
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.6.tgz",
-      "integrity": "sha512-uM2/dH0a6zfvI5f+vg+/mST+uTBdN6Jgpm585ipH84ckCYQwIIDRg6daqsen4S1sy/xgg1P1YyC3zdEC4G6b1Q==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/types": "6.3.6",
+        "@sentry/hub": "6.4.1",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.6.tgz",
-      "integrity": "sha512-QVWakREgVUV/rocm4uMq+RkC0/g9d/z2BYic+2b0ZZMZD2aXF5RulrUQlAO2MzoXcO+bqpkXQsqdhMccqB4Zeg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.4.1.tgz",
+      "integrity": "sha512-w4IFRA7UFZxKL9xVXmQU8eAjVMY/sr0fJcTV8Wma4uZqa1FQVX4p6xgfylLrcaA8VsolE3l9LRrP1XYxCVwvOw==",
       "requires": {
-        "@sentry/core": "6.3.6",
-        "@sentry/hub": "6.3.6",
-        "@sentry/tracing": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/core": "6.4.1",
+        "@sentry/hub": "6.4.1",
+        "@sentry/tracing": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -573,28 +587,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.6.tgz",
-      "integrity": "sha512-dfyYY2eESJGt5Qbigmfmb2U9ntqbwPhLNAOcjKaVg9WQRV5q2RkHCVctPoYk7TEAvfNeNRXCD8SnuFOZhttt8g==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.4.1.tgz",
+      "integrity": "sha512-EPRadE9n/wpUjx4jqP/8vXdOAZBk7vjlzRKniJgKgQUO3v03i0ui6xydaal2mvhplIyOCI2muXdGhjUO7ga4uw==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/minimal": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",
-      "integrity": "sha512-93cFJdJkWyCfyZeWFARSU11qnoHVOS/R2h5WIsEf+jbQmkqG2C+TXVz/19s6nHVsfDrwpvYpwALPv4/nrxfU7g=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
     },
     "@sentry/utils": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.6.tgz",
-      "integrity": "sha512-HnYlDBf8Dq8MEv7AulH7B6R1D/2LAooVclGdjg48tSrr9g+31kmtj+SAj2WWVHP9+bp29BWaC7i5nkfKrOibWw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
       "requires": {
-        "@sentry/types": "6.3.6",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
@@ -717,18 +731,18 @@
       "dev": true
     },
     "@types/mongodb": {
-      "version": "3.6.12",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
-      "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.16.tgz",
+      "integrity": "sha512-D3tM0iRUet3TiIMAdvovxAIRG9gYqFd4j7visGwmPNdQj8Fq/uFFfRxyGCgEwVXAs0NnJPMI/QGVTADxDwhmSQ==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA=="
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -917,11 +931,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-    },
     "array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -939,6 +948,18 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz",
       "integrity": "sha1-qqEo5iybPDWAlFaMIZ/2T+SJ1Co="
+    },
+    "array.prototype.filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.0.tgz",
+      "integrity": "sha512-TfO1gz+tLm+Bswq0FBOXPqAchtCr2Rn48T8dLJoRFl8NoEosjZmzptmuo1X8aZBzZcqsR1W8U761tjACJtngTQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.5"
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -974,9 +995,9 @@
       "dev": true
     },
     "astronomia": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-3.0.4.tgz",
-      "integrity": "sha512-NbX2KsH86iKfVeJUsSlfFXcOO3clWiIcXDA7/rGyCR+lqohSAaP+1ap/ee15ycxadN1sFULG6egjDXjsb+V+TQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-4.0.0.tgz",
+      "integrity": "sha512-COBlYpsvoBp62SpKskdnXatPEvOvyyS0RE9om5aM+EJ02b/Wg3uIuGvjAzAxHTwIrtYWQpqniBMLPv9hlJfIvw=="
     },
     "async-retry": {
       "version": "1.3.1",
@@ -992,11 +1013,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "available-typed-arrays": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.3.tgz",
+      "integrity": "sha512-CuPhFULixV/d89POo1UG4GqGbR7dmrefY2ZdmsYakeR4gOSJXoF7tfeaiqMHGOMrlTiJoeEs87fpLsBYmE2BMw==",
       "requires": {
-        "array-filter": "^1.0.0"
+        "array.prototype.filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -1156,9 +1177,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "caldate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caldate/-/caldate-2.0.0.tgz",
-      "integrity": "sha512-g2utCvTFOn+lScBU59PW1VjOwV7SIgpvXD8+EhrWrQSEtne5TDO9cy/o6s+vK4qwYwVE84gWRbbLTuDY9J1ARA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/caldate/-/caldate-2.0.1.tgz",
+      "integrity": "sha512-edJtriYPt9mYarpEHOZ7QUZWXuY55S8ZdwUVBiLOqeAUYnCI7aTM3Cw+YX60MuJWhDmSRcpfJkiRpz3quMKoGQ==",
       "requires": {
         "moment-timezone": "^0.5.33"
       }
@@ -1371,12 +1392,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
-    },
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
@@ -1434,29 +1449,29 @@
       "integrity": "sha512-477D7ypIiqlXBkxhU7YtG9wWZJEQ+RUpujt2quTfgf4+E8g5fNUkB0QIL0bVyP5/TKBg8y55Hfa1R/c4bt3dEw=="
     },
     "date-bengali-revised": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-2.0.0.tgz",
-      "integrity": "sha512-DjlFFNjlCQTVHcijNeur8qd65rjgijT9xI7uORKX510v0ukZNaRC3731WgwVNLgMU4ovaPJ9j9ix+czbJJdrKg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-2.0.1.tgz",
+      "integrity": "sha512-7D9FceOSpRy1MpLzxs0rMlTaUju9LNnIz6A2Hag3/+nB7RKdVKzuQrO7mchbCqFErLoTM+L5Ja/M03psWqGqGA=="
     },
     "date-chinese": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-2.0.0.tgz",
-      "integrity": "sha512-oOWsPiN84use5p1n5Dgz6l9B5jsfIIG7ESvRRTpJVaV+NgJPWER/bdgbNUxJghuR9YjT3n/vXWR4/WGiljFmiw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-2.1.0.tgz",
+      "integrity": "sha512-wGSHiZKxSi3gSZ+Yv/jAaHNen1zWTCt8kbfkHWPwLWuhrJhQG7qFzea53s/6s0vhdBPnzdI7LVGqWGTAHIA5Mw==",
       "requires": {
-        "astronomia": "^3.0.0"
+        "astronomia": "^4.0.0"
       }
     },
     "date-easter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.0.tgz",
-      "integrity": "sha512-18bMwrMWmp/psK1W/XUdorLw5utYZAa0Fb7eC1/sdwQNIpfIeU7GUa/pNYED50tS7WVIL6zha/U3hxmdldZWRg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.1.tgz",
+      "integrity": "sha512-5uAPmiO5tlztgaJrAy8eQCbsVrvYap12JGQEULi7HtLFRML65Jrop74ylHsA6OrqzcEyd6b9WQRIG/kvNzqC8g=="
     },
     "date-holidays": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.3.0.tgz",
-      "integrity": "sha512-nD5oFXLKaDdetreHWDSyq+Kp8vHQacI5nMdVAa3MnULCF/ewRh8Rq4K11NSKvPMAIjFCJhZqM+a58ppkuNG6tg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.5.0.tgz",
+      "integrity": "sha512-/BHr+o4jfyUs+HnaSms0iy7lB2ZmBiLhDbWLTxSk2g9vEZgkU+0UBV03xVGfifI3ZY7DPi4bhLKdgXZwlsTQ6Q==",
       "requires": {
-        "date-holidays-parser": "^3.1.0",
+        "date-holidays-parser": "^3.2.0",
         "js-yaml": "^4.1.0",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
@@ -1464,15 +1479,15 @@
       }
     },
     "date-holidays-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-3.1.0.tgz",
-      "integrity": "sha512-gBow/WnmNt9nZWzv8n+J63F9vvaBAmdsYI/1vQLMcDIZyHwgNNNXCzCmsAiFadQhxsra+BBZCxvnXc2zzNNcJg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-3.2.0.tgz",
+      "integrity": "sha512-xLqHCE1FSGmbmig57ug/qGPMeihpgi4sGK88HnsHcpt7GTSc4b8Fq2FnecihvTDihCGTNK2ova6dH3rMAU1RmA==",
       "requires": {
-        "astronomia": "^3.0.4",
-        "caldate": "^2.0.0",
-        "date-bengali-revised": "^2.0.0",
-        "date-chinese": "^2.0.0",
-        "date-easter": "^1.0.0",
+        "astronomia": "^4.0.0",
+        "caldate": "^2.0.1",
+        "date-bengali-revised": "^2.0.1",
+        "date-chinese": "^2.1.0",
+        "date-easter": "^1.0.1",
         "deepmerge": "^4.2.2",
         "moment-timezone": "^0.5.33"
       }
@@ -1557,11 +1572,11 @@
       }
     },
     "docxtemplater": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/docxtemplater/-/docxtemplater-3.21.1.tgz",
-      "integrity": "sha512-2YDFFMtmQpIm9V5jcmytWMc9Hnuob0EQFzVYuJhNm42mvQcBrRkPtf/T3S5B2+2ZVgNrYv+P0H07LKT3sM9xmg==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/docxtemplater/-/docxtemplater-3.21.2.tgz",
+      "integrity": "sha512-htRg5Hwzji9EmZgRkGNF9bDc5n4ZYrSWamid88VM8H/nsMX5G09AdbMfFDQKkHAhnqOl2mxN5L6xCQE9Nh/xbg==",
       "requires": {
-        "xmldom": "^0.5.0"
+        "xmldom": "^0.6.0"
       }
     },
     "dot-prop": {
@@ -1665,6 +1680,11 @@
         "unbox-primitive": "^1.0.0"
       }
     },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -1711,15 +1731,15 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "eslint": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
-      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -1730,12 +1750,14 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
@@ -1747,7 +1769,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1756,7 +1778,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -1845,15 +1867,118 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
+        "debug": "^3.2.7",
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
+      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.1",
+        "find-up": "^2.0.0",
+        "has": "^1.0.3",
+        "is-core-module": "^2.4.0",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.3",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "array.prototype.flat": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+          "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.1"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1861,6 +1986,15 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
           }
         },
         "find-up": {
@@ -1916,63 +2050,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flat": "^1.2.3",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.4",
-        "eslint-module-utils": "^2.6.0",
-        "has": "^1.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.1",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.17.0",
-        "tsconfig-paths": "^3.9.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -2500,9 +2577,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.4.tgz",
-      "integrity": "sha512-o8irYyeijEiecTXeoEe8UKNEzV1X+uhR4b2oNdapDMZixypp0J+eHimGOyx5Joa3UAeokGngdtDLXtq9vDqG2Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.1.0.tgz",
+      "integrity": "sha512-X+gbkGjnLN3HUZP2W3KBREuA603BXd80ITvL0PeS0QpyDNYz/u0pIZ7aRuGnrSuUc0grk/qxEgtVTFt1ogbP+A==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2521,15 +2598,6 @@
       "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
       "requires": {
         "node-forge": "^0.10.0"
-      }
-    },
-    "googleapis": {
-      "version": "73.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-73.0.0.tgz",
-      "integrity": "sha512-bLLoHddONoEZCnhcTW603r7Y1fFqbFo0/3VdnzTNA4XQl+gVY3qycWmRSRrL15ts9Iwfg0rhTde5+OUuBFhi0g==",
-      "requires": {
-        "google-auth-library": "^7.0.2",
-        "googleapis-common": "^5.0.2"
       }
     },
     "googleapis-common": {
@@ -3007,6 +3075,12 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3185,14 +3259,14 @@
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       }
     },
@@ -3259,6 +3333,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -3433,12 +3513,6 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
         "find-up": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3540,27 +3614,27 @@
       }
     },
     "mongodb": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
-      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.8.tgz",
+      "integrity": "sha512-sDjJvI73WjON1vapcbyBD3Ao9/VN3TKYY8/QX9EPbs22KaCSrQ5rXo5ZZd44tWJ3wl3FlnrFZ+KyUtNH6+1ZPQ==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.2",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
     },
     "mongoose": {
-      "version": "5.12.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.8.tgz",
-      "integrity": "sha512-+6Q8mvTsIHQkXBWmBGnEy93Gm0fjKIwV/AEIT23wXN3O4Pd3L/aZaJWrdOStcuE4b9SqXrs1QBnnR9MNqNZwrw==",
+      "version": "5.12.11",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.11.tgz",
+      "integrity": "sha512-16TVqYhHQdZNR8RTis/8iiTPy+nJPq0UhKyBFTucLLU3PWcDLY2gAGv6aOk0LygTNhEfgNnENgUUHhjVqTuh8w==",
       "requires": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",
         "kareem": "2.3.2",
-        "mongodb": "3.6.6",
+        "mongodb": "3.6.8",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.8.3",
         "mquery": "3.2.5",
@@ -3680,9 +3754,9 @@
       }
     },
     "node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.0.tgz",
+      "integrity": "sha512-kcwSAWhPi4+QzAtsL2+2s/awvDo2GKLsvMCwNRxb5BUshteXU8U97NCyvQDsGKs/m0He9WcG4YWew/BnuLx++w=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -3695,9 +3769,9 @@
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "nodemailer": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.0.tgz",
-      "integrity": "sha512-ikSMDU1nZqpo2WUPE0wTTw/NGGImTkwpJKDIFPZT+YvvR9Sj+ze5wzu95JHkBMglQLoG2ITxU21WukCC/XsFkg=="
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
+      "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg=="
     },
     "nopt": {
       "version": "5.0.0",
@@ -3885,12 +3959,13 @@
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "path-exists": {
@@ -3932,12 +4007,12 @@
       }
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pend": {
@@ -3951,15 +4026,15 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pizzip": {
@@ -3976,6 +4051,66 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "prelude-ls": {
@@ -4136,24 +4271,24 @@
       "dev": true
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
+        "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "path-type": "^3.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
         "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "read-pkg": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4572,9 +4707,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
       "dev": true
     },
     "sprintf-js": {
@@ -4700,9 +4835,9 @@
       }
     },
     "table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -4714,9 +4849,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
-          "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -4821,9 +4956,9 @@
       }
     },
     "teeny-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
-      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.0.tgz",
+      "integrity": "sha512-hPfSc05a7Mf3syqVhSkrVMb844sMiP60MrfGMts3ft6V6UlSkEIGQzgwf0dy1KjdE3FV2lJ5s7QCBFcaoQLA6g==",
       "requires": {
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -4941,9 +5076,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
       "optional": true
     },
     "unbox-primitive": {
@@ -5197,9 +5332,9 @@
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
     },
     "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.8.4",
+    "@googleapis/drive": "^0.3.1",
     "@hapi/boom": "^9.1.2",
     "@hapi/good": "^9.0.1",
     "@hapi/good-console": "^9.0.1",
@@ -41,7 +42,6 @@
     "dotenv": "^9.0.2",
     "feedparser-promised": "^2.0.1",
     "flat": "^5.0.2",
-    "googleapis": "^73.0.0",
     "handlebars": "^4.7.5",
     "hapi-auth-jwt2": "^10.2.0",
     "hapi-sentry": "^3.2.0",

--- a/src/models/Google/Drive.js
+++ b/src/models/Google/Drive.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { google } = require('googleapis');
+const google = require('@googleapis/drive');
 const get = require('lodash/get');
 
 const jwtClient = () => new google.auth.JWT(


### PR DESCRIPTION
- Périmetre interface : Reduire la taille des nodes_modules en important uniquement le paquet drive de googleapis (celui qu'on utilise)

- Cas d'usage : 
Chargement manuel des documents qui vont sur le drive (fiche auxiliaire)
Affichage des thumbnails
Suppression des documents du drive
Chargement des documents automatique sur le drive suite a la signature en ligne (mandat de prélèvement ou contrat)