### PR TITLE
COM-2093: add status to put route

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -391,14 +391,16 @@ module.exports = {
   },
   // NOTIFICATION
   BLENDED_COURSE_REGISTRATION: 'blended_course_registration',
-  // CUSTOMER STATUS
-  ACTIVATED: 'activated',
-  STOPPED: 'stopped',
-  ARCHIVED: 'archived',
   // TIMESTAMP
   MANUAL_TIME_STAMPING: 'manual_time_stamping',
   QRCODE_MISSING: 'qrcode_missing',
   QRCODE_ERROR: 'qrcode_error',
   CAMERA_ERROR: 'camera_error',
   get MANUAL_TIME_STAMPING_REASONS() { return [this.QRCODE_MISSING, this.QRCODE_ERROR, this.CAMERA_ERROR]; },
+  // STOP REASONS
+  QUALITY: 'quality',
+  HOSPITALIZATION: 'hospitalization',
+  DEATH: 'death',
+  EPHAD_DEPARTURE: 'ephad_departure',
+  CONDITION_IMPROVEMENT: 'condition_improvement',
 };

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -151,25 +151,28 @@ exports.updateCustomerEvents = async (customerId, payload) => {
   }
 };
 
+exports.formatPayload = async (customerId, customerPayload, company) => {
+  if (has(customerPayload, 'payment.iban')) {
+    return exports.formatPaymentPayload(customerId, customerPayload, company);
+  }
+  if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
+    await exports.updateCustomerEvents(customerId, customerPayload);
+  }
+
+  return { $set: flat(customerPayload, { safe: true }) };
+};
+
 exports.updateCustomer = async (customerId, customerPayload, credentials) => {
-  let payload;
   const { company } = credentials;
   if (has(customerPayload, 'referent')) {
     await ReferentHistoriesHelper.updateCustomerReferent(customerId, customerPayload.referent, company);
 
     return Customer.findOne({ _id: customerId }).lean();
-  } if (has(customerPayload, 'payment.iban')) {
-    payload = await exports.formatPaymentPayload(customerId, customerPayload, company);
-  } else if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
-    await exports.updateCustomerEvents(customerId, customerPayload);
-    payload = { $set: flat(customerPayload, { safe: true }) };
-  } else {
-    payload = { $set: flat(customerPayload, { safe: true }) };
   }
 
-  const customer = Customer.findOneAndUpdate({ _id: customerId }, payload, { new: true }).lean();
+  const payload = await exports.formatPayload(customerId, customerPayload, company);
 
-  return customer;
+  return Customer.findOneAndUpdate({ _id: customerId }, payload, { new: true }).lean();
 };
 
 exports.createCustomer = async (payload, credentials) => {

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -151,13 +151,9 @@ exports.updateCustomerEvents = async (customerId, payload) => {
   }
 };
 
-exports.formatPayloadAndUpdateEvents = async (customerId, customerPayload, company) => {
+const formatPayload = async (customerId, customerPayload, company) => {
   if (has(customerPayload, 'payment.iban')) {
     return exports.formatPaymentPayload(customerId, customerPayload, company);
-  }
-
-  if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
-    await exports.updateCustomerEvents(customerId, customerPayload);
   }
 
   return { $set: flat(customerPayload, { safe: true }) };
@@ -171,7 +167,11 @@ exports.updateCustomer = async (customerId, customerPayload, credentials) => {
     return Customer.findOne({ _id: customerId }).lean();
   }
 
-  const payload = await exports.formatPayloadAndUpdateEvents(customerId, customerPayload, company);
+  if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
+    await exports.updateCustomerEvents(customerId, customerPayload);
+  }
+
+  const payload = await formatPayload(customerId, customerPayload, company);
 
   return Customer.findOneAndUpdate({ _id: customerId }, payload, { new: true }).lean();
 };

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -151,10 +151,11 @@ exports.updateCustomerEvents = async (customerId, payload) => {
   }
 };
 
-exports.formatPayload = async (customerId, customerPayload, company) => {
+exports.formatPayloadAndUpdateEvents = async (customerId, customerPayload, company) => {
   if (has(customerPayload, 'payment.iban')) {
     return exports.formatPaymentPayload(customerId, customerPayload, company);
   }
+
   if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
     await exports.updateCustomerEvents(customerId, customerPayload);
   }
@@ -170,7 +171,7 @@ exports.updateCustomer = async (customerId, customerPayload, credentials) => {
     return Customer.findOne({ _id: customerId }).lean();
   }
 
-  const payload = await exports.formatPayload(customerId, customerPayload, company);
+  const payload = await exports.formatPayloadAndUpdateEvents(customerId, customerPayload, company);
 
   return Customer.findOneAndUpdate({ _id: customerId }, payload, { new: true }).lean();
 };

--- a/src/models/Customer.js
+++ b/src/models/Customer.js
@@ -15,9 +15,12 @@ const {
   NURSING_HOME,
   HOSPITALIZED,
   DECEASED,
-  ACTIVATED,
-  STOPPED,
-  ARCHIVED,
+  QUALITY,
+  HOSPITALIZATION,
+  DEATH,
+  EPHAD_DEPARTURE,
+  CONDITION_IMPROVEMENT,
+  OTHER,
 } = require('../helpers/constants');
 const Event = require('./Event');
 const { PHONE_VALIDATION } = require('./utils');
@@ -29,7 +32,7 @@ const subscriptionSchemaDefinition = require('./schemaDefinitions/subscription')
 const FUNDING_FREQUENCIES = [MONTHLY, ONCE];
 const FUNDING_NATURES = [FIXED, HOURLY];
 const SITUATION_OPTIONS = [UNKNOWN, HOME, NURSING_HOME, HOSPITALIZED, DECEASED];
-const STATUS = [ACTIVATED, STOPPED, ARCHIVED];
+const STOP_REASONS = [QUALITY, HOSPITALIZATION, DEATH, EPHAD_DEPARTURE, CONDITION_IMPROVEMENT, OTHER];
 
 const CustomerSchema = mongoose.Schema({
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
@@ -115,12 +118,9 @@ const CustomerSchema = mongoose.Schema({
       createdAt: { type: Date, default: Date.now },
     }],
   }],
-  status: {
-    value: { type: String, enum: STATUS, default: ACTIVATED },
-    activatedAt: { type: Date, default: Date.now },
-    stoppedAt: { type: Date },
-    archivedAt: { type: Date },
-  },
+  stoppedAt: { type: Date },
+  archivedAt: { type: Date },
+  stopReason: { type: String, enum: STOP_REASONS, required() { return this.stoppedAt; } },
 }, {
   timestamps: true,
   toJSON: { virtuals: true },
@@ -226,3 +226,4 @@ module.exports = mongoose.model('Customer', CustomerSchema);
 module.exports.FUNDING_FREQUENCIES = FUNDING_FREQUENCIES;
 module.exports.FUNDING_NATURES = FUNDING_NATURES;
 module.exports.SITUATION_OPTIONS = SITUATION_OPTIONS;
+module.exports.STOP_REASONS = STOP_REASONS;

--- a/src/routes/customers.js
+++ b/src/routes/customers.js
@@ -30,7 +30,7 @@ const {
   updateFunding,
   deleteFunding,
 } = require('../controllers/customerController');
-const { FUNDING_FREQUENCIES, FUNDING_NATURES, SITUATION_OPTIONS } = require('../models/Customer');
+const { FUNDING_FREQUENCIES, FUNDING_NATURES, SITUATION_OPTIONS, STOP_REASONS } = require('../models/Customer');
 const {
   authorizeCustomerDelete,
   authorizeCustomerUpdate,
@@ -102,7 +102,10 @@ exports.plugin = {
               iban: Joi.string(),
               bic: Joi.string(),
             }).min(1),
-          }),
+            stoppedAt: Joi.date(),
+            stopReason: Joi.string().valid(...STOP_REASONS),
+          })
+            .and('stoppedAt', 'stopReason'),
         },
         pre: [{ method: authorizeCustomerUpdate }],
       },

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -50,9 +50,10 @@ exports.authorizeCustomerUpdate = async (req) => {
     }
 
     if (req.payload.stoppedAt) {
-      const customer = await Customer.findOne({ _id: req.params._id }, { stoppedAt: 1, stopReason: 1, createdAt: 1 })
-        .lean();
-      if (customer.stoppedAt || customer.createdAt > req.payload.stoppedAt) return Boom.forbidden();
+      const customer = await Customer.countDocuments(
+        { _id: req.params._id, $or: [{ stoppedAt: { $exists: true } }, { createdAt: { $gt: req.payload.stoppedAt } }] }
+      );
+      if (customer) return Boom.forbidden();
     }
   }
 

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -32,7 +32,7 @@ exports.validateCustomerCompany = async (params, payload, companyId) => {
   if (customer.company.toHexString() !== companyId.toHexString()) throw Boom.forbidden();
 };
 
-exports.checkAuthorization = async (req) => {
+exports.authorizeCustomerUpdate = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   await exports.validateCustomerCompany(req.params, req.payload, companyId);
 
@@ -48,12 +48,16 @@ exports.checkAuthorization = async (req) => {
         .lean();
       if (!thirdPartypayer) return Boom.forbidden();
     }
+
+    if (req.payload.stoppedAt) {
+      const customer = await Customer.findOne({ _id: req.params._id }, { stoppedAt: 1, stopReason: 1, createdAt: 1 })
+        .lean();
+      if (customer.stoppedAt || customer.createdAt > req.payload.stoppedAt) return Boom.forbidden();
+    }
   }
 
   return null;
 };
-
-exports.authorizeCustomerUpdate = async req => exports.checkAuthorization(req);
 
 exports.authorizeSubscriptionCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);

--- a/tests/integration/customers.test.js
+++ b/tests/integration/customers.test.js
@@ -153,6 +153,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       const areAllCustomersFromCompany = res.result.data.customers
         .every(customer => customer.company.toHexString() === authCompany._id.toHexString());
@@ -190,6 +191,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       const areAllCustomersFromCompany = res.result.data.customers
         .every(customer => customer.company._id.toHexString() === otherCompany._id.toHexString());
@@ -205,6 +207,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers/first-intervention',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       const customers = await Customer.find({ company: authCompany._id }).lean();
       expect(Object.values(res.result.data.customers)).toHaveLength(customers.length);
@@ -240,6 +243,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers/first-intervention',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(Object.values(res.result.data.customers)).toHaveLength(1);
       expect(Object.values(res.result.data.customers).every(cus => has(cus, 'firstIntervention'))).toBeTruthy();
@@ -253,6 +257,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers/billed-events',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customers).toBeDefined();
       expect(res.result.data.customers[0].subscriptions).toBeDefined();
@@ -290,6 +295,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers/billed-events',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customers).toBeDefined();
       const areAllCustomersFromCompany = res.result.data.customers.every(async (customer) => {
@@ -307,6 +313,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: '/customers/subscriptions',
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customers.every(cus => cus.subscriptions.length > 0)).toBeTruthy();
       expect(res.result.data.customers.length).toEqual(7);
@@ -402,6 +409,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: `/customers/${customerId.toHexString()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customer).toMatchObject({
         _id: customerId,
@@ -443,6 +451,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: `/customers/${id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(404);
     });
 
@@ -452,6 +461,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: `/customers/${otherCompanyCustomer._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(403);
     });
 
@@ -504,6 +514,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: updatePayload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
       expect(res.result.data.customer).toEqual(expect.objectContaining({
         identity: expect.objectContaining({
@@ -598,6 +609,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: { stoppedAt: new Date(), stopReason: DEATH },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(200);
     });
 
@@ -608,6 +620,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: updatePayload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(404);
     });
 
@@ -620,6 +633,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: { contact: { phone: '123dcsnejnf' } },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(400);
     });
 
@@ -632,6 +646,20 @@ describe('CUSTOMERS ROUTES', () => {
         payload: { stopReason: DEATH },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('should return a 400 error if wrong stop reason', async () => {
+      const customer = customersList[0];
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/customers/${customer._id}`,
+        payload: { stoppedAt: new Date(), stopReason: 'test' },
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
       expect(res.statusCode).toBe(400);
     });
 
@@ -644,10 +672,11 @@ describe('CUSTOMERS ROUTES', () => {
         payload: { stoppedAt: new Date(), stopReason: DEATH },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(403);
     });
 
-    it('should return 403 if stoppedDate before activatedDate', async () => {
+    it('should return 403 if stoppedDate before createdAt', async () => {
       const customer = customersList[10];
 
       const res = await app.inject({
@@ -656,6 +685,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: { stoppedAt: new Date('2021-05-23'), stopReason: DEATH },
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(403);
     });
 
@@ -674,6 +704,7 @@ describe('CUSTOMERS ROUTES', () => {
             },
           },
         });
+
         expect(res.statusCode).toBe(200);
       });
 
@@ -706,6 +737,7 @@ describe('CUSTOMERS ROUTES', () => {
         payload: updatePayload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(403);
     });
   });
@@ -743,6 +775,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: `/customers/${new ObjectID().toHexString()}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(404);
     });
 
@@ -752,6 +785,7 @@ describe('CUSTOMERS ROUTES', () => {
         url: `/customers/${otherCompanyCustomer._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(404);
     });
 
@@ -1357,6 +1391,7 @@ describe('CUSTOMER MANDATES ROUTES', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
+
       expect(res.statusCode).toBe(200);
       sinon.assert.calledOnce(createDocumentStub);
       sinon.assert.calledOnce(generateDocxStub);
@@ -1378,6 +1413,7 @@ describe('CUSTOMER MANDATES ROUTES', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
         payload,
       });
+
       expect(res.statusCode).toBe(403);
     });
 
@@ -1504,6 +1540,7 @@ describe('CUSTOMERS QUOTES ROUTES', () => {
         payload: {},
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(400);
     });
 
@@ -1525,6 +1562,7 @@ describe('CUSTOMERS QUOTES ROUTES', () => {
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
+
       expect(res.statusCode).toBe(403);
     });
 

--- a/tests/integration/seed/customersSeed.js
+++ b/tests/integration/seed/customersSeed.js
@@ -19,6 +19,7 @@ const {
   HOURLY,
   AUXILIARY,
   WEBAPP,
+  DEATH,
 } = require('../../../src/helpers/constants');
 const { populateDBForAuthentication, rolesList, authCompany, otherCompany } = require('./authenticationSeed');
 
@@ -394,6 +395,37 @@ const customersList = [
         }],
       },
     ],
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    identity: { title: 'mr', firstname: 'Julian', lastname: 'Alaphilippe' },
+    contact: {
+      primaryAddress: {
+        fullAddress: '37 rue de ponthieu 75008 Paris',
+        zipCode: '75008',
+        city: 'Paris',
+        street: '37 rue de Ponthieu',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+    },
+    stoppedAt: new Date(),
+    stopReason: DEATH,
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    identity: { title: 'mr', firstname: 'Julian', lastname: 'Alaphilippe' },
+    contact: {
+      primaryAddress: {
+        fullAddress: '37 rue de ponthieu 75008 Paris',
+        zipCode: '75008',
+        city: 'Paris',
+        street: '37 rue de Ponthieu',
+        location: { type: 'Point', coordinates: [2.377133, 48.801389] },
+      },
+    },
+    createdAt: new Date('2021-05-24'),
   },
 ];
 

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -21,7 +21,6 @@ const GDriveStorageHelper = require('../../../src/helpers/gDriveStorage');
 const SubscriptionsHelper = require('../../../src/helpers/subscriptions');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const SinonMongoose = require('../sinonMongoose');
-const { DEATH } = require('../../../src/helpers/constants');
 
 describe('getCustomersBySector', () => {
   let getCustomersFromEvent;
@@ -761,35 +760,6 @@ describe('updateCustomer', () => {
         {
           query: 'findOneAndUpdate',
           args: [{ _id: customerId }, { $set: flat(payload, { safe: true }) }, { new: true }],
-        },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should update status', async () => {
-    const customerId = new ObjectID();
-    const payload = { stoppedAt: new Date(), stopReason: DEATH };
-    const customerResult = { _id: customerId, stoppedAt: new Date(), stopReason: DEATH };
-
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
-
-    const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
-
-    expect(result).toBe(customerResult);
-    sinon.assert.notCalled(formatPaymentPayload);
-    sinon.assert.notCalled(updateCustomerEvents);
-    sinon.assert.notCalled(updateCustomerReferent);
-    SinonMongoose.calledWithExactly(
-      findOneAndUpdateCustomer,
-      [
-        {
-          query: 'findOneAndUpdate',
-          args: [
-            { _id: customerId },
-            { $set: { stoppedAt: new Date(), stopReason: DEATH } },
-            { new: true },
-          ],
         },
         { query: 'lean' },
       ]

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -21,6 +21,7 @@ const GDriveStorageHelper = require('../../../src/helpers/gDriveStorage');
 const SubscriptionsHelper = require('../../../src/helpers/subscriptions');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const SinonMongoose = require('../sinonMongoose');
+const { DEATH } = require('../../../src/helpers/constants');
 
 describe('getCustomersBySector', () => {
   let getCustomersFromEvent;
@@ -760,6 +761,35 @@ describe('updateCustomer', () => {
         {
           query: 'findOneAndUpdate',
           args: [{ _id: customerId }, { $set: flat(payload, { safe: true }) }, { new: true }],
+        },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should update status', async () => {
+    const customerId = new ObjectID();
+    const payload = { stoppedAt: new Date(), stopReason: DEATH };
+    const customerResult = { _id: customerId, stoppedAt: new Date(), stopReason: DEATH };
+
+    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
+
+    const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
+
+    expect(result).toBe(customerResult);
+    sinon.assert.notCalled(formatPaymentPayload);
+    sinon.assert.notCalled(updateCustomerEvents);
+    sinon.assert.notCalled(updateCustomerReferent);
+    SinonMongoose.calledWithExactly(
+      findOneAndUpdateCustomer,
+      [
+        {
+          query: 'findOneAndUpdate',
+          args: [
+            { _id: customerId },
+            { $set: { stoppedAt: new Date(), stopReason: DEATH } },
+            { new: true },
+          ],
         },
         { query: 'lean' },
       ]


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/admin

- Cas d'usage : je peux arrêter un bénéficiaire : 
  -  si la date d'arrêt est antérieure à la date de création : message d'erreur
  - si le bénéficiaire est déjà arrêté : le bouton n'est pas visible
  - si malgré tout on essaie d'arrêter le bénéficiaire : message d'erreur
