### PR TITLE
Com 2094

### DIFF
--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -196,32 +196,34 @@ const handleCustomerStop = async (customerId, customerPayload, credentials) => {
             customerPayload.stoppedAt
           );
           break;
-        // case EVERY_WEEK_DAY:
-        //   await EventsRepetitionHelper.createRepetitionsEveryWeekDay(
-        //     repetition,
-        //     sectorId,
-        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        //     customerPayload.stoppedAt
-        //   );
-        //   break;
-        // case EVERY_WEEK:
-        //   await EventsRepetitionHelper.createRepetitionsByWeek(
-        //     repetition,
-        //     sectorId,
-        //     1,
-        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        //     customerPayload.stoppedAt
-        //   );
-        //   break;
-        // case EVERY_TWO_WEEKS:
-        //   await EventsRepetitionHelper.createRepetitionsByWeek(
-        //     repetition,
-        //     sectorId,
-        //     2,
-        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        //     customerPayload.stoppedAt
-        //   );
-        //   break;
+        case EVERY_WEEK_DAY:
+          await EventsRepetitionHelper.createRepetitionsEveryWeekDay(
+            repetition,
+            sectorId,
+            DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+            customerPayload.stoppedAt
+          );
+          break;
+        case EVERY_WEEK:
+          console.log('ici', repetition, sectorId,
+            DatesHelper.addDays(lastEventCreatedByRepetition, 1), customerPayload.stoppedAt);
+          await EventsRepetitionHelper.createRepetitionsByWeek(
+            repetition,
+            sectorId,
+            1,
+            DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+            customerPayload.stoppedAt
+          );
+          break;
+        case EVERY_TWO_WEEKS:
+          await EventsRepetitionHelper.createRepetitionsByWeek(
+            repetition,
+            sectorId,
+            2,
+            DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+            customerPayload.stoppedAt
+          );
+          break;
         default:
           break;
       }

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -196,22 +196,38 @@ const handleCustomerStop = async (customerId, customerPayload, credentials) => {
             customerPayload.stoppedAt
           );
           break;
-          // case EVERY_WEEK_DAY:
-          //   await EventsRepetitionHelper
-          //     .createRepetitionsEveryWeekDay(repetition, repetition.sector, customerPayload.stoppedAt);
-          //   break;
-          // case EVERY_WEEK:
-          //   await EventsRepetitionHelper
-          //     .createRepetitionsByWeek(repetition, repetition.sector, 1, customerPayload.stoppedAt);
-          //   break;
-          // case EVERY_TWO_WEEKS:
-          //   await EventsRepetitionHelper
-          //     .createRepetitionsByWeek(repetition, repetition.sector, 2, customerPayload.stoppedAt);
-          // break;
+        // case EVERY_WEEK_DAY:
+        //   await EventsRepetitionHelper.createRepetitionsEveryWeekDay(
+        //     repetition,
+        //     sectorId,
+        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+        //     customerPayload.stoppedAt
+        //   );
+        //   break;
+        // case EVERY_WEEK:
+        //   await EventsRepetitionHelper.createRepetitionsByWeek(
+        //     repetition,
+        //     sectorId,
+        //     1,
+        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+        //     customerPayload.stoppedAt
+        //   );
+        //   break;
+        // case EVERY_TWO_WEEKS:
+        //   await EventsRepetitionHelper.createRepetitionsByWeek(
+        //     repetition,
+        //     sectorId,
+        //     2,
+        //     DatesHelper.addDays(lastEventCreatedByRepetition, 1),
+        //     customerPayload.stoppedAt
+        //   );
+        //   break;
         default:
           break;
       }
     }
+
+    await Repetition.deleteOne({ _id: repetition._id });
   }
 };
 

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -18,7 +18,7 @@ const Rum = require('../models/Rum');
 const User = require('../models/User');
 const EventRepository = require('../repositories/EventRepository');
 const CustomerRepository = require('../repositories/CustomerRepository');
-const { INTERVENTION, EVERY_DAY, EVERY_WEEK_DAY, EVERY_WEEK, EVERY_TWO_WEEKS } = require('./constants');
+const { INTERVENTION, EVERY_DAY } = require('./constants');
 const GDriveStorageHelper = require('./gDriveStorage');
 const SubscriptionsHelper = require('./subscriptions');
 const ReferentHistoriesHelper = require('./referentHistories');
@@ -185,32 +185,6 @@ const createEventsOnCustomerStop = async (repetition, stoppedAt, company) => {
       await EventsRepetitionHelper.createRepetitionsEveryDay(
         repetition,
         sectorId,
-        DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        stoppedAt
-      );
-      break;
-    case EVERY_WEEK_DAY:
-      await EventsRepetitionHelper.createRepetitionsEveryWeekDay(
-        repetition,
-        sectorId,
-        DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        stoppedAt
-      );
-      break;
-    case EVERY_WEEK:
-      await EventsRepetitionHelper.createRepetitionsByWeek(
-        repetition,
-        sectorId,
-        1,
-        DatesHelper.addDays(lastEventCreatedByRepetition, 1),
-        stoppedAt
-      );
-      break;
-    case EVERY_TWO_WEEKS:
-      await EventsRepetitionHelper.createRepetitionsByWeek(
-        repetition,
-        sectorId,
-        2,
         DatesHelper.addDays(lastEventCreatedByRepetition, 1),
         stoppedAt
       );

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -169,8 +169,8 @@ const handleCustomerStop = async (customerId, stoppedAt, credentials) => {
 
   await EventsHelper.deleteList(customerId, stoppedAt, null, credentials);
 
-  const customerRepetitions = await Repetition.find({ customer: customerId, company: company._id }).lean();
-  for (const repetition of customerRepetitions) {
+  const remainingRepetitions = await Repetition.find({ customer: customerId, company: company._id }).lean();
+  for (const repetition of remainingRepetitions) {
     await EventsHelper.createEventsOnCustomerStop(repetition, stoppedAt, company);
 
     await Repetition.deleteOne({ _id: repetition._id });

--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -159,6 +159,7 @@ const formatPayload = async (customerId, customerPayload, company) => {
 };
 
 const handleCustomerStop = async (customerId, customerPayload, credentials) => {
+  const { company } = credentials;
   const timeStampedEventsCount = await EventHistory.countDocuments({
     'event.customer': customerId,
     startDate: { $gte: customerPayload.stoppedAt },
@@ -167,6 +168,9 @@ const handleCustomerStop = async (customerId, customerPayload, credentials) => {
   if (timeStampedEventsCount > 0) throw Boom.conflict();
 
   await EventHelper.deleteList(customerId, customerPayload.stoppedAt, null, credentials);
+
+  const customerRepetitions = await Repetition.find({ customer: customerId, company: company._id }).lean();
+  console.log('ici', customerRepetitions);
 };
 
 exports.updateCustomer = async (customerId, customerPayload, credentials) => {

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -12,6 +12,12 @@ exports.getStartOfDay = date => (new Date(date)).setHours(0, 0, 0, 0);
 
 exports.getEndOfDay = date => (new Date(date)).setHours(23, 59, 59, 999);
 
+exports.dayDiff = (date1, date2) => {
+  const milliSecondsDiff = this.getStartOfDay(date1) - this.getStartOfDay(date2);
+
+  return milliSecondsDiff / 1000 / 60 / 60 / 24;
+};
+
 exports.addDays = (date, days) => {
   const myDate = new Date(date);
 

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -13,15 +13,25 @@ exports.getStartOfDay = date => (new Date(date)).setHours(0, 0, 0, 0);
 exports.getEndOfDay = date => (new Date(date)).setHours(23, 59, 59, 999);
 
 exports.dayDiff = (date1, date2) => {
+  const milliSecondsDiff = new Date(date1) - new Date(date2);
+
+  const diff = milliSecondsDiff > 0
+    ? Math.floor(milliSecondsDiff / 1000 / 60 / 60 / 24)
+    : Math.ceil(milliSecondsDiff / 1000 / 60 / 60 / 24);
+
+  return Object.is(diff, -0) ? -diff : diff;
+};
+
+exports.dayDiffRegardlessOfHour = (date1, date2) => {
   const milliSecondsDiff = this.getStartOfDay(date1) - this.getStartOfDay(date2);
 
   return milliSecondsDiff / 1000 / 60 / 60 / 24;
 };
 
 exports.addDays = (date, days) => {
-  const myDate = new Date(date);
+  const newDate = new Date(date);
 
-  return new Date(myDate.setDate(myDate.getDate() + days));
+  return new Date(newDate.setDate(newDate.getDate() + days));
 };
 
 const DATE_FORMATS = {

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -19,7 +19,7 @@ exports.dayDiff = (date1, date2) => {
     ? Math.floor(milliSecondsDiff / 1000 / 60 / 60 / 24)
     : Math.ceil(milliSecondsDiff / 1000 / 60 / 60 / 24);
 
-  return Object.is(diff, -0) ? -diff : diff;
+  return diff || 0;
 };
 
 exports.dayDiffRegardlessOfHour = (date1, date2) => {

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -12,6 +12,12 @@ exports.getStartOfDay = date => (new Date(date)).setHours(0, 0, 0, 0);
 
 exports.getEndOfDay = date => (new Date(date)).setHours(23, 59, 59, 999);
 
+exports.addDays = (date, days) => {
+  const myDate = new Date(date);
+
+  return new Date(myDate.setDate(myDate.getDate() + days));
+};
+
 const DATE_FORMATS = {
   D: { day: 'numeric' },
   DD: { day: '2-digit' },

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -29,7 +29,6 @@ const Event = require('../models/Event');
 const Repetition = require('../models/Repetition');
 const User = require('../models/User');
 const DistanceMatrix = require('../models/DistanceMatrix');
-const EventHistory = require('../models/EventHistory');
 const EventRepository = require('../repositories/EventRepository');
 const { AUXILIARY, CUSTOMER } = require('./constants');
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -41,9 +41,9 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
   return new Event(payload);
 };
 
-exports.createRepetitionsEveryDay = async (payload, sector) => {
+exports.createRepetitionsEveryDay = async (payload, sector, endDate = null) => {
   const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = endDate || moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 
@@ -55,9 +55,9 @@ exports.createRepetitionsEveryDay = async (payload, sector) => {
   await Event.insertMany(repeatedEvents);
 };
 
-exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
+exports.createRepetitionsEveryWeekDay = async (payload, sector, endDate = null) => {
   const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = endDate || moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 
@@ -72,9 +72,9 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
   await Event.insertMany(repeatedEvents);
 };
 
-exports.createRepetitionsByWeek = async (payload, sector, step) => {
+exports.createRepetitionsByWeek = async (payload, sector, step, endDate = null) => {
   const start = moment(payload.startDate).add(step, 'w');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = endDate || moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('weeks', { step }));
   const repeatedEvents = [];
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -27,7 +27,7 @@ const DatesHelper = require('./dates');
 momentRange.extendMoment(moment);
 
 exports.formatRepeatedPayload = async (event, sector, momentDay) => {
-  const step = DatesHelper.dayDiff(momentDay, event.startDate);
+  const step = DatesHelper.dayDiffRegardlessOfHour(momentDay, event.startDate);
   let payload = {
     ...cloneDeep(omit(event, '_id')), // cloneDeep necessary to copy repetition
     startDate: moment(event.startDate).add(step, 'd'),

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -22,11 +22,12 @@ const EventHistoriesHelper = require('./eventHistories');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
+const DatesHelper = require('./dates');
 
 momentRange.extendMoment(moment);
 
 exports.formatRepeatedPayload = async (event, sector, momentDay) => {
-  const step = moment(momentDay).endOf('day').diff(event.startDate, 'd');
+  const step = DatesHelper.dayDiff(momentDay, event.startDate);
   let payload = {
     ...cloneDeep(omit(event, '_id')), // cloneDeep necessary to copy repetition
     startDate: moment(event.startDate).add(step, 'd'),

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -56,9 +56,9 @@ exports.createRepetitionsEveryDay = async (payload, sector, startDate = null, en
   await Event.insertMany(repeatedEvents);
 };
 
-exports.createRepetitionsEveryWeekDay = async (payload, sector, endDate = null) => {
+exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
   const start = moment(payload.startDate).add(1, 'd');
-  const end = endDate || moment(payload.startDate).add(90, 'd');
+  const end = moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 
@@ -73,9 +73,9 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector, endDate = null) 
   await Event.insertMany(repeatedEvents);
 };
 
-exports.createRepetitionsByWeek = async (payload, sector, step, endDate = null) => {
+exports.createRepetitionsByWeek = async (payload, sector, step) => {
   const start = moment(payload.startDate).add(step, 'w');
-  const end = endDate || moment(payload.startDate).add(90, 'd');
+  const end = moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('weeks', { step }));
   const repeatedEvents = [];
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -26,7 +26,7 @@ const EventsValidationHelper = require('./eventsValidation');
 momentRange.extendMoment(moment);
 
 exports.formatRepeatedPayload = async (event, sector, momentDay) => {
-  const step = momentDay.diff(event.startDate, 'd');
+  const step = moment(momentDay).endOf('day').diff(event.startDate, 'd');
   let payload = {
     ...cloneDeep(omit(event, '_id')), // cloneDeep necessary to copy repetition
     startDate: moment(event.startDate).add(step, 'd'),
@@ -41,8 +41,8 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
   return new Event(payload);
 };
 
-exports.createRepetitionsEveryDay = async (payload, sector, endDate = null) => {
-  const start = moment(payload.startDate).add(1, 'd');
+exports.createRepetitionsEveryDay = async (payload, sector, startDate = null, endDate = null) => {
+  const start = startDate || moment(payload.startDate).add(1, 'd');
   const end = endDate || moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -541,7 +541,6 @@ describe('updateCustomer', () => {
   let createRepetitionsEveryDay;
   let nowStub;
   let deleteOneRepetition;
-  let createRepetitionsByWeek;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
   beforeEach(() => {
     findOneCustomer = sinon.stub(Customer, 'findOne');
@@ -556,7 +555,6 @@ describe('updateCustomer', () => {
     createRepetitionsEveryDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryDay');
     nowStub = sinon.stub(Date, 'now');
     deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
-    createRepetitionsByWeek = sinon.stub(EventsRepetitionHelper, 'createRepetitionsByWeek');
   });
   afterEach(() => {
     findOneCustomer.restore();
@@ -571,7 +569,6 @@ describe('updateCustomer', () => {
     createRepetitionsEveryDay.restore();
     nowStub.restore();
     deleteOneRepetition.restore();
-    createRepetitionsByWeek.restore();
   });
 
   it('should unset the referent of a customer', async () => {
@@ -840,7 +837,7 @@ describe('updateCustomer', () => {
         _id: new ObjectID(),
         type: 'intervention',
         customer: customerId,
-        frequency: 'every_week',
+        frequency: 'every_day',
         parentId: new ObjectID(),
         startDate: '2021-12-25T09:00:00',
         endDate: '2021-12-25T10:00:00',
@@ -872,18 +869,17 @@ describe('updateCustomer', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    sinon.assert.calledOnceWithExactly(
-      createRepetitionsEveryDay,
+    sinon.assert.calledWithExactly(
+      createRepetitionsEveryDay.getCall(0),
       repetitions[0],
       auxiliary.sector,
       new Date('2021-09-24T16:34:04.144Z'),
       '2022-06-25T16:34:04.144Z'
     );
-    sinon.assert.calledOnceWithExactly(
-      createRepetitionsByWeek,
+    sinon.assert.calledWithExactly(
+      createRepetitionsEveryDay.getCall(1),
       repetitions[1],
       repetitions[1].sector,
-      1,
       new Date('2022-03-26T08:00:00.000Z'),
       '2022-06-25T16:34:04.144Z'
     );

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -541,6 +541,7 @@ describe('updateCustomer', () => {
   let createRepetitionsEveryDay;
   let nowStub;
   let deleteOneRepetition;
+  let createRepetitionsByWeek;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
   beforeEach(() => {
     findOneCustomer = sinon.stub(Customer, 'findOne');
@@ -555,6 +556,7 @@ describe('updateCustomer', () => {
     createRepetitionsEveryDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryDay');
     nowStub = sinon.stub(Date, 'now');
     deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
+    createRepetitionsByWeek = sinon.stub(EventsRepetitionHelper, 'createRepetitionsByWeek');
   });
   afterEach(() => {
     findOneCustomer.restore();
@@ -569,6 +571,7 @@ describe('updateCustomer', () => {
     createRepetitionsEveryDay.restore();
     nowStub.restore();
     deleteOneRepetition.restore();
+    createRepetitionsByWeek.restore();
   });
 
   it('should unset the referent of a customer', async () => {
@@ -824,6 +827,7 @@ describe('updateCustomer', () => {
     const customerId = new ObjectID();
     const repetitions = [
       {
+        _id: new ObjectID(),
         type: 'intervention',
         customer: customerId,
         frequency: 'every_day',
@@ -831,6 +835,16 @@ describe('updateCustomer', () => {
         startDate: '2019-12-01T09:00:00',
         endDate: '2019-12-01T10:00:00',
         auxiliary: auxiliaryId,
+      },
+      {
+        _id: new ObjectID(),
+        type: 'intervention',
+        customer: customerId,
+        frequency: 'every_week',
+        parentId: new ObjectID(),
+        startDate: '2021-12-25T09:00:00',
+        endDate: '2021-12-25T10:00:00',
+        sector: new ObjectID(),
       },
     ];
     const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
@@ -865,7 +879,16 @@ describe('updateCustomer', () => {
       new Date('2021-09-24T16:34:04.144Z'),
       '2022-06-25T16:34:04.144Z'
     );
-    sinon.assert.calledOnceWithExactly(deleteOneRepetition, { _id: repetitions[0]._id });
+    sinon.assert.calledOnceWithExactly(
+      createRepetitionsByWeek,
+      repetitions[1],
+      repetitions[1].sector,
+      1,
+      new Date('2022-03-26T08:00:00.000Z'),
+      '2022-06-25T16:34:04.144Z'
+    );
+    sinon.assert.calledWithExactly(deleteOneRepetition.getCall(0), { _id: repetitions[0]._id });
+    sinon.assert.calledWithExactly(deleteOneRepetition.getCall(1), { _id: repetitions[1]._id });
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -786,8 +786,8 @@ describe('updateCustomer', () => {
       customer: customerId,
       frequency: 'every_day',
       parentId: new ObjectID(),
-      startDate: '2021-07-01T09:00:00',
-      endDate: '2021-07-01T10:00:00',
+      startDate: '2021-07-01T09:00:00Z',
+      endDate: '2021-07-01T10:00:00Z',
     }];
     const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
     const payload = { stoppedAt: '2019-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
@@ -829,8 +829,8 @@ describe('updateCustomer', () => {
         customer: customerId,
         frequency: 'every_day',
         parentId: new ObjectID(),
-        startDate: '2019-12-01T09:00:00',
-        endDate: '2019-12-01T10:00:00',
+        startDate: '2019-12-01T09:00:00Z',
+        endDate: '2019-12-01T10:00:00Z',
         auxiliary: auxiliaryId,
       },
       {
@@ -839,8 +839,8 @@ describe('updateCustomer', () => {
         customer: customerId,
         frequency: 'every_day',
         parentId: new ObjectID(),
-        startDate: '2021-12-25T09:00:00',
-        endDate: '2021-12-25T10:00:00',
+        startDate: '2021-12-25T09:00:00Z',
+        endDate: '2021-12-25T10:00:00Z',
         sector: new ObjectID(),
       },
     ];
@@ -880,7 +880,7 @@ describe('updateCustomer', () => {
       createRepetitionsEveryDay.getCall(1),
       repetitions[1],
       repetitions[1].sector,
-      new Date('2022-03-26T08:00:00.000Z'),
+      new Date('2022-03-26T09:00:00.000Z'),
       '2022-06-25T16:34:04.144Z'
     );
     sinon.assert.calledWithExactly(deleteOneRepetition.getCall(0), { _id: repetitions[0]._id });

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -540,6 +540,7 @@ describe('updateCustomer', () => {
   let findOneUser;
   let createRepetitionsEveryDay;
   let nowStub;
+  let deleteOneRepetition;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
   beforeEach(() => {
     findOneCustomer = sinon.stub(Customer, 'findOne');
@@ -553,6 +554,7 @@ describe('updateCustomer', () => {
     findOneUser = sinon.stub(User, 'findOne');
     createRepetitionsEveryDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryDay');
     nowStub = sinon.stub(Date, 'now');
+    deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
   });
   afterEach(() => {
     findOneCustomer.restore();
@@ -566,6 +568,7 @@ describe('updateCustomer', () => {
     findOneUser.restore();
     createRepetitionsEveryDay.restore();
     nowStub.restore();
+    deleteOneRepetition.restore();
   });
 
   it('should unset the referent of a customer', async () => {
@@ -799,6 +802,7 @@ describe('updateCustomer', () => {
     expect(result).toBe(customerResult);
     sinon.assert.calledOnceWithExactly(deleteListEvent, customerId, '2019-06-25T16:34:04.144Z', null, credentials);
     sinon.assert.notCalled(findOneUser);
+    sinon.assert.calledOnceWithExactly(deleteOneRepetition, { _id: repetitions[0]._id });
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -815,7 +819,7 @@ describe('updateCustomer', () => {
   });
 
   it('should deleted customer\'s events + repetition and create events when customer is stopped'
-    + 'and last event created by repetition is before stopping date #tag', async () => {
+    + 'and last event created by repetition is before stopping date', async () => {
     const auxiliaryId = new ObjectID();
     const customerId = new ObjectID();
     const repetitions = [
@@ -861,6 +865,7 @@ describe('updateCustomer', () => {
       new Date('2021-09-24T16:34:04.144Z'),
       '2022-06-25T16:34:04.144Z'
     );
+    sinon.assert.calledOnceWithExactly(deleteOneRepetition, { _id: repetitions[0]._id });
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -81,12 +81,12 @@ describe('isSameOrAfter', () => {
   });
 });
 
-describe('dayDiff', () => {
+describe('dayDiffRegardlessOfHour', () => {
   it('should return number of days between two dates regardless of hours', () => {
     const date1 = '2021-01-05T10:04:34';
     const date2 = '2021-01-01T09:15:24';
 
-    const result = DatesHelper.dayDiff(date1, date2);
+    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
 
     expect(result).toBe(4);
   });
@@ -95,9 +95,65 @@ describe('dayDiff', () => {
     const date1 = '2021-01-05T10:04:34';
     const date2 = '2021-01-04T11:04:54';
 
-    const result = DatesHelper.dayDiff(date1, date2);
+    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
 
     expect(result).toBe(1);
+  });
+
+  it('should return number of days between two dates regardless of hours', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-05T11:04:54';
+
+    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
+
+    expect(result).toBe(0);
+  });
+
+  it('should return number of days between two dates regardless of hours', () => {
+    const date1 = '2021-01-04T10:04:34';
+    const date2 = '2021-01-05T11:04:54';
+
+    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
+
+    expect(result).toBe(-1);
+  });
+});
+
+describe('dayDiff', () => {
+  it('should return number of days between two dates', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-01T09:15:24';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(4);
+  });
+
+  it('should return number of days between two dates', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-04T11:04:54';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(0);
+  });
+
+  it('should return number of days between two dates', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-05T11:04:54';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(0);
+  });
+
+  it('should return number of days between two dates', () => {
+    const date1 = '2021-01-04T10:04:34';
+    const date2 = '2021-01-05T11:04:54';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(-1);
   });
 });
 

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -81,6 +81,15 @@ describe('isSameOrAfter', () => {
   });
 });
 
+describe('addDays #tag', () => {
+  it('should add days to date', () => {
+    const newDate = DatesHelper.addDays('2020-12-25', 9);
+    const resultDate = new Date('2021-01-03');
+
+    expect(newDate.toString()).toBe(resultDate.toString());
+  });
+});
+
 describe('format', () => {
   it('should null if no date', () => {
     const formattedDate = DatesHelper.format();

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -81,7 +81,7 @@ describe('isSameOrAfter', () => {
   });
 });
 
-describe('addDays #tag', () => {
+describe('addDays', () => {
   it('should add days to date', () => {
     const newDate = DatesHelper.addDays('2020-12-25', 9);
     const resultDate = new Date('2021-01-03');

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -81,6 +81,26 @@ describe('isSameOrAfter', () => {
   });
 });
 
+describe('dayDiff', () => {
+  it('should return number of days between two dates regardless of hours', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-01T09:15:24';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(4);
+  });
+
+  it('should return number of days between two dates regardless of hours', () => {
+    const date1 = '2021-01-05T10:04:34';
+    const date2 = '2021-01-04T11:04:54';
+
+    const result = DatesHelper.dayDiff(date1, date2);
+
+    expect(result).toBe(1);
+  });
+});
+
 describe('addDays', () => {
   it('should add days to date', () => {
     const newDate = DatesHelper.addDays('2020-12-25', 9);

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1574,7 +1574,7 @@ describe('deleteEvents', () => {
       await EventHelper.deleteEvents(events, credentials);
       sinon.assert.notCalled(deleteMany);
     } catch (e) {
-      expect(e).toEqual(Boom.forbidden('Some events are already billed'));
+      expect(e).toEqual(Boom.forbidden());
     }
   });
 });

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1574,7 +1574,7 @@ describe('deleteEvents', () => {
       await EventHelper.deleteEvents(events, credentials);
       sinon.assert.notCalled(deleteMany);
     } catch (e) {
-      expect(e).toEqual(Boom.forbidden());
+      expect(e).toEqual(Boom.conflict());
     }
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests -np
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- ~~[ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme~~
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin / coach / auxiliaire

- Cas d'usage : 
Pour l'instant, seule la suppression des événements après la date d'arrêt + la suppression de la répétition + la création d'événements pour une répétition quotidienne est faite.
La création d'événements pour une répétition tous les jours de la semaine, toutes les semaines et toutes les 2 semaines seront faite dans une prochaine PR

COMMENT TESTER :
- En front, rendez visible le bouton 'Arrêter' sur CustomerProfileHeader
- Ajoutez un bénéficiaire + souscription et ajoutez lui : 
  - une répétition chaque jour qui commence après la date d'aujourd'hui
  - un événement après la date d'arrêt
  - une répétition après la date d'arrêt
- Arrêtez le et vérifiez : 
  - que tous les événements et la répétition après la date d'arrêt sont supprimés
  - que les événements sont bien créés entre le dernier événement créé par votre répétition (qui commence avant la date d'arrêt) et la date d'arrêt.
- Arrêtez un bénéficiaire déjà existant qui a des répétitions journalières (NOUVION par exemple).
  - Vérifiez que les événements sont bien créés
  