### PR TITLE
COM-2138

### DIFF
--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -68,9 +68,8 @@ const update = async (req) => {
 
 const remove = async (req) => {
   try {
-    const { auth, pre } = req;
-    const event = await EventsHelper.deleteEvent(pre.event, auth.credentials);
-    if (!event) return Boom.notFound(translate[language].eventNotFound);
+    const { auth, params } = req;
+    await EventsHelper.deleteEvent(params._id, auth.credentials);
 
     return { message: translate[language].eventDeleted };
   } catch (e) {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -385,7 +385,7 @@ exports.updateAbsencesOnContractEnd = async (auxiliaryId, contractEndDate, crede
 exports.deleteEvent = async (eventId, credentials) => {
   const companyId = get(credentials, 'company._id', null);
 
-  await exports.deleteEventsAndRepetition({ _id: eventId, company: companyId }, true, credentials);
+  await exports.deleteEventsAndRepetition({ _id: eventId, company: companyId }, false, credentials);
 };
 
 exports.createEventHistoryOnDeleteList = async (events, credentials) => {

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -30,7 +30,6 @@ const DistanceMatrixHelper = require('./distanceMatrix');
 const DraftPayHelper = require('./draftPay');
 const ContractHelper = require('./contracts');
 const Event = require('../models/Event');
-const EventHistory = require('../models/EventHistory');
 const Repetition = require('../models/Repetition');
 const User = require('../models/User');
 const DistanceMatrix = require('../models/DistanceMatrix');
@@ -383,13 +382,10 @@ exports.updateAbsencesOnContractEnd = async (auxiliaryId, contractEndDate, crede
   return Promise.all(promises);
 };
 
-exports.deleteEvent = async (event, credentials) => {
-  if (!EventsValidationHelper.isDeletionAllowed(event)) throw Boom.conflict(translate[language].isBilledOrTimeStamped);
-  const deletionInfo = omit(event, 'repetition');
-  await EventHistoriesHelper.createEventHistoryOnDelete(deletionInfo, credentials);
-  await Event.deleteOne({ _id: event._id });
+exports.deleteEvent = async (eventId, credentials) => {
+  const companyId = get(credentials, 'company._id', null);
 
-  return event;
+  await exports.deleteEventsAndRepetition({ _id: eventId, company: companyId }, true, credentials);
 };
 
 exports.createEventHistoryOnDeleteList = async (events, credentials) => {
@@ -403,15 +399,8 @@ exports.createEventHistoryOnDeleteList = async (events, credentials) => {
 
 exports.deleteEventsAndRepetition = async (query, shouldDeleteRepetitions, credentials) => {
   const events = await Event.find(query).lean();
-  if (events.some(event => !EventsValidationHelper.isDeletionAllowed(event))) {
-    throw Boom.conflict(translate[language].isBilled);
-  }
-  const timestampedEventsCount = await EventHistory.countDocuments({
-    'event.eventId': { $in: events.map(event => event._id) },
-    'event.type': INTERVENTION,
-    action: { $in: EventHistory.TIME_STAMPING_ACTIONS },
-  });
-  if (timestampedEventsCount > 0) throw Boom.conflict(translate[language].isTimeStamped);
+
+  await EventsValidationHelper.checkDeletionIsAllowed(events);
 
   if (!shouldDeleteRepetitions) {
     await this.createEventHistoryOnDeleteList(events, credentials);

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -145,9 +145,8 @@ module.exports = {
     timeStampOtherConflict: 'Timestamp error. Contact technical support.',
     timeStampTooLate: 'Can\'t timestamp startDate after event ends.',
     timeStampTooEarly: 'Can\'t timestamp endDate before event starts.',
-    isBilledOrTimeStamped: 'At least one event is billed or timestamped.',
-    isBilled: 'At least one event is billed.',
-    isTimeStamped: 'At least one event is timestamped.',
+    isBilled: 'You can not delete a billed event.',
+    isTimeStamped: 'You can not delete a timestamped event.',
     timeStampCancelledEvent: 'Can\'t timestamp a cancelled event.',
     /* Sectors */
     sectorCreated: 'Sector created.',
@@ -472,9 +471,8 @@ module.exports = {
     timeStampOtherConflict: 'Problème lors de l\'horodatage. Contactez le support technique.',
     timeStampTooLate: 'Vous ne pouvez pas horodater le début d\'un évènement terminé.',
     timeStampTooEarly: 'Vous ne pouvez pas horodater la fin d\'un évènement avant son commencement.',
-    isBilledOrTimeStamped: 'Un ou plusieurs évènements sont facturés ou horodatés.',
-    isBilled: 'Un ou plusieurs évènements sont facturés.',
-    isTimeStamped: 'Un ou plusieurs évènements sont horodatés.',
+    isBilled: 'Vous ne pouvez pas supprimer un évènement facturé.',
+    isTimeStamped: 'Vous ne pouvez pas supprimer un évènement horodaté.',
     timeStampCancelledEvent: 'Vous ne pouvez pas horodater un évènement annulé.',
     /* Sectors */
     sectorCreated: 'Équipe créée.',

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -232,10 +232,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
-        pre: [
-          { method: getEvent, assign: 'event' },
-          { method: authorizeEventDeletion },
-        ],
+        pre: [{ method: authorizeEventDeletion }],
       },
       handler: remove,
     });

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -28,19 +28,14 @@ const DatesHelper = require('../../helpers/dates');
 const { language } = translate;
 
 exports.getEvent = async (req) => {
-  try {
-    const event = await Event.findById(req.params._id)
-      .populate('startDateTimeStampedCount')
-      .populate('endDateTimeStampedCount')
-      .lean();
+  const event = await Event.findById(req.params._id)
+    .populate('startDateTimeStampedCount')
+    .populate('endDateTimeStampedCount')
+    .lean();
 
-    if (!event) throw Boom.notFound(translate[language].eventNotFound);
+  if (!event) throw Boom.notFound(translate[language].eventNotFound);
 
-    return event;
-  } catch (e) {
-    req.log('error', e);
-    return Boom.isBoom(e) ? e : Boom.badImplementation(e);
-  }
+  return event;
 };
 
 exports.authorizeEventGet = async (req) => {
@@ -98,7 +93,7 @@ const checkAuxiliaryPermission = (credentials, event) => {
 
 exports.authorizeEventDeletion = async (req) => {
   const { credentials } = req.auth;
-  const { event } = req.pre;
+  const event = await exports.getEvent(req);
 
   const isAuxiliary = get(credentials, 'role.client.name') === AUXILIARY;
   if (isAuxiliary) {

--- a/tests/unit/helpers/eventsValidation.test.js
+++ b/tests/unit/helpers/eventsValidation.test.js
@@ -908,6 +908,7 @@ describe('checkDeletionIsAllowed', () => {
   afterEach(() => {
     eventHistoryCountDocuments.restore();
   });
+
   it('should return nothing if events are not interventions', async () => {
     const events = [{ _id: new ObjectID(), type: INTERNAL_HOUR, isBilled: true }];
 
@@ -947,8 +948,10 @@ describe('checkDeletionIsAllowed', () => {
     ];
     try {
       await EventsValidationHelper.checkDeletionIsAllowed(events);
+
+      expect(false).toBe(true);
     } catch (e) {
-      expect(e).toEqual(Boom.conflict('Vous ne pouvez pas supprimer un événement facturé.'));
+      expect(e).toEqual(Boom.conflict('Vous ne pouvez pas supprimer un évènement facturé.'));
     } finally {
       sinon.assert.notCalled(eventHistoryCountDocuments);
     }
@@ -964,8 +967,10 @@ describe('checkDeletionIsAllowed', () => {
 
     try {
       await EventsValidationHelper.checkDeletionIsAllowed(events);
+
+      expect(false).toBe(true);
     } catch (e) {
-      expect(e).toEqual(Boom.conflict('Vous ne pouvez pas supprimer un événement horodaté.'));
+      expect(e).toEqual(Boom.conflict('Vous ne pouvez pas supprimer un évènement horodaté.'));
     } finally {
       sinon.assert.calledOnceWithExactly(
         eventHistoryCountDocuments, {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin/coach/auxiliaire
TEST
- Cas d'usage : 
 - créer un événement, l'horodaté, essayer de le supprimer
  - essayer de supprimer un événement facturé
  - essayer de supprimer des événements en masse dont l'un est horodaté