### PR TITLE
COM-2131: refacto prehandler authorizecontractcreation

### DIFF
--- a/src/routes/preHandlers/contracts.js
+++ b/src/routes/preHandlers/contracts.js
@@ -1,7 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const Contract = require('../../models/Contract');
-const User = require('../../models/User');
 const UserCompany = require('../../models/UserCompany');
 const Customer = require('../../models/Customer');
 const translate = require('../../helpers/translate');
@@ -26,7 +25,7 @@ exports.authorizeContractCreation = async (req) => {
   const { credentials } = req.auth;
   const companyId = credentials.company._id.toHexString();
 
-  const user = await User.countDocuments({ _id: payload.user, company: companyId });
+  const user = await UserCompany.countDocuments({ user: payload.user, company: companyId });
   if (!user) throw Boom.forbidden();
 
   return null;

--- a/src/routes/preHandlers/contracts.js
+++ b/src/routes/preHandlers/contracts.js
@@ -26,7 +26,7 @@ exports.authorizeContractCreation = async (req) => {
   const companyId = credentials.company._id.toHexString();
 
   const user = await UserCompany.countDocuments({ user: payload.user, company: companyId });
-  if (!user) throw Boom.forbidden();
+  if (!user) throw Boom.notFound();
 
   return null;
 };
@@ -54,7 +54,7 @@ exports.authorizeGetContract = async (req) => {
 
 exports.authorizeUpload = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
-  const customer = await Customer.findOne({ _id: req.payload.customer, company: companyId }).lean();
+  const customer = await Customer.countDocuments({ _id: req.payload.customer, company: companyId });
   if (req.payload.customer && !customer) throw Boom.forbidden();
   return null;
 };

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -190,7 +190,7 @@ describe('POST /contracts', () => {
       headers: { Cookie: `alenvi_token=${authToken}` },
     });
 
-    expect(response.statusCode).toBe(403);
+    expect(response.statusCode).toBe(404);
   });
 
   const missingParams = [

--- a/tests/integration/contracts.test.js
+++ b/tests/integration/contracts.test.js
@@ -55,7 +55,7 @@ describe('GET /contracts', () => {
   });
 
   it('should get my contracts if I am an auxiliary without company', async () => {
-    const userId = userCompanies[1].user;
+    const userId = userCompanies[4].user;
     authToken = await getToken('auxiliary_without_company');
     const response = await app.inject({
       method: 'GET',

--- a/tests/integration/seed/contractsSeed.js
+++ b/tests/integration/seed/contractsSeed.js
@@ -242,6 +242,9 @@ const userFromOtherCompany = {
 
 const userCompanies = [
   { user: contractUsers[0]._id, company: authCompany._id },
+  { user: contractUsers[1]._id, company: authCompany._id },
+  { user: contractUsers[2]._id, company: authCompany._id },
+  { user: contractUsers[3]._id, company: authCompany._id },
   { user: getUser('auxiliary_without_company')._id, company: authCompany._id },
 ];
 


### PR DESCRIPTION
REFACTO du preHandler authorizecontractcreation

POUR TESTER LA PR
Périmetre interface : client

Périmetre roles : client_admin, coach, auxiliaire

Pour tester :

Création d’un contrat pour un auxiliaire
Testée sur postman avec la requête create a contract (visiblement il faut virer le status de la requête et s'assurer que l'user passé en paramètre existe bien et n'a pas de contract en cours (j'ai créé un auxiliaire pour l'occasion)). Entre chaque test penser à mettre fin au contract pour que le suivant passe 
Avec mon compte
En supprimant company de User avec mon compte
En supprimant company de User avec un compte d'une autre entreprise -> 404