### PR TITLE
Com 2123-  MAJ du referent d'un bénéficiaire

### DIFF
--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -4,7 +4,7 @@ const translate = require('../../helpers/translate');
 const UtilsHelper = require('../../helpers/utils');
 const { INTERVENTION } = require('../../helpers/constants');
 const Customer = require('../../models/Customer');
-const User = require('../../models/User');
+const UserCompany = require('../../models/UserCompany');
 const Event = require('../../models/Event');
 const Sector = require('../../models/Sector');
 const Service = require('../../models/Service');
@@ -38,7 +38,7 @@ exports.authorizeCustomerUpdate = async (req) => {
 
   if (req.payload) {
     if (req.payload.referent) {
-      const referent = await User.countDocuments({ _id: req.payload.referent, company: companyId });
+      const referent = await UserCompany.countDocuments({ user: req.payload.referent, company: companyId });
       if (!referent) return Boom.forbidden();
     }
 

--- a/src/routes/preHandlers/customers.js
+++ b/src/routes/preHandlers/customers.js
@@ -29,7 +29,7 @@ exports.validateCustomerCompany = async (params, payload, companyId) => {
   const customer = await Customer.findOne(query).lean();
   if (!customer) throw Boom.notFound(translate[language].customerNotFound);
 
-  if (customer.company.toHexString() !== companyId.toHexString()) throw Boom.forbidden();
+  if (!UtilsHelper.areObjectIdsEquals(customer.company, companyId)) throw Boom.forbidden();
 };
 
 exports.authorizeCustomerUpdate = async (req) => {


### PR DESCRIPTION
### POUR TESTER LA PR
 MAJ du referent d'un bénéficiaire

- Cas d'usage : lorsque je suis sur la fiche d'un bénéficiaire je peux mettre a jour l'auxiliaire référent
- Pour tester: 
Dans le service: `/src/helpers/authorization` : 
	-  importer `const UserCompany = require('../models/UserCompany’);`
	- dans `validate`:  
		- commenter: `.populate({ path: 'company' })`
		- ajouter: `const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();`
		- transformer tous les `user.company` en `userCompany.company`

**Test pour verifier que le prehandler fonctionne toujours avec un utilisateur de la meme structure:**
-  commenter le champs `Company` de la collection `Users`
-  sur la fiche bénéficiaire, modifier l'auxiliaire référent

**Test pour vérifier que l’on a bien une 403 avec un utilisateur d’une autre structure:**
- commenter le champs `Company` de la collection `Users`
- creer une structure test avec l’abonnement ERP
- ajouter un utilisateur 
- sur postman: 	
    - envoyer la requête `Post {{API_LINK}}/users/authenticate` pour se connecter avec l’utilisateur créé précédemment (email + mdp de l'utilisateur créé)
   - envoyer la requête `Put {{API_LINK}}/customers/` avec l’id d’un bénéficiaire et ajouter en query: `référent` et en value l’id de l’auxiliaire référent que l’on veut ajouter au bénéficiaire 
