### PR TITLE
Com 2081 fix

### DIFF
--- a/src/helpers/draftBills.js
+++ b/src/helpers/draftBills.js
@@ -290,6 +290,7 @@ exports.computeBillingInfoForEvents = (events, service, fundings, billingStartDa
         matchingService
       );
     }
+
     if (moment(event.startDate).isBefore(startDate)) startDate = moment(event.startDate);
   }
 

--- a/tests/unit/helpers/draftbills.test.js
+++ b/tests/unit/helpers/draftbills.test.js
@@ -597,8 +597,14 @@ describe('getEventBilling', () => {
 
 describe('formatDraftBillsForCustomer', () => {
   let getInclTaxes;
-  beforeEach(() => { getInclTaxes = sinon.stub(DraftBillsHelper, 'getInclTaxes'); });
-  afterEach(() => { getInclTaxes.restore(); });
+
+  beforeEach(() => {
+    getInclTaxes = sinon.stub(DraftBillsHelper, 'getInclTaxes');
+  });
+
+  afterEach(() => {
+    getInclTaxes.restore();
+  });
 
   it('should format bill for customer', () => {
     const customerPrices = { exclTaxes: 20, inclTaxes: 25, hours: 3, eventsList: [{ event: '123456' }] };


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles -np
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : Si le beneficiaire doit payer une partie des interventions, toutes les heures sont comptées.
Les différentes choses à tester : 
- vérifier que quelques lignes dans a facturer sont bien inchangés par rapport a dev (j'ai verifié de A à D)
- beneficiaire sans tpp : toutes les heures sont comptées
- Beneficiaire avec tpp 100 % au meme tarif: 
      - avec surcharge / jour ferie: toutes les heures sont comptées --> tester une facturation
      - sans surcharge : si pas d'heure en plus aucune heure n'est comptée
- Beneficiaire avec tpp 100 % a un tarif different : toutes les heures sont comptées
- Beneficiaire avec tpp different de 100 % : toutes les heures sont comptées 