### PR TITLE
COM-2128 - use UserCompany in finalPay preHandler

### DIFF
--- a/src/routes/preHandlers/finalPay.js
+++ b/src/routes/preHandlers/finalPay.js
@@ -1,11 +1,11 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const User = require('../../models/User');
+const UserCompany = require('../../models/UserCompany');
 
 exports.authorizeFinalPayCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const ids = req.payload.map(pay => pay.auxiliary);
-  const usersCount = await User.countDocuments({ company: companyId, _id: { $in: ids } });
-  if (usersCount !== ids.length) throw Boom.forbidden();
+  const usersCount = await UserCompany.countDocuments({ user: { $in: ids }, company: companyId });
+  if (usersCount !== ids.length) throw Boom.notFound();
   return null;
 };

--- a/tests/integration/finalPay.test.js
+++ b/tests/integration/finalPay.test.js
@@ -170,8 +170,8 @@ describe('FINAL PAY ROUTES - POST /finalpay', () => {
 
       expect(response.statusCode).toBe(200);
 
-      const finalPayList = await FinalPay.find({ company: authCompany._id }).lean();
-      expect(finalPayList.length).toEqual(1);
+      const finalPayList = await FinalPay.countDocuments({ company: authCompany._id });
+      expect(finalPayList).toEqual(1);
     });
 
     it('should not create a new final pay if user is not from the same company', async () => {
@@ -182,7 +182,7 @@ describe('FINAL PAY ROUTES - POST /finalpay', () => {
         payload: [{ ...payload[0], auxiliary: auxiliaryFromOtherCompany._id }],
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     Object.keys(payload[0]).forEach((key) => {

--- a/tests/integration/seed/finalPaySeed.js
+++ b/tests/integration/seed/finalPaySeed.js
@@ -9,6 +9,7 @@ const Event = require('../../../src/models/Event');
 const Sector = require('../../../src/models/Sector');
 const SectorHistory = require('../../../src/models/SectorHistory');
 const FinalPay = require('../../../src/models/FinalPay');
+const UserCompany = require('../../../src/models/UserCompany');
 const { rolesList, populateDBForAuthentication, authCompany, otherCompany } = require('./authenticationSeed');
 const { WEBAPP } = require('../../../src/helpers/constants');
 
@@ -56,6 +57,11 @@ const auxiliaryFromOtherCompany = {
   company: otherCompany._id,
   origin: WEBAPP,
 };
+
+const userCompanyList = [
+  { user: auxiliaryId, company: authCompany._id },
+  { user: auxiliaryFromOtherCompany._id, company: otherCompany._id },
+];
 
 const contract = {
   createdAt: '2018-12-04T16:34:04',
@@ -167,6 +173,7 @@ const populateDB = async () => {
   await Sector.deleteMany({});
   await SectorHistory.deleteMany({});
   await FinalPay.deleteMany({});
+  await UserCompany.deleteMany({});
 
   await populateDBForAuthentication();
   await (new Sector(sector)).save();
@@ -176,6 +183,7 @@ const populateDB = async () => {
   await (new Service(service)).save();
   await (new Event(event)).save();
   await (new Contract(contract)).save();
+  await UserCompany.insertMany(userCompanyList);
 };
 
 module.exports = { populateDB, auxiliary, auxiliaryFromOtherCompany };

--- a/tests/integration/seed/finalPaySeed.js
+++ b/tests/integration/seed/finalPaySeed.js
@@ -165,15 +165,15 @@ const sectorHistory = {
 };
 
 const populateDB = async () => {
-  await User.deleteMany({});
-  await Customer.deleteMany({});
-  await Service.deleteMany({});
-  await Contract.deleteMany({});
-  await Event.deleteMany({});
-  await Sector.deleteMany({});
-  await SectorHistory.deleteMany({});
-  await FinalPay.deleteMany({});
-  await UserCompany.deleteMany({});
+  await User.deleteMany();
+  await Customer.deleteMany();
+  await Service.deleteMany();
+  await Contract.deleteMany();
+  await Event.deleteMany();
+  await Sector.deleteMany();
+  await SectorHistory.deleteMany();
+  await FinalPay.deleteMany();
+  await UserCompany.deleteMany();
 
   await populateDBForAuthentication();
   await (new Sector(sector)).save();


### PR DESCRIPTION
REFACTO du preHandler

POUR TESTER LA PR
Périmetre interface : client

Périmetre roles : client_admin

Pour tester :

Validation de la paie des auxiliaires sur la page “Fin de contrats” / STC
  - Ajoutez une auxiliaire + contrat + une intervention -> fin de contrat -> STC

Dans postman (lien de la collection en thread du ticket) :
  - Changer l'id dans le payload par l'id de votre auxiliaire
  - Avec mon compte
  - En supprimant company de User avec mon compte
  - En supprimant company de User avec un compte d'une autre entreprise -> 404