### PR TITLE
Com 2092

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -393,10 +393,21 @@ module.exports = {
   BLENDED_COURSE_REGISTRATION: 'blended_course_registration',
   // TIMESTAMP
   MANUAL_TIME_STAMPING: 'manual_time_stamping',
+  get TIMESTAMPING_ACTION_TYPE_LIST() {
+    return {
+      [this.MANUAL_TIME_STAMPING]: 'Manuel',
+    };
+  },
   QRCODE_MISSING: 'qrcode_missing',
   QRCODE_ERROR: 'qrcode_error',
   CAMERA_ERROR: 'camera_error',
-  get MANUAL_TIME_STAMPING_REASONS() { return [this.QRCODE_MISSING, this.QRCODE_ERROR, this.CAMERA_ERROR]; },
+  get MANUAL_TIME_STAMPING_REASONS() {
+    return {
+      [this.QRCODE_MISSING]: 'QR Code manquant',
+      [this.QRCODE_ERROR]: 'Erreur de QR Code',
+      [this.CAMERA_ERROR]: 'Problème de caméra',
+    };
+  },
   // STOP REASONS
   QUALITY: 'quality',
   HOSPITALIZATION: 'hospitalization',

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -18,6 +18,12 @@ const DATE_FORMATS = {
   MMMM: { month: 'long' },
   YY: { year: '2-digit' },
   YYYY: { year: 'numeric' },
+  h: { hour: 'numeric' },
+  hh: { hour: '2-digit' },
+  m: { minute: 'numeric' },
+  mm: { minute: '2-digit' },
+  s: { second: 'numeric' },
+  ss: { second: '2-digit' },
 };
 exports.format = (date, format = '') => {
   if (!date) return null;
@@ -25,6 +31,29 @@ exports.format = (date, format = '') => {
   const options = format.split(' ').map(f => DATE_FORMATS[f]);
 
   return new Date(date).toLocaleDateString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) });
+};
+
+const DATE_AND_TIME_FORMATS = {
+  D: { day: 'numeric' },
+  DD: { day: '2-digit' },
+  MM: { month: '2-digit' },
+  MMM: { month: 'short' },
+  MMMM: { month: 'long' },
+  YY: { year: '2-digit' },
+  YYYY: { year: 'numeric' },
+  h: { hour: 'numeric' },
+  hh: { hour: '2-digit' },
+  m: { minute: 'numeric' },
+  mm: { minute: '2-digit' },
+  s: { second: 'numeric' },
+  ss: { second: '2-digit' },
+};
+exports.formatDateAndTime = (date, format = '') => {
+  if (!date) return null;
+
+  const options = format.split(' ').map(f => DATE_AND_TIME_FORMATS[f]);
+
+  return new Date(date).toLocaleString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) });
 };
 
 exports.descendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -36,10 +36,10 @@ exports.format = (date, format = '') => {
 
 exports.formatDateAndTime = (date, format = '') => {
   if (!date) return null;
-
   const options = format.split(' ').map(f => DATE_FORMATS[f]);
 
-  return new Date(date).toLocaleString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) });
+  return new Date(date).toLocaleString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) })
+    .replace('à ', '');
 };
 
 exports.descendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -25,6 +25,7 @@ const DATE_FORMATS = {
   s: { second: 'numeric' },
   ss: { second: '2-digit' },
 };
+
 exports.format = (date, format = '') => {
   if (!date) return null;
 
@@ -33,25 +34,10 @@ exports.format = (date, format = '') => {
   return new Date(date).toLocaleDateString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) });
 };
 
-const DATE_AND_TIME_FORMATS = {
-  D: { day: 'numeric' },
-  DD: { day: '2-digit' },
-  MM: { month: '2-digit' },
-  MMM: { month: 'short' },
-  MMMM: { month: 'long' },
-  YY: { year: '2-digit' },
-  YYYY: { year: 'numeric' },
-  h: { hour: 'numeric' },
-  hh: { hour: '2-digit' },
-  m: { minute: 'numeric' },
-  mm: { minute: '2-digit' },
-  s: { second: 'numeric' },
-  ss: { second: '2-digit' },
-};
 exports.formatDateAndTime = (date, format = '') => {
   if (!date) return null;
 
-  const options = format.split(' ').map(f => DATE_AND_TIME_FORMATS[f]);
+  const options = format.split(' ').map(f => DATE_FORMATS[f]);
 
   return new Date(date).toLocaleString('fr-FR', { timeZone: 'Europe/Paris', ...Object.assign({}, ...options) });
 };

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -29,13 +29,14 @@ const Payment = require('../models/Payment');
 const FinalPay = require('../models/FinalPay');
 const EventRepository = require('../repositories/EventRepository');
 const UserRepository = require('../repositories/UserRepository');
+const TIMESTAMPING_ACTIONS = require('../models/EventHistory');
 
 const workingEventExportHeader = [
   'Type',
   'Heure interne',
   'Service',
-  'Début',
-  'Fin',
+  ['Début planifié', 'Début horodaté', 'Type d\'horodatage', 'Motif'],
+  ['Fin planifiée', 'Fin horodatée', 'Type d\'horodatage', 'Motif'],
   'Durée',
   'Répétition',
   'Équipe',
@@ -81,6 +82,7 @@ exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
     .populate({ path: 'customer', populate: { path: 'subscriptions', populate: 'service' } })
     .populate('internalHour')
     .populate('sector')
+    .populate({ path: 'histories', match: { action: { $in: TIMESTAMPING_ACTIONS }, company: companyId } })
     .lean();
 
   const eventsWithPopulatedSubscription = events.map((event) => {

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -17,6 +17,7 @@ const {
   PAYMENT_TYPES_LIST,
   INTERNAL_HOUR,
   INTERVENTION,
+  MANUAL_TIME_STAMPING,
 } = require('./constants');
 const UtilsHelper = require('./utils');
 const DraftPayHelper = require('./draftPay');
@@ -116,8 +117,18 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      moment(event.startDate).format('DD/MM/YYYY HH:mm'),
-      moment(event.endDate).format('DD/MM/YYYY HH:mm'),
+      [
+        get(event, 'histories.update.startHour.from') || '',
+        get(event, 'histories.update.startHour.to') || '',
+        get(event, 'histories.action', '') || '',
+        get(event, 'histories.action') === MANUAL_TIME_STAMPING ? get(event, 'histories.manualTimeStampingReason') : '',
+      ],
+      [
+        get(event, 'histories.update.endHour.from') || event.endDate,
+        get(event, 'histories.update.endHour.to') || '',
+        get(event, 'histories.action') || '',
+        get(event, 'histories.action') === MANUAL_TIME_STAMPING ? get(event, 'histories.manualTimeStampingReason') : '',
+      ],
       UtilsHelper.formatFloatForExport(moment(event.endDate).diff(event.startDate, 'h', true)),
       repetition || '',
       get(event, 'sector.name') || get(auxiliarySector, 'sector.name') || '',

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -30,14 +30,20 @@ const Payment = require('../models/Payment');
 const FinalPay = require('../models/FinalPay');
 const EventRepository = require('../repositories/EventRepository');
 const UserRepository = require('../repositories/UserRepository');
-const TIMESTAMPING_ACTIONS = require('../models/EventHistory');
+const { TIMESTAMPING_ACTIONS } = require('../models/EventHistory');
 
 const workingEventExportHeader = [
   'Type',
   'Heure interne',
   'Service',
-  ['Début planifié', 'Début horodaté', 'Type d\'horodatage', 'Motif'],
-  ['Fin planifiée', 'Fin horodatée', 'Type d\'horodatage', 'Motif'],
+  'Début planifié',
+  'Début horodaté',
+  'Type d\'horodatage',
+  'Motif',
+  'Fin planifiée',
+  'Fin horodatée',
+  'Type d\'horodatage',
+  'Motif',
   'Durée',
   'Répétition',
   'Équipe',
@@ -113,22 +119,23 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       : null;
     const auxiliarySector = auxiliary ? getMatchingSector(auxiliary.sectorHistory, event) : null;
 
+    const startHourTimeStamping = event.histories.find(history => get(history, 'update.startHour'));
+    const endHourTimeStamping = event.histories.find(history => get(history, 'update.endHour'));
+
     const cells = [
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      [
-        get(event, 'histories.update.startHour.from') || '',
-        get(event, 'histories.update.startHour.to') || '',
-        get(event, 'histories.action', '') || '',
-        get(event, 'histories.action') === MANUAL_TIME_STAMPING ? get(event, 'histories.manualTimeStampingReason') : '',
-      ],
-      [
-        get(event, 'histories.update.endHour.from') || event.endDate,
-        get(event, 'histories.update.endHour.to') || '',
-        get(event, 'histories.action') || '',
-        get(event, 'histories.action') === MANUAL_TIME_STAMPING ? get(event, 'histories.manualTimeStampingReason') : '',
-      ],
+      get(startHourTimeStamping, 'update.startHour.from') || event.startDate,
+      get(startHourTimeStamping, 'update.startHour.to') || '',
+      get(startHourTimeStamping, 'action') || '',
+      get(startHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
+        ? get(startHourTimeStamping, 'manualTimeStampingReason') : '',
+      get(endHourTimeStamping, 'update.endHour.from') || event.endDate,
+      get(endHourTimeStamping, 'update.endHour.to') || '',
+      get(endHourTimeStamping, 'action') || '',
+      get(endHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
+        ? get(endHourTimeStamping, 'manualTimeStampingReason') : '',
       UtilsHelper.formatFloatForExport(moment(event.endDate).diff(event.startDate, 'h', true)),
       repetition || '',
       get(event, 'sector.name') || get(auxiliarySector, 'sector.name') || '',

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -21,7 +21,7 @@ const {
   TIMESTAMPING_ACTION_TYPE_LIST,
   MANUAL_TIME_STAMPING_REASONS,
 } = require('./constants');
-const { formatDateAndTime } = require('./dates');
+const DatesHelper = require('./dates');
 const UtilsHelper = require('./utils');
 const DraftPayHelper = require('./draftPay');
 const Event = require('../models/Event');
@@ -129,15 +129,15 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      formatDateAndTime(get(startHourTimeStamping, 'update.startHour.from'), 'DDMMMMYYYYhhmmss') ||
-        formatDateAndTime(event.startDate, 'DDMMMMYYYYhhmmss'),
-      formatDateAndTime(get(startHourTimeStamping, 'update.startHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      DatesHelper.formatDateAndTime(get(startHourTimeStamping, 'update.startHour.from'), 'DDMMMMYYYYhhmmss') ||
+        DatesHelper.formatDateAndTime(event.startDate, 'DDMMMMYYYYhhmmss'),
+      DatesHelper.formatDateAndTime(get(startHourTimeStamping, 'update.startHour.to'), 'DDMMMMYYYYhhmmss') || '',
       TIMESTAMPING_ACTION_TYPE_LIST[get(startHourTimeStamping, 'action')] || '',
       get(startHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(startHourTimeStamping, 'manualTimeStampingReason')] : '',
-      formatDateAndTime(get(endHourTimeStamping, 'update.endHour.from'), 'DDMMMMYYYYhhmmss') ||
-        formatDateAndTime(event.endDate, 'DDMMMMYYYYhhmmss'),
-      formatDateAndTime(get(endHourTimeStamping, 'update.endHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      DatesHelper.formatDateAndTime(get(endHourTimeStamping, 'update.endHour.from'), 'DDMMMMYYYYhhmmss') ||
+        DatesHelper.formatDateAndTime(event.endDate, 'DDMMMMYYYYhhmmss'),
+      DatesHelper.formatDateAndTime(get(endHourTimeStamping, 'update.endHour.to'), 'DDMMMMYYYYhhmmss') || '',
       TIMESTAMPING_ACTION_TYPE_LIST[get(endHourTimeStamping, 'action')] || '',
       get(endHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(endHourTimeStamping, 'manualTimeStampingReason')] : '',

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -18,7 +18,10 @@ const {
   INTERNAL_HOUR,
   INTERVENTION,
   MANUAL_TIME_STAMPING,
+  TIMESTAMPING_ACTION_TYPE_LIST,
+  MANUAL_TIME_STAMPING_REASONS,
 } = require('./constants');
+const { formatDateAndTime } = require('./dates');
 const UtilsHelper = require('./utils');
 const DraftPayHelper = require('./draftPay');
 const Event = require('../models/Event');
@@ -126,16 +129,18 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      get(startHourTimeStamping, 'update.startHour.from') || event.startDate,
-      get(startHourTimeStamping, 'update.startHour.to') || '',
-      get(startHourTimeStamping, 'action') || '',
+      formatDateAndTime(get(startHourTimeStamping, 'update.startHour.from'), 'DDMMMMYYYYhhmmss') ||
+        formatDateAndTime(event.startDate, 'DDMMMMYYYYhhmmss'),
+      formatDateAndTime(get(startHourTimeStamping, 'update.startHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      TIMESTAMPING_ACTION_TYPE_LIST[get(startHourTimeStamping, 'action')] || '',
       get(startHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
-        ? get(startHourTimeStamping, 'manualTimeStampingReason') : '',
-      get(endHourTimeStamping, 'update.endHour.from') || event.endDate,
-      get(endHourTimeStamping, 'update.endHour.to') || '',
-      get(endHourTimeStamping, 'action') || '',
+        ? MANUAL_TIME_STAMPING_REASONS[get(startHourTimeStamping, 'manualTimeStampingReason')] : '',
+      formatDateAndTime(get(endHourTimeStamping, 'update.endHour.from'), 'DDMMMMYYYYhhmmss') ||
+        formatDateAndTime(event.endDate, 'DDMMMMYYYYhhmmss'),
+      formatDateAndTime(get(endHourTimeStamping, 'update.endHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      TIMESTAMPING_ACTION_TYPE_LIST[get(endHourTimeStamping, 'action')] || '',
       get(endHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
-        ? get(endHourTimeStamping, 'manualTimeStampingReason') : '',
+        ? MANUAL_TIME_STAMPING_REASONS[get(endHourTimeStamping, 'manualTimeStampingReason')] : '',
       UtilsHelper.formatFloatForExport(moment(event.endDate).diff(event.startDate, 'h', true)),
       repetition || '',
       get(event, 'sector.name') || get(auxiliarySector, 'sector.name') || '',

--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -76,6 +76,12 @@ const getServiceName = (service) => {
 const getMatchingSector = (histories, event) => histories.filter(sh => moment(sh.startDate).isBefore(event.startDate))
   .sort((a, b) => new Date(b.startDate) - new Date(a.startDate))[0];
 
+const displayDate = (timestamp = null, path, scheduledDate = null) => {
+  if (timestamp) return DatesHelper.formatDateAndTime(get(timestamp, path), 'DDMMMMYYYYhhmmss');
+  if (scheduledDate) return DatesHelper.formatDateAndTime(scheduledDate, 'DDMMMMYYYYhhmmss');
+  return '';
+};
+
 exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
   const payload = {
     company: companyId,
@@ -113,6 +119,7 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
   const auxiliaries = await UserRepository.getAuxiliariesWithSectorHistory(auxiliaryIds, companyId);
 
   const rows = [workingEventExportHeader];
+
   for (const event of events) {
     let repetition = get(event.repetition, 'frequency');
     repetition = NEVER === repetition ? '' : REPETITION_FREQUENCY_TYPE_LIST[repetition];
@@ -129,15 +136,13 @@ exports.exportWorkingEventsHistory = async (startDate, endDate, credentials) => 
       EVENT_TYPE_LIST[event.type],
       get(event, 'internalHour.name', ''),
       event.subscription ? getServiceName(event.subscription.service) : '',
-      DatesHelper.formatDateAndTime(get(startHourTimeStamping, 'update.startHour.from'), 'DDMMMMYYYYhhmmss') ||
-        DatesHelper.formatDateAndTime(event.startDate, 'DDMMMMYYYYhhmmss'),
-      DatesHelper.formatDateAndTime(get(startHourTimeStamping, 'update.startHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      displayDate(startHourTimeStamping, 'update.startHour.from', event.startDate),
+      displayDate(startHourTimeStamping, 'update.startHour.to'),
       TIMESTAMPING_ACTION_TYPE_LIST[get(startHourTimeStamping, 'action')] || '',
       get(startHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(startHourTimeStamping, 'manualTimeStampingReason')] : '',
-      DatesHelper.formatDateAndTime(get(endHourTimeStamping, 'update.endHour.from'), 'DDMMMMYYYYhhmmss') ||
-        DatesHelper.formatDateAndTime(event.endDate, 'DDMMMMYYYYhhmmss'),
-      DatesHelper.formatDateAndTime(get(endHourTimeStamping, 'update.endHour.to'), 'DDMMMMYYYYhhmmss') || '',
+      displayDate(endHourTimeStamping, 'update.endHour.from', event.endDate),
+      displayDate(endHourTimeStamping, 'update.endHour.to'),
       TIMESTAMPING_ACTION_TYPE_LIST[get(endHourTimeStamping, 'action')] || '',
       get(endHourTimeStamping, 'action') === MANUAL_TIME_STAMPING
         ? MANUAL_TIME_STAMPING_REASONS[get(endHourTimeStamping, 'manualTimeStampingReason')] : '',

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
+
 const {
   INTERNAL_HOUR,
   ABSENCE,
@@ -118,6 +120,8 @@ EventSchema.virtual('histories', { ref: 'EventHistory', localField: '_id', forei
 
 EventSchema.pre('find', validateQuery);
 EventSchema.pre('aggregate', validateAggregation);
+
+EventSchema.plugin(mongooseLeanVirtuals);
 
 module.exports = mongoose.model('Event', EventSchema);
 module.exports.EVENT_TYPES = EVENT_TYPES;

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -1,6 +1,4 @@
 const mongoose = require('mongoose');
-const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
-
 const {
   INTERNAL_HOUR,
   ABSENCE,
@@ -120,8 +118,6 @@ EventSchema.virtual('histories', { ref: 'EventHistory', localField: '_id', forei
 
 EventSchema.pre('find', validateQuery);
 EventSchema.pre('aggregate', validateAggregation);
-
-EventSchema.plugin(mongooseLeanVirtuals);
 
 module.exports = mongoose.model('Event', EventSchema);
 module.exports.EVENT_TYPES = EVENT_TYPES;

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -52,7 +52,7 @@ const EventHistorySchema = mongoose.Schema({
   },
   auxiliaries: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   sectors: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Sector' }],
-  manualTimeStampingReason: { type: String, enum: MANUAL_TIME_STAMPING_REASONS },
+  manualTimeStampingReason: { type: String, enum: Object.keys(MANUAL_TIME_STAMPING_REASONS) },
 }, { timestamps: true });
 
 EventHistorySchema.pre('find', validateQuery);

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -27,6 +27,7 @@ const {
   MANUAL_TIME_STAMPING_REASONS,
   CUSTOMER,
   AUXILIARY,
+  TIMESTAMPING_ACTION_TYPE_LIST,
 } = require('../helpers/constants');
 const {
   EVENT_TYPES,
@@ -36,7 +37,6 @@ const {
   ABSENCE_TYPES,
   REPETITION_FREQUENCIES,
 } = require('../models/Event');
-const { TIMESTAMPING_ACTIONS } = require('../models/EventHistory');
 const {
   getEvent,
   authorizeEventCreation,
@@ -296,10 +296,10 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
           payload: Joi.object().keys({
-            action: Joi.string().required().valid(...TIMESTAMPING_ACTIONS),
+            action: Joi.string().required().valid(...Object.keys(TIMESTAMPING_ACTION_TYPE_LIST)),
             startDate: Joi.date(),
             endDate: Joi.date(),
-            reason: Joi.string().required().valid(...MANUAL_TIME_STAMPING_REASONS),
+            reason: Joi.string().required().valid(...Object.keys(MANUAL_TIME_STAMPING_REASONS)),
           }).xor('startDate', 'endDate'),
         },
         pre: [{ method: getEvent, assign: 'event' }, { method: authorizeTimeStamping }],

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -62,9 +62,9 @@ describe('GET /exports/working_event/history', () => {
       const rows = response.result.split('\r\n');
       expect(rows).toEqual([
         '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
-        `"Intervention";;"Service 1";"17/01/2019 à 15:30:19";"17/01/2019 à 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 à 17:30:19";"17/01/2019 à 17:35:19";"Manuel";"QR Code manquant";"2,00";"Tous les jours";"Etoile";;;;;"Oui";${customer._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
-        `"Heure interne";"planning";;"17/01/2019 à 15:30:19";;;;"17/01/2019 à 17:30:19";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
-        `"Intervention";;"Service 1";"16/01/2019 à 10:30:19";;;;"16/01/2019 à 12:30:21";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customer._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant"`,
+        `"Intervention";;"Service 1";"17/01/2019 15:30:19";"17/01/2019 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 17:30:19";"17/01/2019 17:35:19";"Manuel";"QR Code manquant";"2,00";"Tous les jours";"Etoile";;;;;"Oui";${customer._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
+        `"Heure interne";"planning";;"17/01/2019 15:30:19";;;;"17/01/2019 17:30:19";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
+        `"Intervention";;"Service 1";"16/01/2019 10:30:19";;;;"16/01/2019 12:30:21";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customer._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant"`,
       ]);
     });
   });

--- a/tests/integration/exports.test.js
+++ b/tests/integration/exports.test.js
@@ -61,10 +61,10 @@ describe('GET /exports/working_event/history', () => {
       expect(response.result).toBeDefined();
       const rows = response.result.split('\r\n');
       expect(rows).toEqual([
-        '\ufeff"Type";"Heure interne";"Service";"Début";"Fin";"Durée";"Répétition";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
-        `"Intervention";;"Service 1";"17/01/2019 15:30";"17/01/2019 17:30";"2,00";"Tous les jours";"Etoile";;;;;"Oui";${customer._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
-        `"Heure interne";"planning";;"17/01/2019 15:30";"17/01/2019 17:30";"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
-        `"Intervention";;"Service 1";"16/01/2019 10:30";"16/01/2019 12:30";"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customer._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant"`,
+        '\ufeff"Type";"Heure interne";"Service";"Début planifié";"Début horodaté";"Type d\'horodatage";"Motif";"Fin planifiée";"Fin horodatée";"Type d\'horodatage";"Motif";"Durée";"Répétition";"Équipe";"Id Auxiliaire";"Auxiliaire - Titre";"Auxiliaire - Prénom";"Auxiliaire - Nom";"A affecter";"Id Bénéficiaire";"Bénéficiaire - Titre";"Bénéficiaire - Nom";"Bénéficiaire - Prénom";"Divers";"Facturé";"Annulé";"Statut de l\'annulation";"Raison de l\'annulation"',
+        `"Intervention";;"Service 1";"17/01/2019 à 15:30:19";"17/01/2019 à 15:35:19";"Manuel";"QR Code manquant";"17/01/2019 à 17:30:19";"17/01/2019 à 17:35:19";"Manuel";"QR Code manquant";"2,00";"Tous les jours";"Etoile";;;;;"Oui";${customer._id.toHexString()};"M.";"BARDET";"Romain";;"Non";"Non";;`,
+        `"Heure interne";"planning";;"17/01/2019 à 15:30:19";;;;"17/01/2019 à 17:30:19";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";;;;;;"Non";"Non";;`,
+        `"Intervention";;"Service 1";"16/01/2019 à 10:30:19";;;;"16/01/2019 à 12:30:21";;;;"2,00";;"Etoile";${auxiliaryList[0]._id.toHexString()};"M.";"Lulu";"UIUI";"Non";${customer._id.toHexString()};"M.";"BARDET";"Romain";"test";"Non";"Oui";"Facturée & payée";"Initiative de l'intervenant"`,
       ]);
     });
   });

--- a/tests/integration/seed/exportSeed.js
+++ b/tests/integration/seed/exportSeed.js
@@ -17,6 +17,7 @@ const FinalPay = require('../../../src/models/FinalPay');
 const ReferentHistory = require('../../../src/models/ReferentHistory');
 const Contract = require('../../../src/models/Contract');
 const Establishment = require('../../../src/models/Establishment');
+const EventHistory = require('../../../src/models/EventHistory');
 const Helper = require('../../../src/models/Helper');
 const { authCustomer } = require('../../seed/customerSeed');
 const { rolesList, populateDBForAuthentication, authCompany, userList } = require('./authenticationSeed');
@@ -39,6 +40,8 @@ const {
   MONTHLY,
   ONCE,
   WEBAPP,
+  MANUAL_TIME_STAMPING,
+  QRCODE_MISSING,
 } = require('../../../src/helpers/constants');
 
 const sector = {
@@ -497,6 +500,25 @@ const eventList = [
   },
 ];
 
+const eventHistoriesList = [
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    event: { eventId: eventList[3]._id },
+    action: MANUAL_TIME_STAMPING,
+    manualTimeStampingReason: QRCODE_MISSING,
+    update: { startHour: { from: '2019-01-17T14:30:19.543Z', to: '2019-01-17T14:35:19.543Z' } },
+  },
+  {
+    _id: new ObjectID(),
+    company: authCompany._id,
+    event: { eventId: eventList[3]._id },
+    action: MANUAL_TIME_STAMPING,
+    manualTimeStampingReason: QRCODE_MISSING,
+    update: { endHour: { from: '2019-01-17T16:30:19.543Z', to: '2019-01-17T16:35:19.543Z' } },
+  },
+];
+
 const billsList = [
   {
     _id: new ObjectID(),
@@ -849,6 +871,7 @@ const populateEvents = async () => {
   await InternalHour.deleteMany();
   await Service.deleteMany();
   await Contract.deleteMany();
+  await EventHistory.deleteMany();
 
   await populateDBForAuthentication();
   await Event.insertMany(eventList);
@@ -859,6 +882,7 @@ const populateEvents = async () => {
   await new InternalHour(internalHour).save();
   await Service.insertMany(serviceList);
   await Contract.insertMany(contractList);
+  await EventHistory.insertMany(eventHistoriesList);
 };
 
 const populateSectorHistories = async () => {

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -171,8 +171,14 @@ describe('exportWorkingEventsHistory', () => {
     'Type',
     'Heure interne',
     'Service',
-    'Début',
-    'Fin',
+    'Début planifié',
+    'Début horodaté',
+    'Type d\'horodatage',
+    'Motif',
+    'Fin planifiée',
+    'Fin horodatée',
+    'Type d\'horodatage',
+    'Motif',
     'Durée',
     'Répétition',
     'Équipe',
@@ -216,8 +222,20 @@ describe('exportWorkingEventsHistory', () => {
         identity: { title: 'mrs', firstname: 'Mimi', lastname: 'Mathy' },
       },
       auxiliary: auxiliaryId,
-      startDate: moment('2019-05-20T08:00:00').toDate(),
-      endDate: moment('2019-05-20T10:00:00').toDate(),
+      startDate: '2019-05-20T08:00:00',
+      endDate: '2019-05-20T10:00:00',
+      histories: [
+        { update: {
+          startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' },
+        },
+        event: {
+          type: 'intervention',
+          auxiliary: auxiliaryId,
+        },
+        auxiliaries: [auxiliaryId],
+        action: 'manual_time_stamping',
+        manualTimeStampingReason: 'qrcode_missing' },
+      ],
     },
     {
       isCancelled: false,
@@ -232,8 +250,30 @@ describe('exportWorkingEventsHistory', () => {
         identity: { title: 'mrs', firstname: 'Mimi', lastname: 'Mathy' },
       },
       sector: { name: 'Girafes - 75' },
-      startDate: moment('2019-05-20T08:00:00').toDate(),
-      endDate: moment('2019-05-20T10:00:00').toDate(),
+      startDate: '2019-05-20T08:00:00',
+      endDate: '2019-05-20T10:00:00',
+      histories: [
+        { update: {
+          startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' },
+        },
+        event: {
+          type: 'intervention',
+          auxiliary: auxiliaryId,
+        },
+        auxiliaries: [auxiliaryId],
+        action: 'manual_time_stamping',
+        manualTimeStampingReason: 'qrcode_missing' },
+        { update: {
+          endHour: { from: '2019-05-20T10:00:00', to: '2019-05-20T10:03:24' },
+        },
+        event: {
+          type: 'intervention',
+          auxiliary: auxiliaryId,
+        },
+        auxiliaries: [auxiliaryId],
+        action: 'manual_time_stamping',
+        manualTimeStampingReason: 'camera_error' },
+      ],
     },
     {
       isCancelled: true,
@@ -247,9 +287,10 @@ describe('exportWorkingEventsHistory', () => {
         _id: new ObjectID(),
         identity: { title: 'mr', firstname: 'Bojack', lastname: 'Horseman' },
       },
-      startDate: moment('2019-05-20T08:00:00').toDate(),
-      endDate: moment('2019-05-20T10:00:00').toDate(),
+      startDate: '2019-05-20T08:00:00',
+      endDate: '2019-05-20T10:00:00',
       misc: 'brbr',
+      histories: [{}],
     },
   ];
   let getWorkingEventsForExport;
@@ -283,16 +324,17 @@ describe('exportWorkingEventsHistory', () => {
 
     expect(exportArray).toEqual([
       header,
-      ['Intervention', '', 'Lala', '20/05/2019 08:00', '20/05/2019 10:00', '2,00', 'Une fois par semaine',
-        'Girafes - 75', expect.any(ObjectID), '', 'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme',
-        'MATHY', 'Mimi', '', 'Oui', 'Non', '', ''],
-      ['Intervention', '', 'Lala', '20/05/2019 08:00', '20/05/2019 10:00', '2,00', 'Une fois par semaine',
-        'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
+      ['Intervention', '', 'Lala', '2019-05-20T08:00:00', '2019-05-20T08:01:18', 'manual_time_stamping',
+        'qrcode_missing', '2019-05-20T10:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75',
+        expect.any(ObjectID), '', 'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Heure interne', 'Formation', '', '20/05/2019 08:00', '20/05/2019 10:00', '2,00', '', 'Etoiles - 75',
-        '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr', 'Non', 'Oui',
-        'Facturée & non payée',
-        'Initiative de l\'intervenant'],
+      ['Intervention', '', 'Lala', '2019-05-20T08:00:00', '2019-05-20T08:01:18', 'manual_time_stamping',
+        'qrcode_missing', '2019-05-20T10:00:00', '2019-05-20T10:03:24', 'manual_time_stamping', 'camera_error', '2,00',
+        'Une fois par semaine', 'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
+        'Oui', 'Non', '', ''],
+      ['Heure interne', 'Formation', '', '2019-05-20T08:00:00', '', '', '', '2019-05-20T10:00:00', '', '', '', '2,00', '',
+        'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr', 'Non', 'Oui',
+        'Facturée & non payée', 'Initiative de l\'intervenant'],
     ]);
   });
 });

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -17,6 +17,7 @@ const EventRepository = require('../../../src/repositories/EventRepository');
 const UserRepository = require('../../../src/repositories/UserRepository');
 const { INTERNAL_HOUR, INTERVENTION } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
+const DatesHelper = require('../../../src/helpers/dates');
 
 describe('getWorkingEventsForExport', () => {
   const auxiliaryId = new ObjectID();
@@ -287,15 +288,18 @@ describe('exportWorkingEventsHistory', () => {
   let getWorkingEventsForExport;
   let getLastVersion;
   let getAuxiliariesWithSectorHistory;
+  let formatDateAndTime;
   beforeEach(() => {
     getWorkingEventsForExport = sinon.stub(ExportHelper, 'getWorkingEventsForExport');
     getLastVersion = sinon.stub(UtilsHelper, 'getLastVersion');
     getAuxiliariesWithSectorHistory = sinon.stub(UserRepository, 'getAuxiliariesWithSectorHistory');
+    formatDateAndTime = sinon.stub(DatesHelper, 'formatDateAndTime');
   });
   afterEach(() => {
     getWorkingEventsForExport.restore();
     getLastVersion.restore();
     getAuxiliariesWithSectorHistory.restore();
+    formatDateAndTime.restore();
   });
 
   it('should return an array containing just the header', async () => {
@@ -306,9 +310,22 @@ describe('exportWorkingEventsHistory', () => {
     expect(exportArray).toEqual([header]);
   });
 
-  it('should return an array with the header and 2 rows', async () => {
+  it('should return an array with the header and 3 rows', async () => {
     getWorkingEventsForExport.returns(events);
     getAuxiliariesWithSectorHistory.returns(auxiliaries);
+    formatDateAndTime.onCall(0).returns('20/05/2019 à 10:00:00');
+    formatDateAndTime.onCall(1).returns('20/05/2019 à 10:01:18');
+    formatDateAndTime.onCall(2).returns('20/05/2019 à 12:00:00');
+    formatDateAndTime.onCall(3).returns('');
+    formatDateAndTime.onCall(4).returns('20/05/2019 à 10:00:00');
+    formatDateAndTime.onCall(5).returns('20/05/2019 à 10:01:18');
+    formatDateAndTime.onCall(6).returns('20/05/2019 à 12:00:00');
+    formatDateAndTime.onCall(7).returns('20/05/2019 à 12:03:24');
+    formatDateAndTime.onCall(8).returns('20/05/2019 à 10:00:00');
+    formatDateAndTime.onCall(9).returns('');
+    formatDateAndTime.onCall(10).returns('20/05/2019 à 12:00:00');
+    formatDateAndTime.onCall(11).returns('');
+
     getLastVersion.callsFake(ver => ver[0]);
 
     const exportArray = await ExportHelper.exportWorkingEventsHistory(null, null);

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -315,17 +315,17 @@ describe('exportWorkingEventsHistory', () => {
 
     expect(exportArray).toEqual([
       header,
-      ['Intervention', '', 'Lala', '2019-05-20T08:00:00', '2019-05-20T08:01:18', 'manual_time_stamping',
-        'qrcode_missing', '2019-05-20T10:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75',
-        expect.any(ObjectID), '', 'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
+      ['Intervention', '', 'Lala', '20/05/2019 à 08:00:00', '20/05/2019 à 08:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 à 10:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75', expect.any(ObjectID), '',
+        'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Intervention', '', 'Lala', '2019-05-20T08:00:00', '2019-05-20T08:01:18', 'manual_time_stamping',
-        'qrcode_missing', '2019-05-20T10:00:00', '2019-05-20T10:03:24', 'manual_time_stamping', 'camera_error', '2,00',
+      ['Intervention', '', 'Lala', '20/05/2019 à 08:00:00', '20/05/2019 à 08:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 à 10:00:00', '20/05/2019 à 10:03:24', 'Manuel', 'Problème de caméra', '2,00',
         'Une fois par semaine', 'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Heure interne', 'Formation', '', '2019-05-20T08:00:00', '', '', '', '2019-05-20T10:00:00', '', '', '', '2,00', '',
-        'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr', 'Non', 'Oui',
-        'Facturée & non payée', 'Initiative de l\'intervenant'],
+      ['Heure interne', 'Formation', '', '20/05/2019 à 08:00:00', '', '', '', '20/05/2019 à 10:00:00', '', '', '',
+        '2,00', '', 'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr',
+        'Non', 'Oui', 'Facturée & non payée', 'Initiative de l\'intervenant'],
     ]);
   });
 });

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -225,16 +225,13 @@ describe('exportWorkingEventsHistory', () => {
       startDate: '2019-05-20T08:00:00',
       endDate: '2019-05-20T10:00:00',
       histories: [
-        { update: {
-          startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' },
+        {
+          update: { startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' } },
+          event: { type: 'intervention', auxiliary: auxiliaryId },
+          auxiliaries: [auxiliaryId],
+          action: 'manual_time_stamping',
+          manualTimeStampingReason: 'qrcode_missing',
         },
-        event: {
-          type: 'intervention',
-          auxiliary: auxiliaryId,
-        },
-        auxiliaries: [auxiliaryId],
-        action: 'manual_time_stamping',
-        manualTimeStampingReason: 'qrcode_missing' },
       ],
     },
     {
@@ -253,26 +250,20 @@ describe('exportWorkingEventsHistory', () => {
       startDate: '2019-05-20T08:00:00',
       endDate: '2019-05-20T10:00:00',
       histories: [
-        { update: {
-          startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' },
+        {
+          update: { startHour: { from: '2019-05-20T08:00:00', to: '2019-05-20T08:01:18' } },
+          event: { type: 'intervention', auxiliary: auxiliaryId },
+          auxiliaries: [auxiliaryId],
+          action: 'manual_time_stamping',
+          manualTimeStampingReason: 'qrcode_missing',
         },
-        event: {
-          type: 'intervention',
-          auxiliary: auxiliaryId,
+        {
+          update: { endHour: { from: '2019-05-20T10:00:00', to: '2019-05-20T10:03:24' } },
+          event: { type: 'intervention', auxiliary: auxiliaryId },
+          auxiliaries: [auxiliaryId],
+          action: 'manual_time_stamping',
+          manualTimeStampingReason: 'camera_error',
         },
-        auxiliaries: [auxiliaryId],
-        action: 'manual_time_stamping',
-        manualTimeStampingReason: 'qrcode_missing' },
-        { update: {
-          endHour: { from: '2019-05-20T10:00:00', to: '2019-05-20T10:03:24' },
-        },
-        event: {
-          type: 'intervention',
-          auxiliary: auxiliaryId,
-        },
-        auxiliaries: [auxiliaryId],
-        action: 'manual_time_stamping',
-        manualTimeStampingReason: 'camera_error' },
       ],
     },
     {
@@ -290,7 +281,7 @@ describe('exportWorkingEventsHistory', () => {
       startDate: '2019-05-20T08:00:00',
       endDate: '2019-05-20T10:00:00',
       misc: 'brbr',
-      histories: [{}],
+      histories: [],
     },
   ];
   let getWorkingEventsForExport;

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -313,18 +313,16 @@ describe('exportWorkingEventsHistory', () => {
   it('should return an array with the header and 3 rows', async () => {
     getWorkingEventsForExport.returns(events);
     getAuxiliariesWithSectorHistory.returns(auxiliaries);
-    formatDateAndTime.onCall(0).returns('20/05/2019 à 10:00:00');
-    formatDateAndTime.onCall(1).returns('20/05/2019 à 10:01:18');
-    formatDateAndTime.onCall(2).returns('20/05/2019 à 12:00:00');
-    formatDateAndTime.onCall(3).returns('');
-    formatDateAndTime.onCall(4).returns('20/05/2019 à 10:00:00');
-    formatDateAndTime.onCall(5).returns('20/05/2019 à 10:01:18');
-    formatDateAndTime.onCall(6).returns('20/05/2019 à 12:00:00');
-    formatDateAndTime.onCall(7).returns('20/05/2019 à 12:03:24');
-    formatDateAndTime.onCall(8).returns('20/05/2019 à 10:00:00');
-    formatDateAndTime.onCall(9).returns('');
-    formatDateAndTime.onCall(10).returns('20/05/2019 à 12:00:00');
-    formatDateAndTime.onCall(11).returns('');
+
+    formatDateAndTime.onCall(0).returns('20/05/2019 10:00:00');
+    formatDateAndTime.onCall(1).returns('20/05/2019 10:01:18');
+    formatDateAndTime.onCall(2).returns('20/05/2019 12:00:00');
+    formatDateAndTime.onCall(3).returns('20/05/2019 10:00:00');
+    formatDateAndTime.onCall(4).returns('20/05/2019 10:01:18');
+    formatDateAndTime.onCall(5).returns('20/05/2019 12:00:00');
+    formatDateAndTime.onCall(6).returns('20/05/2019 12:03:24');
+    formatDateAndTime.onCall(7).returns('20/05/2019 10:00:00');
+    formatDateAndTime.onCall(8).returns('20/05/2019 12:00:00');
 
     getLastVersion.callsFake(ver => ver[0]);
 
@@ -332,15 +330,15 @@ describe('exportWorkingEventsHistory', () => {
 
     expect(exportArray).toEqual([
       header,
-      ['Intervention', '', 'Lala', '20/05/2019 à 10:00:00', '20/05/2019 à 10:01:18', 'Manuel', 'QR Code manquant',
-        '20/05/2019 à 12:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75', expect.any(ObjectID), '',
+      ['Intervention', '', 'Lala', '20/05/2019 10:00:00', '20/05/2019 10:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 12:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75', expect.any(ObjectID), '',
         'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Intervention', '', 'Lala', '20/05/2019 à 10:00:00', '20/05/2019 à 10:01:18', 'Manuel', 'QR Code manquant',
-        '20/05/2019 à 12:00:00', '20/05/2019 à 12:03:24', 'Manuel', 'Problème de caméra', '2,00',
+      ['Intervention', '', 'Lala', '20/05/2019 10:00:00', '20/05/2019 10:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 12:00:00', '20/05/2019 12:03:24', 'Manuel', 'Problème de caméra', '2,00',
         'Une fois par semaine', 'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Heure interne', 'Formation', '', '20/05/2019 à 10:00:00', '', '', '', '20/05/2019 à 12:00:00', '', '', '',
+      ['Heure interne', 'Formation', '', '20/05/2019 10:00:00', '', '', '', '20/05/2019 12:00:00', '', '', '',
         '2,00', '', 'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr',
         'Non', 'Oui', 'Facturée & non payée', 'Initiative de l\'intervenant'],
     ]);

--- a/tests/unit/helpers/historyExport.test.js
+++ b/tests/unit/helpers/historyExport.test.js
@@ -315,15 +315,15 @@ describe('exportWorkingEventsHistory', () => {
 
     expect(exportArray).toEqual([
       header,
-      ['Intervention', '', 'Lala', '20/05/2019 à 08:00:00', '20/05/2019 à 08:01:18', 'Manuel', 'QR Code manquant',
-        '20/05/2019 à 10:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75', expect.any(ObjectID), '',
+      ['Intervention', '', 'Lala', '20/05/2019 à 10:00:00', '20/05/2019 à 10:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 à 12:00:00', '', '', '', '2,00', 'Une fois par semaine', 'Girafes - 75', expect.any(ObjectID), '',
         'Jean-Claude', 'VAN DAMME', 'Non', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Intervention', '', 'Lala', '20/05/2019 à 08:00:00', '20/05/2019 à 08:01:18', 'Manuel', 'QR Code manquant',
-        '20/05/2019 à 10:00:00', '20/05/2019 à 10:03:24', 'Manuel', 'Problème de caméra', '2,00',
+      ['Intervention', '', 'Lala', '20/05/2019 à 10:00:00', '20/05/2019 à 10:01:18', 'Manuel', 'QR Code manquant',
+        '20/05/2019 à 12:00:00', '20/05/2019 à 12:03:24', 'Manuel', 'Problème de caméra', '2,00',
         'Une fois par semaine', 'Girafes - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'Mme', 'MATHY', 'Mimi', '',
         'Oui', 'Non', '', ''],
-      ['Heure interne', 'Formation', '', '20/05/2019 à 08:00:00', '', '', '', '20/05/2019 à 10:00:00', '', '', '',
+      ['Heure interne', 'Formation', '', '20/05/2019 à 10:00:00', '', '', '', '20/05/2019 à 12:00:00', '', '', '',
         '2,00', '', 'Etoiles - 75', '', '', '', '', 'Oui', expect.any(ObjectID), 'M.', 'HORSEMAN', 'Bojack', 'brbr',
         'Non', 'Oui', 'Facturée & non payée', 'Initiative de l\'intervenant'],
     ]);


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach, admin client

- Cas d'usage :  Lorsque l'utilisateur exporte l'historique des interventions et heures internes sur une certaine période, les 8 colonnes : `Début planifié`, `Début horodaté`, `Type horodatage`, `Motif`,  `Fin planifiée`, `Fin horodatée`, `Type horodatage`, `Motif`.
Pour une :
- heure interne: les colonnes `Début horodaté`/` Fin horodaté`, `Type horodatage`, `Motif` sont vides
- intervention: toutes les colonnes sont remplies
