### PR TITLE
Com 2125 - userCompany refacto

### DIFF
--- a/src/routes/preHandlers/contracts.js
+++ b/src/routes/preHandlers/contracts.js
@@ -2,8 +2,10 @@ const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const Contract = require('../../models/Contract');
 const User = require('../../models/User');
+const UserCompany = require('../../models/UserCompany');
 const Customer = require('../../models/Customer');
 const translate = require('../../helpers/translate');
+const UtilsHelper = require('../../helpers/utils');
 
 const { language } = translate;
 
@@ -34,7 +36,7 @@ exports.authorizeContractUpdate = async (req) => {
   const { credentials } = req.auth;
   const { contract } = req.pre;
 
-  if (credentials.company._id.toHexString() !== contract.company.toHexString()) throw Boom.forbidden();
+  if (!UtilsHelper.areObjectIdsEquals(credentials.company._id, contract.company)) throw Boom.forbidden();
   if (!req.path.match(/upload/) && !!contract.endDate) throw Boom.forbidden();
 
   return null;
@@ -44,7 +46,7 @@ exports.authorizeGetContract = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
 
   if (req.query.user) {
-    const user = await User.countDocuments({ _id: req.query.user, company: companyId });
+    const user = await UserCompany.countDocuments({ user: req.query.user, company: companyId });
     if (!user) throw Boom.notFound();
   }
 

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -22,9 +22,10 @@ const {
   otherContract,
   otherContractUser,
   userFromOtherCompany,
+  userCompanies,
 } = require('./seed/contractsSeed');
 const { generateFormData } = require('./utils');
-const { getToken, getUser, authCompany } = require('./seed/authenticationSeed');
+const { getToken, authCompany } = require('./seed/authenticationSeed');
 const EsignHelper = require('../../src/helpers/eSign');
 
 describe('NODE ENV', () => {
@@ -39,7 +40,8 @@ describe('GET /contracts', () => {
 
   it('should return list of contracts', async () => {
     authToken = await getToken('client_admin');
-    const userId = contractsList[0].user;
+    const userId = userCompanies[0].user;
+
     const response = await app.inject({
       method: 'GET',
       url: `/contracts?user=${userId}`,
@@ -53,18 +55,18 @@ describe('GET /contracts', () => {
   });
 
   it('should get my contracts if I am an auxiliary without company', async () => {
-    const user = getUser('auxiliary_without_company');
+    const userId = userCompanies[1].user;
     authToken = await getToken('auxiliary_without_company');
     const response = await app.inject({
       method: 'GET',
-      url: `/contracts?user=${user._id}`,
+      url: `/contracts?user=${userId}`,
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
     expect(response.statusCode).toBe(200);
     expect(response.result.data.contracts).toBeDefined();
     expect(response.result.data.contracts.length)
-      .toBe(contractsList.filter(contract => contract.user === user._id).length);
+      .toBe(contractsList.filter(contract => contract.user === userId).length);
   });
 
   it('should not return the contracts if user is not from the company', async () => {

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -8,6 +8,7 @@ const Sector = require('../../../src/models/Sector');
 const SectorHistory = require('../../../src/models/SectorHistory');
 const Event = require('../../../src/models/Event');
 const Establishment = require('../../../src/models/Establishment');
+const UserCompany = require('../../../src/models/UserCompany');
 const { rolesList, getUser } = require('./authenticationSeed');
 const { populateDBForAuthentication, authCompany, otherCompany } = require('./authenticationSeed');
 
@@ -239,6 +240,11 @@ const userFromOtherCompany = {
   origin: WEBAPP,
 };
 
+const userCompanies = [
+  { user: contractUsers[0]._id, company: authCompany._id },
+  { user: getUser('auxiliary_without_company')._id, company: authCompany._id },
+];
+
 const contractsList = [
   {
     serialNumber: 'mnbvcxzaserfghjiu',
@@ -404,13 +410,14 @@ const contractEvents = [
 ];
 
 const populateDB = async () => {
-  await Contract.deleteMany({});
-  await User.deleteMany({});
-  await Customer.deleteMany({});
-  await Event.deleteMany({});
-  await Sector.deleteMany({});
-  await SectorHistory.deleteMany({});
-  await Establishment.deleteMany({});
+  await Contract.deleteMany();
+  await User.deleteMany();
+  await Customer.deleteMany();
+  await Event.deleteMany();
+  await Sector.deleteMany();
+  await SectorHistory.deleteMany();
+  await Establishment.deleteMany();
+  await UserCompany.deleteMany();
 
   await populateDBForAuthentication();
   await User.insertMany([...contractUsers, otherContractUser, userFromOtherCompany]);
@@ -420,6 +427,7 @@ const populateDB = async () => {
   await Contract.insertMany([...contractsList, otherContract]);
   await Event.insertMany(contractEvents);
   await SectorHistory.insertMany(sectorHistories);
+  await UserCompany.insertMany(userCompanies);
 };
 
 module.exports = {
@@ -431,4 +439,5 @@ module.exports = {
   otherContract,
   otherContractUser,
   userFromOtherCompany,
+  userCompanies,
 };


### PR DESCRIPTION
### POUR TESTER LA PR
 MAJ du referent d'un bénéficiaire

- Cas d'usage : ETQ Coach ou admin je peux accéder aux contrats d'une auxiliaire 
- Pour tester: 
Dans le service: `/src/helpers/authorization` : 
	-  importer `const UserCompany = require('../models/UserCompany’);`
	- dans `validate`:  
		- commenter: `.populate({ path: 'company' })`
		- ajouter: `const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();`
		- transformer tous les `user.company` en `userCompany.company`

**Tester que l'on a bien accès aux contrats d'une auxiliaire lorsaue l'on commente le champ `company` dans le modele `Users`**
**Test pour vérifier que l’on a bien une 404 avec un utilisateur d’une autre structure:**
- creer une structure test avec l’abonnement ERP
- ajouter un utilisateur
- sur postman: 	
    - envoyer la requête `Post {{API_LINK}}/users/authenticate` pour se connecter avec le compte créé précédemment 
   - envoyer la requête `GET {{API_LINK}}/contracts?user=` avec l’id d'une auxiliaire d'une autre structure --> 403
