### PR TITLE
COM-2137 replace MANUAL_TIME_STAMPING by TIME_STAMPING_ACTIONS

### DIFF
--- a/src/helpers/historyExport.js
+++ b/src/helpers/historyExport.js
@@ -33,7 +33,7 @@ const Payment = require('../models/Payment');
 const FinalPay = require('../models/FinalPay');
 const EventRepository = require('../repositories/EventRepository');
 const UserRepository = require('../repositories/UserRepository');
-const { TIMESTAMPING_ACTIONS } = require('../models/EventHistory');
+const { TIME_STAMPING_ACTIONS } = require('../models/EventHistory');
 
 const workingEventExportHeader = [
   'Type',
@@ -98,7 +98,7 @@ exports.getWorkingEventsForExport = async (startDate, endDate, companyId) => {
     .populate({ path: 'customer', populate: { path: 'subscriptions', populate: 'service' } })
     .populate('internalHour')
     .populate('sector')
-    .populate({ path: 'histories', match: { action: { $in: TIMESTAMPING_ACTIONS }, company: companyId } })
+    .populate({ path: 'histories', match: { action: { $in: TIME_STAMPING_ACTIONS }, company: companyId } })
     .lean();
 
   const eventsWithPopulatedSubscription = events.map((event) => {

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -33,7 +33,7 @@ const driveResourceSchemaDefinition = require('./schemaDefinitions/driveResource
 const addressSchemaDefinition = require('./schemaDefinitions/address');
 const billEventSurchargesSchemaDefinition = require('./schemaDefinitions/billEventSurcharges');
 const { validateQuery, validateAggregation } = require('./preHooks/validate');
-const { TIMESTAMPING_ACTIONS } = require('./EventHistory');
+const { TIME_STAMPING_ACTIONS } = require('./EventHistory');
 
 const EVENT_TYPES = [ABSENCE, INTERNAL_HOUR, INTERVENTION, UNAVAILABILITY];
 const ABSENCE_NATURES = [HOURLY, DAILY];
@@ -124,7 +124,7 @@ EventSchema.virtual(
     foreignField: 'event.eventId',
     options: {
       match: doc => ({
-        action: { $in: TIMESTAMPING_ACTIONS },
+        action: { $in: TIME_STAMPING_ACTIONS },
         'update.startHour': { $exists: true },
         company: doc.company,
       }),

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -14,7 +14,7 @@ const addressSchemaDefinition = require('./schemaDefinitions/address');
 const { validateQuery, validateAggregation } = require('./preHooks/validate');
 
 const EVENTS_HISTORY_ACTIONS = [EVENT_CREATION, EVENT_DELETION, EVENT_UPDATE, MANUAL_TIME_STAMPING];
-const TIMESTAMPING_ACTIONS = [MANUAL_TIME_STAMPING];
+const TIME_STAMPING_ACTIONS = [MANUAL_TIME_STAMPING];
 
 const EventHistorySchema = mongoose.Schema({
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
@@ -59,4 +59,4 @@ EventHistorySchema.pre('find', validateQuery);
 EventHistorySchema.pre('aggregate', validateAggregation);
 
 module.exports = mongoose.model('EventHistory', EventHistorySchema);
-module.exports.TIMESTAMPING_ACTIONS = TIMESTAMPING_ACTIONS;
+module.exports.TIME_STAMPING_ACTIONS = TIME_STAMPING_ACTIONS;

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -20,7 +20,6 @@ const {
   TRANSPORT_ACCIDENT,
   ILLNESS,
   INTERVENTION,
-  MANUAL_TIME_STAMPING,
 } = require('../../helpers/constants');
 const DatesHelper = require('../../helpers/dates');
 
@@ -208,7 +207,7 @@ exports.authorizeTimeStamping = async (req) => {
   });
   if (!eventCount) throw Boom.notFound();
 
-  const timeStampPayload = { 'event.eventId': req.params._id, action: MANUAL_TIME_STAMPING };
+  const timeStampPayload = { 'event.eventId': req.params._id, action: EventHistory.TIME_STAMPING_ACTIONS };
   if (req.payload.startDate) timeStampPayload['update.startHour'] = { $exists: true };
   else timeStampPayload['update.endHour'] = { $exists: true };
 

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -207,7 +207,8 @@ exports.authorizeTimeStamping = async (req) => {
   });
   if (!eventCount) throw Boom.notFound();
 
-  const timeStampPayload = { 'event.eventId': req.params._id, action: EventHistory.TIME_STAMPING_ACTIONS };
+  const timeStampPayload = { 'event.eventId': req.params._id, action: { $in: EventHistory.TIME_STAMPING_ACTIONS } };
+
   if (req.payload.startDate) timeStampPayload['update.startHour'] = { $exists: true };
   else timeStampPayload['update.endHour'] = { $exists: true };
 

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -22,6 +22,7 @@ const {
   INTERVENTION,
 } = require('../../helpers/constants');
 const DatesHelper = require('../../helpers/dates');
+const { TIME_STAMPING_ACTIONS } = require('../../models/EventHistory');
 
 const { language } = translate;
 
@@ -207,7 +208,7 @@ exports.authorizeTimeStamping = async (req) => {
   });
   if (!eventCount) throw Boom.notFound();
 
-  const timeStampPayload = { 'event.eventId': req.params._id, action: { $in: EventHistory.TIME_STAMPING_ACTIONS } };
+  const timeStampPayload = { 'event.eventId': req.params._id, action: { $in: TIME_STAMPING_ACTIONS } };
 
   if (req.payload.startDate) timeStampPayload['update.startHour'] = { $exists: true };
   else timeStampPayload['update.endHour'] = { $exists: true };

--- a/tests/unit/helpers/eventTimeStamping.test.js
+++ b/tests/unit/helpers/eventTimeStamping.test.js
@@ -6,6 +6,7 @@ const eventTimeStampingHelper = require('../../../src/helpers/eventTimeStamping'
 const eventHistoryHelper = require('../../../src/helpers/eventHistories');
 const eventValidationHelper = require('../../../src/helpers/eventsValidation');
 const Event = require('../../../src/models/Event');
+const { MANUAL_TIME_STAMPING } = require('../../../src/helpers/constants');
 
 describe('isStartDateTimeStampAllowed', () => {
   let hasConflictsStub;
@@ -124,7 +125,7 @@ describe('addTimeStamp', () => {
   it('should add startDate timestamp and updateEvent', async () => {
     const event = { _id: new ObjectID() };
     const startDate = new Date();
-    const payload = { action: 'manual_timestamping', reason: 'qrcode', startDate };
+    const payload = { action: MANUAL_TIME_STAMPING, reason: 'qrcode', startDate };
     const credentials = { _id: new ObjectID() };
 
     isStartDateTimeStampAllowedStub.returns(true);
@@ -140,7 +141,7 @@ describe('addTimeStamp', () => {
   it('should return a 409 if startDate timestamp is not allowed', async () => {
     const event = { _id: new ObjectID() };
     const startDate = new Date();
-    const payload = { action: 'manual_timestamping', reason: 'qrcode', startDate };
+    const payload = { action: MANUAL_TIME_STAMPING, reason: 'qrcode', startDate };
     const credentials = { _id: new ObjectID() };
 
     try {
@@ -160,7 +161,7 @@ describe('addTimeStamp', () => {
   it('should add endDate timestamp and updateEvent', async () => {
     const event = { _id: new ObjectID() };
     const endDate = new Date();
-    const payload = { action: 'manual_timestamping', reason: 'qrcode', endDate };
+    const payload = { action: MANUAL_TIME_STAMPING, reason: 'qrcode', endDate };
     const credentials = { _id: new ObjectID() };
 
     isEndDateTimeStampAllowedStub.returns(true);
@@ -176,7 +177,7 @@ describe('addTimeStamp', () => {
   it('should return a 409 if startDate timestamp is not allowed', async () => {
     const event = { _id: new ObjectID() };
     const endDate = new Date();
-    const payload = { action: 'manual_timestamping', reason: 'qrcode', endDate };
+    const payload = { action: MANUAL_TIME_STAMPING, reason: 'qrcode', endDate };
     const credentials = { _id: new ObjectID() };
 
     try {


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation : -np
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- refacto: remplacer MANUAL_TIME_STAMPING par TIME_STAMPING_ACTIONS dans le helper `authorizeTimeStamping` 
