### PR TITLE
add function to create userCompany with verification

### DIFF
--- a/src/helpers/userCompanies.js
+++ b/src/helpers/userCompanies.js
@@ -3,7 +3,7 @@ const UserCompany = require('../models/UserCompany');
 const UtilsHelper = require('./utils');
 
 exports.create = async (user, company) => {
-  const userCompany = await UserCompany.findOne({ user, company }).lean();
+  const userCompany = await UserCompany.findOne({ user }, { company: 1 }).lean();
 
   if (!userCompany) await UserCompany.create({ user, company });
   else if (!UtilsHelper.areObjectIdsEquals(userCompany.company, company)) throw Boom.conflict();

--- a/src/helpers/userCompanies.js
+++ b/src/helpers/userCompanies.js
@@ -1,0 +1,10 @@
+const Boom = require('@hapi/boom');
+const UserCompany = require('../models/UserCompany');
+const UtilsHelper = require('./utils');
+
+exports.create = async (user, company) => {
+  const userCompany = await UserCompany.findOne({ user, company }).lean();
+
+  if (!userCompany) await UserCompany.create({ user, company });
+  else if (!UtilsHelper.areObjectIdsEquals(userCompany.company, company)) throw Boom.conflict();
+};

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -9,7 +9,6 @@ const flat = require('flat');
 const { v4: uuidv4 } = require('uuid');
 const Role = require('../models/Role');
 const User = require('../models/User');
-const UserCompany = require('../models/UserCompany');
 const Company = require('../models/Company');
 const Contract = require('../models/Contract');
 const translate = require('./translate');
@@ -19,6 +18,7 @@ const SectorHistoriesHelper = require('./sectorHistories');
 const GDriveStorageHelper = require('./gDriveStorage');
 const UtilsHelper = require('./utils');
 const HelpersHelper = require('./helpers');
+const UserCompaniesHelper = require('./userCompanies');
 
 const { language } = translate;
 
@@ -169,7 +169,7 @@ exports.createAndSaveFile = async (params, payload) => {
 
 const createUserCompany = async (payload, company) => {
   const user = await User.create({ ...payload, company });
-  await UserCompany.create({ user: user._id, company });
+  await UserCompaniesHelper.create(user._id, company);
 
   return user;
 };
@@ -233,7 +233,7 @@ exports.updateUser = async (userId, userPayload, credentials, canEditWithoutComp
   const payload = await formatUpdatePayload(userPayload);
 
   if (userPayload.customer) await HelpersHelper.create(userId, userPayload.customer, companyId);
-  if (userPayload.company) await UserCompany.create({ user: userId, company: userPayload.company });
+  if (userPayload.company) await UserCompaniesHelper.create(userId, userPayload.company);
 
   if (userPayload.sector) {
     await SectorHistoriesHelper.updateHistoryOnSectorUpdate(userId, payload.sector, companyId);

--- a/tests/unit/helpers/userCompanies.test.js
+++ b/tests/unit/helpers/userCompanies.test.js
@@ -1,0 +1,72 @@
+const { ObjectID } = require('mongodb');
+const Boom = require('@hapi/boom');
+const expect = require('expect');
+const sinon = require('sinon');
+const UserCompany = require('../../../src/models/UserCompany');
+const UserCompaniesHelper = require('../../../src/helpers/userCompanies');
+const SinonMongoose = require('../sinonMongoose');
+
+describe('create #tag', () => {
+  let findOne;
+  let create;
+
+  beforeEach(() => {
+    create = sinon.stub(UserCompany, 'create');
+    findOne = sinon.stub(UserCompany, 'findOne');
+  });
+
+  afterEach(() => {
+    create.restore();
+    findOne.restore();
+  });
+
+  it('should create UserCompany', async () => {
+    const userId = new ObjectID();
+    const companyId = new ObjectID();
+
+    findOne.returns(SinonMongoose.stubChainedQueries([], ['lean']));
+
+    await UserCompaniesHelper.create(userId, companyId);
+
+    sinon.assert.calledOnceWithExactly(create, { user: userId, company: companyId });
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+    );
+  });
+
+  it('should do nothing if already userCompany for this user and this company', async () => {
+    const userId = new ObjectID();
+    const companyId = new ObjectID();
+
+    findOne.returns(SinonMongoose.stubChainedQueries([{ user: userId, company: companyId }], ['lean']));
+
+    await UserCompaniesHelper.create(userId, companyId);
+
+    sinon.assert.notCalled(create);
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+    );
+  });
+
+  it('should throw an error if already userCompany for this user and an other company', async () => {
+    const userId = new ObjectID();
+    const companyId = new ObjectID();
+
+    try {
+      findOne.returns(SinonMongoose.stubChainedQueries([{ user: userId, company: new ObjectID() }], ['lean']));
+
+      await UserCompaniesHelper.create(userId, companyId);
+
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toEqual(Boom.conflict());
+      sinon.assert.notCalled(create);
+      SinonMongoose.calledWithExactly(
+        findOne,
+        [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+      );
+    }
+  });
+});

--- a/tests/unit/helpers/userCompanies.test.js
+++ b/tests/unit/helpers/userCompanies.test.js
@@ -6,7 +6,7 @@ const UserCompany = require('../../../src/models/UserCompany');
 const UserCompaniesHelper = require('../../../src/helpers/userCompanies');
 const SinonMongoose = require('../sinonMongoose');
 
-describe('create #tag', () => {
+describe('create', () => {
   let findOne;
   let create;
 
@@ -31,7 +31,7 @@ describe('create #tag', () => {
     sinon.assert.calledOnceWithExactly(create, { user: userId, company: companyId });
     SinonMongoose.calledWithExactly(
       findOne,
-      [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
     );
   });
 
@@ -46,7 +46,7 @@ describe('create #tag', () => {
     sinon.assert.notCalled(create);
     SinonMongoose.calledWithExactly(
       findOne,
-      [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+      [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
     );
   });
 
@@ -65,7 +65,7 @@ describe('create #tag', () => {
       sinon.assert.notCalled(create);
       SinonMongoose.calledWithExactly(
         findOne,
-        [{ query: 'findOne', args: [{ user: userId, company: companyId }] }, { query: 'lean' }]
+        [{ query: 'findOne', args: [{ user: userId }, { company: 1 }] }, { query: 'lean' }]
       );
     }
   });

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -15,8 +15,8 @@ const translate = require('../../../src/helpers/translate');
 const GDriveStorageHelper = require('../../../src/helpers/gDriveStorage');
 const GCloudStorageHelper = require('../../../src/helpers/gCloudStorage');
 const HelpersHelper = require('../../../src/helpers/helpers');
+const UserCompaniesHelper = require('../../../src/helpers/userCompanies');
 const User = require('../../../src/models/User');
-const UserCompany = require('../../../src/models/UserCompany');
 const Contract = require('../../../src/models/Contract');
 const Role = require('../../../src/models/Role');
 const { HELPER, AUXILIARY_WITHOUT_COMPANY, WEBAPP } = require('../../../src/helpers/constants');
@@ -717,7 +717,7 @@ describe('createUser', () => {
     userFindOne = sinon.stub(User, 'findOne');
     roleFindById = sinon.stub(Role, 'findById');
     userCreate = sinon.stub(User, 'create');
-    userCompanyCreate = sinon.stub(UserCompany, 'create');
+    userCompanyCreate = sinon.stub(UserCompaniesHelper, 'create');
     userFindOneAndUpdate = sinon.stub(User, 'findOneAndUpdate');
     objectIdStub = sinon.stub(mongoose.Types, 'ObjectId').returns(userId);
     createHistoryStub = sinon.stub(SectorHistoriesHelper, 'createHistory');
@@ -783,7 +783,7 @@ describe('createUser', () => {
 
     expect(result).toEqual(newUser);
     sinon.assert.calledOnceWithExactly(createHistoryStub, { _id: userId, sector: payload.sector }, companyId);
-    sinon.assert.calledOnceWithExactly(userCompanyCreate, { user: userId, company: companyId });
+    sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, companyId);
     SinonMongoose.calledWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
@@ -832,7 +832,7 @@ describe('createUser', () => {
 
     expect(result).toEqual(newUser);
     sinon.assert.notCalled(createHistoryStub);
-    sinon.assert.calledOnceWithExactly(userCompanyCreate, { user: userId, company: companyId });
+    sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, companyId);
     SinonMongoose.calledWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
@@ -874,7 +874,7 @@ describe('createUser', () => {
     const result = await UsersHelper.createUser(payload, { company: { _id: credentialsCompanyId } });
 
     expect(result).toEqual(newUser);
-    sinon.assert.calledOnceWithExactly(userCompanyCreate, { user: userId, company: userCompanyId });
+    sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, userCompanyId);
     SinonMongoose.calledWithExactly(
       roleFindById,
       [{ query: 'findById', args: [payload.role, { name: 1, interface: 1 }] }, { query: 'lean' }]
@@ -944,7 +944,7 @@ describe('createUser', () => {
     sinon.assert.notCalled(createHistoryStub);
     sinon.assert.notCalled(roleFindById);
     sinon.assert.notCalled(userFindOne);
-    sinon.assert.calledOnceWithExactly(userCompanyCreate, { user: userId, company: userCompanyId });
+    sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, userCompanyId);
     sinon.assert.calledOnceWithExactly(userCreate, { ...payload, refreshToken: sinon.match.string });
   });
 
@@ -1022,7 +1022,7 @@ describe('updateUser', () => {
     roleFindById = sinon.stub(Role, 'findById');
     updateHistoryOnSectorUpdateStub = sinon.stub(SectorHistoriesHelper, 'updateHistoryOnSectorUpdate');
     createHelper = sinon.stub(HelpersHelper, 'create');
-    userCompanyCreate = sinon.stub(UserCompany, 'create');
+    userCompanyCreate = sinon.stub(UserCompaniesHelper, 'create');
   });
   afterEach(() => {
     userUpdateOne.restore();
@@ -1138,7 +1138,7 @@ describe('updateUser', () => {
       { _id: userId, company: credentials.company._id },
       { $set: flat(payload) }
     );
-    sinon.assert.calledOnceWithExactly(userCompanyCreate, { user: userId, company: payload.company });
+    sinon.assert.calledOnceWithExactly(userCompanyCreate, userId, payload.company);
     sinon.assert.notCalled(createHelper);
     sinon.assert.notCalled(roleFindById);
     sinon.assert.notCalled(updateHistoryOnSectorUpdateStub);


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- Si mes changements impactent l'application erp : -np
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme -np
- Je n'ai pas fait de breaking change : -np
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route : -np
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route : -np
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route : -np
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route : -np
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route : -np
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route : -np
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client/vendeur

- Périmetre roles : admin

- Cas d'usage : 
Dans les cas suivant, verifier que l'on cree bien un objet UserCompany :

Ajout d'un apprenant dans une structure (verifier sur le repertoire apprenant cote client + ajout de stagiaire intra (cote client et coté vendeur + ajout de stagiaire inter cote vendeur)

Ajout d'un coach (cote client et cote vendeur)

Ajout d'une auxiliaire

Ajout d'un aidant

Verifier egalement que si l'utilisateur a deja une entreprise, cela ne recree pas un UserCompany.
Verifier les cas de creation ainsi que de modification d'utilisateurs