### PR TITLE
Com 2094 2

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -504,10 +504,9 @@ exports.getUnassignedHoursBySector = async (query, credentials) => {
 };
 
 const createEventsEveryDayOnCustomerStop = async (repetition, stoppedAt, company, onlyWeekDay = false) => {
-  const lastEventCreationStartDate = DatesHelper.isSameOrAfter(repetition.startDate, Date.now())
-    ? repetition.startDate
-    : Date.now();
-  const lastEventCreatedByRepetition = DatesHelper.addDays(lastEventCreationStartDate, 90);
+  const lastEventCreatedByRepetition = DatesHelper.isSameOrAfter(repetition.startDate, Date.now())
+    ? DatesHelper.addDays(repetition.startDate, 90)
+    : DatesHelper.addDays(Date.now(), 90);
 
   const shouldCreateEvents = DatesHelper.isSameOrAfter(stoppedAt, lastEventCreatedByRepetition);
   if (!shouldCreateEvents) return;

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -55,9 +55,9 @@ exports.createRepetitionsEveryDay = async (payload, sector, startDate = null, en
   await Event.insertMany(repeatedEvents);
 };
 
-exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
-  const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
+exports.createRepetitionsEveryWeekDay = async (payload, sector, startDate = null, endDate = null) => {
+  const start = startDate || moment(payload.startDate).add(1, 'd');
+  const end = endDate || moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -539,6 +539,7 @@ describe('updateCustomer', () => {
   let findRepetition;
   let findOneUser;
   let createRepetitionsEveryDay;
+  let createRepetitionsEveryWeekDay;
   let nowStub;
   let deleteOneRepetition;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
@@ -553,6 +554,7 @@ describe('updateCustomer', () => {
     findRepetition = sinon.stub(Repetition, 'find');
     findOneUser = sinon.stub(User, 'findOne');
     createRepetitionsEveryDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryDay');
+    createRepetitionsEveryWeekDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryWeekDay');
     nowStub = sinon.stub(Date, 'now');
     deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
   });
@@ -567,6 +569,7 @@ describe('updateCustomer', () => {
     findRepetition.restore();
     findOneUser.restore();
     createRepetitionsEveryDay.restore();
+    createRepetitionsEveryWeekDay.restore();
     nowStub.restore();
     deleteOneRepetition.restore();
   });
@@ -837,7 +840,7 @@ describe('updateCustomer', () => {
         _id: new ObjectID(),
         type: 'intervention',
         customer: customerId,
-        frequency: 'every_day',
+        frequency: 'every_week_day',
         parentId: new ObjectID(),
         startDate: '2021-12-25T09:00:00Z',
         endDate: '2021-12-25T10:00:00Z',
@@ -869,15 +872,15 @@ describe('updateCustomer', () => {
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
       ]
     );
-    sinon.assert.calledWithExactly(
-      createRepetitionsEveryDay.getCall(0),
+    sinon.assert.calledOnceWithExactly(
+      createRepetitionsEveryDay,
       repetitions[0],
       auxiliary.sector,
       new Date('2021-09-24T16:34:04.144Z'),
       '2022-06-25T16:34:04.144Z'
     );
-    sinon.assert.calledWithExactly(
-      createRepetitionsEveryDay.getCall(1),
+    sinon.assert.calledOnceWithExactly(
+      createRepetitionsEveryWeekDay,
       repetitions[1],
       repetitions[1].sector,
       new Date('2022-03-26T09:00:00.000Z'),


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin / coach / auxiliaire

- Cas d'usage : 
Lorsque j'arrête un bénéficiaire qui a une répétition chaque jour de la semaine travaillée, les événements + répétitions après la date d'arrêt sont supprimés, puis, avant de supprimer les autres répétitions on vient créer les événements qui pourrait ne pas avoir été créé par le script de création d'événement.

COMMENT TESTER :

En front, rendez visible le bouton 'Arrêter' sur CustomerProfileHeader
Ajoutez un bénéficiaire + souscription et ajoutez lui :
- une répétition chaque jour de la semaine travaillée qui commence après la date d'aujourd'hui
- un événement après la date d'arrêt
- une répétition après la date d'arrêt
Arrêtez le et vérifiez :
- que tous les événements et la répétition après la date d'arrêt sont supprimés
- que les événements sont bien créés entre le dernier événement créé par votre répétition (qui commence avant la date d'arrêt) et la date d'arrêt.
Arrêtez un bénéficiaire déjà existant qui a une répétition d'intervention chaque jour de la semaine travaillée  (Nicole Sur Belkacem par exemple).
- Vérifiez que les événements sont bien créés