### PR TITLE
Com 2091

### DIFF
--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -79,9 +79,10 @@ exports.isUpdateAllowed = async (eventFromDB, payload, credentials) => {
   const updateAuxiliary = payload.auxiliary &&
     !UtilsHelper.areObjectIdsEquals(eventFromDB.auxiliary, payload.auxiliary);
   const cancelEvent = payload.isCancelled;
-  const forbiddenUpdateOnTimeStampedEvent = updateStartDate || updateEndDate || updateAuxiliary || cancelEvent;
+  const forbiddenUpdateOnTimeStampedEvent = updateAuxiliary || cancelEvent;
   const { startDateTimeStampedCount, endDateTimeStampedCount } = eventFromDB;
-  if ((startDateTimeStampedCount || endDateTimeStampedCount) && forbiddenUpdateOnTimeStampedEvent) return false;
+  if (startDateTimeStampedCount && (updateStartDate || forbiddenUpdateOnTimeStampedEvent)) return false;
+  if (endDateTimeStampedCount && (updateEndDate || forbiddenUpdateOnTimeStampedEvent)) return false;
 
   if (eventFromDB.type === INTERVENTION && eventFromDB.isBilled) return false;
   if ([ABSENCE, UNAVAILABILITY].includes(eventFromDB.type) && isAuxiliaryUpdated(payload, eventFromDB)) return false;

--- a/src/helpers/eventsValidation.js
+++ b/src/helpers/eventsValidation.js
@@ -75,11 +75,13 @@ exports.isCreationAllowed = async (event, credentials) => {
 
 exports.isUpdateAllowed = async (eventFromDB, payload, credentials) => {
   const updateStartDate = payload.startDate && DatesHelper.diff(eventFromDB.startDate, payload.startDate) !== 0;
+  const updateEndDate = payload.endDate && DatesHelper.diff(eventFromDB.endDate, payload.endDate) !== 0;
   const updateAuxiliary = payload.auxiliary &&
     !UtilsHelper.areObjectIdsEquals(eventFromDB.auxiliary, payload.auxiliary);
   const cancelEvent = payload.isCancelled;
-  const forbiddenUpdateOnTimeStampedEvent = updateStartDate || updateAuxiliary || cancelEvent;
-  if (eventFromDB.startDateTimeStampedCount && forbiddenUpdateOnTimeStampedEvent) return false;
+  const forbiddenUpdateOnTimeStampedEvent = updateStartDate || updateEndDate || updateAuxiliary || cancelEvent;
+  const { startDateTimeStampedCount, endDateTimeStampedCount } = eventFromDB;
+  if ((startDateTimeStampedCount || endDateTimeStampedCount) && forbiddenUpdateOnTimeStampedEvent) return false;
 
   if (eventFromDB.type === INTERVENTION && eventFromDB.isBilled) return false;
   if ([ABSENCE, UNAVAILABILITY].includes(eventFromDB.type) && isAuxiliaryUpdated(payload, eventFromDB)) return false;

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -133,6 +133,23 @@ EventSchema.virtual(
   }
 );
 
+EventSchema.virtual(
+  'endDateTimeStampedCount',
+  {
+    ref: 'EventHistory',
+    localField: '_id',
+    foreignField: 'event.eventId',
+    options: {
+      match: doc => ({
+        action: { $in: TIMESTAMPING_ACTIONS },
+        'update.endHour': { $exists: true },
+        company: doc.company,
+      }),
+    },
+    count: true,
+  }
+);
+
 EventSchema.pre('find', validateQuery);
 EventSchema.pre('aggregate', validateAggregation);
 

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -67,6 +67,7 @@ exports.getEventsGroupedBy = async (rules, groupByFunc, companyId) => {
       ],
     })
     .populate('startDateTimeStampedCount')
+    .populate('endDateTimeStampedCount')
     .lean();
 
   return groupBy(events.map(exports.formatEvent), groupByFunc);

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -30,6 +30,7 @@ exports.getEvent = async (req) => {
   try {
     const event = await Event.findById(req.params._id)
       .populate('startDateTimeStampedCount')
+      .populate('endDateTimeStampedCount')
       .lean();
 
     if (!event) throw Boom.notFound(translate[language].eventNotFound);

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1533,7 +1533,7 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toEqual(403);
     });
 
-    it('should return a 422 event is timeStamped and user tries to update startDate', async () => {
+    it('should return a 422 event is startDate timeStamped and user tries to update date', async () => {
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
         endDate: '2019-01-23T12:00:00.000Z',
@@ -1550,7 +1550,7 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toEqual(422);
     });
 
-    it('should return a 422 event is timeStamped and user tries to update auxiliary', async () => {
+    it('should return a 422 event is startDate timeStamped and user tries to update auxiliary', async () => {
       const payload = { auxiliary: auxiliaries[1]._id };
 
       const response = await app.inject({
@@ -1563,7 +1563,7 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toEqual(422);
     });
 
-    it('should return a 422 event is timeStamped and user tries to update isCancelled', async () => {
+    it('should return a 422 event is startDate timeStamped and user tries to update isCancelled', async () => {
       const payload = {
         auxiliary: auxiliaries[2]._id,
         isCancelled: true,
@@ -1574,6 +1574,54 @@ describe('PUT /events/{_id}', () => {
       const response = await app.inject({
         method: 'PUT',
         url: `/events/${eventsList[23]._id}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(422);
+    });
+
+    it('should return a 422 event is endDate timeStamped and user tries to update date', async () => {
+      const payload = {
+        startDate: '2019-01-23T10:00:00.000Z',
+        endDate: '2019-01-23T12:00:00.000Z',
+        sector: sectors[0]._id.toHexString(),
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[24]._id}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(422);
+    });
+
+    it('should return a 422 event is endDate timeStamped and user tries to update auxiliary', async () => {
+      const payload = { auxiliary: auxiliaries[1]._id };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[24]._id}`,
+        payload,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toEqual(422);
+    });
+
+    it('should return a 422 event is endDate timeStamped and user tries to update isCancelled', async () => {
+      const payload = {
+        auxiliary: auxiliaries[3]._id,
+        isCancelled: true,
+        cancel: { condition: INVOICED_AND_PAID, reason: AUXILIARY_INITIATIVE },
+        misc: 'blablabla',
+      };
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[24]._id}`,
         payload,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -718,6 +718,7 @@ const eventsList = [
     customer: customerAuxiliary._id,
     subscription: customerAuxiliary.subscriptions[2]._id,
     createdAt: '2019-01-05T15:24:18.653Z',
+    isCancelled: false,
     address: {
       fullAddress: '23 rue du test 92160 Antony',
       street: '23 rue du test',
@@ -737,6 +738,7 @@ const eventsList = [
     customer: customerAuxiliary._id,
     subscription: customerAuxiliary.subscriptions[2]._id,
     createdAt: '2019-01-05T15:24:18.653Z',
+    isCancelled: false,
     address: {
       fullAddress: '24 rue du test 92160 Antony',
       street: '24 rue du test',

--- a/tests/integration/seed/eventsSeed.js
+++ b/tests/integration/seed/eventsSeed.js
@@ -718,7 +718,6 @@ const eventsList = [
     customer: customerAuxiliary._id,
     subscription: customerAuxiliary.subscriptions[2]._id,
     createdAt: '2019-01-05T15:24:18.653Z',
-    isCancelled: false,
     address: {
       fullAddress: '23 rue du test 92160 Antony',
       street: '23 rue du test',

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -741,17 +741,18 @@ describe('isUpdateAllowed', () => {
     }
   });
 
-  it('should return false if event is startDate timeStamped and user wants to update date', async () => {
+  it('should return false if event is startDate timeStamped and user wants to update start date', async () => {
     const auxiliaryId = new ObjectID();
     const payload = {
       auxiliary: auxiliaryId.toHexString(),
-      startDate: '2019-04-13T09:00:00',
+      startDate: '2019-04-13T09:05:00',
       endDate: '2019-04-13T11:00:00',
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      startDate: '2020-05-14T19:00:00',
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       startDateTimeStampedCount: 1,
     };
 
@@ -773,6 +774,7 @@ describe('isUpdateAllowed', () => {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       startDateTimeStampedCount: 1,
     };
 
@@ -795,6 +797,7 @@ describe('isUpdateAllowed', () => {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       startDateTimeStampedCount: 1,
     };
 
@@ -805,17 +808,18 @@ describe('isUpdateAllowed', () => {
     sinon.assert.notCalled(isEditionAllowed);
   });
 
-  it('should return false if event is endDate timeStamped and user wants to update date', async () => {
+  it('should return false if event is endDate timeStamped and user wants to update end date', async () => {
     const auxiliaryId = new ObjectID();
     const payload = {
       auxiliary: auxiliaryId.toHexString(),
       startDate: '2019-04-13T09:00:00',
-      endDate: '2019-04-13T11:00:00',
+      endDate: '2019-04-13T11:05:00',
     };
     const eventFromDB = {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
-      endDate: '2020-05-14T19:00:00',
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       endDateTimeStampedCount: 1,
     };
 
@@ -837,6 +841,7 @@ describe('isUpdateAllowed', () => {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       endDateTimeStampedCount: 1,
     };
 
@@ -859,6 +864,7 @@ describe('isUpdateAllowed', () => {
       auxiliary: auxiliaryId,
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
       endDateTimeStampedCount: 1,
     };
 

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -741,7 +741,7 @@ describe('isUpdateAllowed', () => {
     }
   });
 
-  it('should return false if event is timeStamped and user wants to update startDate', async () => {
+  it('should return false if event is startDate timeStamped and user wants to update date', async () => {
     const auxiliaryId = new ObjectID();
     const payload = {
       auxiliary: auxiliaryId.toHexString(),
@@ -762,7 +762,7 @@ describe('isUpdateAllowed', () => {
     sinon.assert.notCalled(isEditionAllowed);
   });
 
-  it('should return false if event is timeStamped and user wants to update auxiliary', async () => {
+  it('should return false if event is startDate timeStamped and user wants to update auxiliary', async () => {
     const auxiliaryId = new ObjectID();
     const payload = {
       auxiliary: new ObjectID(),
@@ -783,7 +783,7 @@ describe('isUpdateAllowed', () => {
     sinon.assert.notCalled(isEditionAllowed);
   });
 
-  it('should return false if event is timeStamped and user wants to cancel event', async () => {
+  it('should return false if event is startDate timeStamped and user wants to cancel event', async () => {
     const auxiliaryId = new ObjectID();
     const payload = {
       auxiliary: auxiliaryId,
@@ -796,6 +796,70 @@ describe('isUpdateAllowed', () => {
       type: INTERVENTION,
       startDate: '2019-04-13T09:00:00',
       startDateTimeStampedCount: 1,
+    };
+
+    const result = await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload, credentials);
+
+    expect(result).toBe(false);
+    sinon.assert.notCalled(hasConflicts);
+    sinon.assert.notCalled(isEditionAllowed);
+  });
+
+  it('should return false if event is endDate timeStamped and user wants to update date', async () => {
+    const auxiliaryId = new ObjectID();
+    const payload = {
+      auxiliary: auxiliaryId.toHexString(),
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+    };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      endDate: '2020-05-14T19:00:00',
+      endDateTimeStampedCount: 1,
+    };
+
+    const result = await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload, credentials);
+
+    expect(result).toBe(false);
+    sinon.assert.notCalled(hasConflicts);
+    sinon.assert.notCalled(isEditionAllowed);
+  });
+
+  it('should return false if event is endDate timeStamped and user wants to update auxiliary', async () => {
+    const auxiliaryId = new ObjectID();
+    const payload = {
+      auxiliary: new ObjectID(),
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+    };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      startDate: '2019-04-13T09:00:00',
+      endDateTimeStampedCount: 1,
+    };
+
+    const result = await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload, credentials);
+
+    expect(result).toBe(false);
+    sinon.assert.notCalled(hasConflicts);
+    sinon.assert.notCalled(isEditionAllowed);
+  });
+
+  it('should return false if event is endDate timeStamped and user wants to cancel event', async () => {
+    const auxiliaryId = new ObjectID();
+    const payload = {
+      auxiliary: auxiliaryId,
+      startDate: '2019-04-13T09:00:00',
+      endDate: '2019-04-13T11:00:00',
+      isCancelled: true,
+    };
+    const eventFromDB = {
+      auxiliary: auxiliaryId,
+      type: INTERVENTION,
+      startDate: '2019-04-13T09:00:00',
+      endDateTimeStampedCount: 1,
     };
 
     const result = await EventsValidationHelper.isUpdateAllowed(eventFromDB, payload, credentials);


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent -> on ne peut pas horodater (donc changer la endDate) d'un évenement déjà horodaté

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme -np
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - ~~Justification des breaking changes s'il y en a:~~
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- ~~J'ai ajouté un champ possible dans la route :~~
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [x] J'ai géré le cas où l'application ne l'envoie pas -> c'est un virtual
  - ~~J'ai rendu obligatoire un champs :~~
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - ~~J'ai retiré un champ possible :~~
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/admin/auxiliaire

- Cas d'usage : 
Lorsqu'un évenement est horodaté (pour sa date de fin), je ne peux plus modifier :
- son auxiliaire
- son secteur
- sa date
- je ne peux plus annuler l'évenement
