### PR TITLE
COM-2140: refacto deleterepetition

### DIFF
--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -81,12 +81,9 @@ const remove = async (req) => {
 const removeRepetition = async (req) => {
   try {
     const { auth, pre } = req;
-    const event = await deleteRepetition(pre.event, auth.credentials);
+    await deleteRepetition(pre.event, auth.credentials);
 
-    return {
-      message: translate[language].eventDeleted,
-      data: { event },
-    };
+    return { message: translate[language].eventDeleted };
   } catch (e) {
     req.log('error', e);
     return Boom.isBoom(e) ? e : Boom.badImplementation(e);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -18,7 +18,6 @@ const {
 const Event = require('../models/Event');
 const User = require('../models/User');
 const Repetition = require('../models/Repetition');
-const EventHistoriesHelper = require('./eventHistories');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
@@ -172,20 +171,15 @@ exports.updateRepetition = async (eventFromDb, eventPayload, credentials) => {
 
 exports.deleteRepetition = async (event, credentials) => {
   const { type, repetition } = event;
-  if (type !== ABSENCE && repetition && repetition.frequency !== NEVER) {
-    await EventHistoriesHelper.createEventHistoryOnDelete(event, credentials);
+  if (type === ABSENCE || !repetition || repetition.frequency === NEVER) return;
 
-    await Event.deleteMany({
-      'repetition.parentId': event.repetition.parentId,
-      startDate: { $gte: new Date(event.startDate) },
-      company: get(credentials, 'company._id'),
-      $or: [{ isBilled: false }, { isBilled: { $exists: false } }],
-    });
+  const query = {
+    'repetition.parentId': event.repetition.parentId,
+    startDate: { $gte: new Date(event.startDate) },
+    company: get(credentials, 'company._id'),
+  };
 
-    await Repetition.deleteOne({ parentId: event.repetition.parentId });
-  }
-
-  return event;
+  await EventsHelper.deleteEventsAndRepetition(query, true, credentials);
 };
 
 exports.formatEventBasedOnRepetition = async (repetition, date) => {

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -245,10 +245,7 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required() }),
         },
-        pre: [
-          { method: getEvent, assign: 'event' },
-          { method: authorizeEventDeletion },
-        ],
+        pre: [{ method: authorizeEventDeletion, assign: 'event' }],
       },
       handler: removeRepetition,
     });

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -105,7 +105,7 @@ exports.authorizeEventDeletion = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   if (!UtilsHelper.areObjectIdsEquals(event.company, companyId)) throw Boom.forbidden();
 
-  return null;
+  return event;
 };
 
 exports.authorizeEventCreation = async (req) => {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : Auxiliaire / Coach / Admin

- Cas d'usage : sur la modale d'édition d'un événement appartenant à une répétition, je peux supprimer l'événement et tous les suivants : pas de suppression si un des événements est horodaté
