### PR TITLE
COM-2127: refacto UserCompany in pay preHandler

### DIFF
--- a/src/routes/preHandlers/pay.js
+++ b/src/routes/preHandlers/pay.js
@@ -1,6 +1,5 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const User = require('../../models/User');
 const Sector = require('../../models/Sector');
 const UserCompany = require('../../models/UserCompany');
 const UtilsHelper = require('../../helpers/utils');
@@ -8,7 +7,7 @@ const UtilsHelper = require('../../helpers/utils');
 exports.authorizePayCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const ids = req.payload.map(pay => pay.auxiliary);
-  const usersCount = await User.countDocuments({ company: companyId, _id: { $in: ids } });
+  const usersCount = await UserCompany.countDocuments({ company: companyId, user: { $in: ids } });
   if (usersCount !== ids.length) throw Boom.forbidden();
 
   return null;

--- a/src/routes/preHandlers/pay.js
+++ b/src/routes/preHandlers/pay.js
@@ -8,7 +8,7 @@ exports.authorizePayCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const ids = req.payload.map(pay => pay.auxiliary);
   const usersCount = await UserCompany.countDocuments({ company: companyId, user: { $in: ids } });
-  if (usersCount !== ids.length) throw Boom.forbidden();
+  if (usersCount !== ids.length) throw Boom.notFound();
 
   return null;
 };

--- a/tests/integration/pay.test.js
+++ b/tests/integration/pay.test.js
@@ -133,7 +133,7 @@ describe('PAY ROUTES - POST /pay', () => {
         payload: [{ ...payload[0], auxiliary: new ObjectID(auxiliaryFromOtherCompany._id) }],
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     Object.keys(payload[0]).forEach((key) => {


### PR DESCRIPTION
REFACTO du preHandler

POUR TESTER LA PR
Périmetre interface : client

Périmetre roles : client_admin, coach, auxiliaire

Pour tester :

Validation de la paie des auxiliaires sur la page Paie mensuelle
Testée sur postman avec la requête envoyée sur slack:
Avec mon compte
En supprimant company de User avec mon compte
En supprimant company de User avec un compte d'une autre entreprise -> 404