### PR TITLE
Com 2100

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -230,6 +230,7 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
   const payload = await formatUpdatePayload(userPayload);
 
   if (userPayload.customer) await HelpersHelper.create(userId, userPayload.customer, companyId);
+  if (userPayload.company) await UserCompany.create({ user: userId, company: userPayload.company });
 
   if (userPayload.sector) {
     await SectorHistoriesHelper.updateHistoryOnSectorUpdate(userId, payload.sector, companyId);

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -38,7 +38,7 @@ exports.getUser = async (req) => {
 exports.authorizeUserUpdate = async (req) => {
   const { credentials } = req.auth;
   const userFromDB = req.pre.user;
-  const userCompany = userFromDB.company ? userFromDB.company.toHexString() : get(req, 'payload.company');
+  const userCompany = userFromDB.company || get(req, 'payload.company');
   const isLoggedUserVendor = !!get(credentials, 'role.vendor');
   const loggedUserClientRole = get(credentials, 'role.client.name');
 
@@ -55,15 +55,15 @@ exports.authorizeUserUpdate = async (req) => {
 
 const checkCompany = (credentials, userFromDB, payload, isLoggedUserVendor) => {
   const loggedUserCompany = get(credentials, 'company._id') || '';
-  const userCompany = userFromDB.company ? userFromDB.company.toHexString() : payload.company;
+  const userCompany = userFromDB.company || payload.company;
 
   const sameCompany = userCompany && loggedUserCompany &&
-    UtilsHelper.areObjectIdsEquals(userCompany, loggedUserCompany.toHexString());
+    UtilsHelper.areObjectIdsEquals(userCompany, loggedUserCompany);
   const updatingOwnInfos = UtilsHelper.areObjectIdsEquals(credentials._id, userFromDB._id);
   const canLoggedUserUpdate = isLoggedUserVendor || sameCompany || updatingOwnInfos;
 
   const isCompanyUpdated = payload.company && userFromDB.company &&
-    payload.company !== userFromDB.company.toHexString();
+    !UtilsHelper.areObjectIdsEquals(payload.company, userFromDB.company);
 
   if (!canLoggedUserUpdate || isCompanyUpdated) throw Boom.forbidden();
 };
@@ -75,10 +75,13 @@ const checkEstablishment = async (companyId, payload) => {
 
 const checkRole = async (userFromDB, payload) => {
   const role = await Role.findOne({ _id: payload.role }, { name: 1, interface: 1 }).lean();
-  const clientRoleSwitch = role.interface === CLIENT && get(userFromDB, 'role.client') &&
-      userFromDB.role.client.toHexString() !== payload.role;
+  const previousClientRole = get(userFromDB, 'role.client');
+
+  const clientRoleSwitch = role.interface === CLIENT && previousClientRole &&
+    !UtilsHelper.areObjectIdsEquals(previousClientRole, payload.role);
+
   if (clientRoleSwitch) {
-    const formerClientRole = await Role.findById(userFromDB.role.client, { name: 1 }).lean();
+    const formerClientRole = await Role.findById(previousClientRole, { name: 1 }).lean();
     const allowedRoleChanges = [
       { from: AUXILIARY, to: PLANNING_REFERENT },
       { from: PLANNING_REFERENT, to: AUXILIARY },
@@ -97,7 +100,7 @@ const checkRole = async (userFromDB, payload) => {
 
 const checkCustomer = async (userCompany, payload) => {
   const role = await Role.findOne({ name: HELPER }).lean();
-  if (get(payload, 'role', null) !== role._id.toHexString()) throw Boom.forbidden();
+  if (!UtilsHelper.areObjectIdsEquals(get(payload, 'role', null), role._id)) throw Boom.forbidden();
   const customerCount = await Customer.countDocuments({ _id: payload.customer, company: userCompany });
 
   if (!customerCount) throw Boom.forbidden();

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -100,7 +100,7 @@ const checkRole = async (userFromDB, payload) => {
 
 const checkCustomer = async (userCompany, payload) => {
   const role = await Role.findOne({ name: HELPER }).lean();
-  if (!UtilsHelper.areObjectIdsEquals(get(payload, 'role', null), role._id)) throw Boom.forbidden();
+  if (!UtilsHelper.areObjectIdsEquals(payload.role, role._id)) throw Boom.forbidden();
   const customerCount = await Customer.countDocuments({ _id: payload.customer, company: userCompany });
 
   if (!customerCount) throw Boom.forbidden();

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -1060,6 +1060,8 @@ describe('PUT /users/:id/', () => {
 
     it('should add helper role to user if no company', async () => {
       const role = await Role.findOne({ name: HELPER }).lean();
+      expect(await UserCompany.countDocuments({ user: userList[8]._id })).toBe(0);
+
       const res = await app.inject({
         method: 'PUT',
         url: `/users/${userList[8]._id}`,
@@ -1068,6 +1070,7 @@ describe('PUT /users/:id/', () => {
       });
 
       expect(res.statusCode).toBe(200);
+      expect(await UserCompany.countDocuments({ user: userList[8]._id })).toBe(1);
     });
 
     it('should not add helper role to user if customer is not from the same company as user', async () => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client/vendeur

- Périmetre roles : admin client/ROF 

- Cas d'usage : 
Dans les cas suivant, verifier que l'on cree bien un objet `UserCompany` :
- Ajout d'un apprenant dans une structure (verifier sur le repertoire apprenant cote client + ajout de stagiaire intra (cote client et coté vendeur + ajout de stagiaire inter cote vendeur)
- Ajout d'un coach (cote client et cote vendeur)
- Ajout d'une auxiliaire
- Ajout d'un aidant

Verifier egalement que si l'utilisateur a deja une entreprise, cela ne recree pas un UserCompany.
J'en ai profite pour faire un mini refacto des prehandler en utilisant `areObjectIdsEqual`