### PR TITLE
Com 2141

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -28,6 +28,8 @@ const ContractRepository = require('../repositories/ContractRepository');
 const SectorHistoryHelper = require('./sectorHistories');
 const translate = require('./translate');
 
+const { language } = translate;
+
 exports.getQuery = (query, companyId) => {
   const rules = [{ company: companyId }];
   if (query.startDate && query.endDate) {
@@ -133,11 +135,11 @@ const canEndContract = async (contract, lastVersion, contractToEnd) => {
   });
 
   if (hasTimeStampedEvents) {
-    throw Boom.forbidden(translate['en-EN'].contractHasTimeStampedEventAfterEndDate);
+    throw Boom.forbidden(translate[language].contractHasTimeStampedEventAfterEndDate);
   }
 
   if (DatesHelper.isBefore(contractToEnd.endDate, lastVersion.startDate)) {
-    throw Boom.conflict('End date is before last version start date');
+    throw Boom.conflict(translate[language].contractEndDateBeforeStartDate);
   }
 };
 

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -87,7 +87,8 @@ module.exports = {
     contractAdded: 'Contract added.',
     contractRemoved: 'Contract removed.',
     staffRegisteredFound: 'Staff Registered Found.',
-    contractHasTimeStampedEventAfterEndDate: 'There are time stamped events after the end date of the contract.',
+    contractHasTimeStampedEventAfterEndDate: 'There are timestamped events after the end date of the contract.',
+    contractEndDateBeforeStartDate: 'End date is before last version start date.',
     /* Contracts amendments */
     contractVersionAdded: 'Contract amendment added.',
     contractVersionRemoved: 'Contract amendment removed.',
@@ -414,7 +415,10 @@ module.exports = {
     contractAdded: 'Contrat ajouté.',
     contractRemoved: 'Contrat supprimé.',
     staffRegisteredFound: 'Registre Unique du personnel récuperé.',
-    contractHasTimeStampedEventAfterEndDate: 'Il y a des évènements horodatés après la date de fin du contrat.',
+    contractHasTimeStampedEventAfterEndDate:
+      'Impossible: il y a des évènements horodatés après la date de fin du contrat.',
+    contractEndDateBeforeStartDate:
+      'Impossible de mettre fin à un contrat pour lequel la date de fin est avant la date de début.',
     /* Contracts amendments */
     contractVersionAdded: 'Avenant au contrat ajouté.',
     contractVersionRemoved: 'Avenant au contrat supprimé.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -87,6 +87,7 @@ module.exports = {
     contractAdded: 'Contract added.',
     contractRemoved: 'Contract removed.',
     staffRegisteredFound: 'Staff Registered Found.',
+    contractHasTimeStampedEventAfterEndDate: 'There are time stamped events after the end date of the contract.',
     /* Contracts amendments */
     contractVersionAdded: 'Contract amendment added.',
     contractVersionRemoved: 'Contract amendment removed.',
@@ -413,6 +414,7 @@ module.exports = {
     contractAdded: 'Contrat ajouté.',
     contractRemoved: 'Contrat supprimé.',
     staffRegisteredFound: 'Registre Unique du personnel récuperé.',
+    contractHasTimeStampedEventAfterEndDate: 'Il y a des évènements horodatés après la date de fin du contrat.',
     /* Contracts amendments */
     contractVersionAdded: 'Avenant au contrat ajouté.',
     contractVersionRemoved: 'Avenant au contrat supprimé.',

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -562,7 +562,7 @@ describe('endContract', () => {
     );
   });
 
-  it('should throw a 403 error if there is eventHistory after contract end date', async () => {
+  it('should throw a 403 error if there are time stamped events after contract end date', async () => {
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
     const credential = { _id: new ObjectID(), company: { _id: companyId } };

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -562,6 +562,79 @@ describe('endContract', () => {
     );
   });
 
+  it('should throw a 403 error if there is eventHistory after contract end date', async () => {
+    const auxiliaryId = new ObjectID();
+    const companyId = new ObjectID();
+    const credential = { _id: new ObjectID(), company: { _id: companyId } };
+
+    const contract = {
+      _id: new ObjectID(),
+      endDate: null,
+      user: auxiliaryId,
+      startDate: '2018-12-03T23:00:00',
+      versions: [{ _id: new ObjectID(), startDate: '2018-12-03T23:00:00' }],
+    };
+
+    const contractToEnd = {
+      endDate: '2018-12-06T23:00:00',
+      endNotificationDate: '2018-12-02T23:00:00',
+      endReason: RESIGNATION,
+      otherMisc: 'test',
+    };
+
+    const updatedContract = {
+      ...contract,
+      ...contractToEnd,
+      user: { _id: auxiliaryId, sector: new ObjectID() },
+      versions: [{ ...contract.versions[0], endDate: contractToEnd.endDate }],
+    };
+
+    try {
+      findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
+      findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
+      countDocumentHistories.returns(1);
+
+      await ContractHelper.endContract(contract._id.toHexString(), contractToEnd, credential);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.output.statusCode).toEqual(403);
+    } finally {
+      sinon.assert.notCalled(updateUserInactivityDate);
+      sinon.assert.notCalled(removeRepetitionsOnContractEnd);
+      sinon.assert.notCalled(unassignInterventionsOnContractEnd);
+      sinon.assert.notCalled(unassignReferentOnContractEnd);
+      sinon.assert.notCalled(removeEventsExceptInterventionsOnContractEnd);
+      sinon.assert.notCalled(updateAbsencesOnContractEnd);
+      sinon.assert.notCalled(updateEndDateStub);
+      sinon.assert.notCalled(findOneAndUpdateContract);
+      SinonMongoose.calledWithExactly(
+        findOneContract,
+        [
+          { query: 'findOne', args: [{ _id: contract._id.toHexString() }] },
+          { query: 'lean' },
+        ]
+      );
+      SinonMongoose.calledWithExactly(
+        countDocumentHistories,
+        [
+          {
+            query: 'countDocuments',
+            args: [
+              {
+                'event.auxiliary': contract.user,
+                action: { $in: EventHistory.TIME_STAMPING_ACTIONS },
+                $or: [
+                  { 'update.startHour.to': { $gte: contractToEnd.endDate } },
+                  { 'update.endHour.to': { $gte: contractToEnd.endDate } },
+                ],
+              },
+            ],
+          },
+        ]
+      );
+    }
+  });
+
   it('should throw an error if contract end date is before last version start date', async () => {
     const contractId = new ObjectID();
     const payload = {
@@ -582,6 +655,7 @@ describe('endContract', () => {
       findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
 
       await ContractHelper.endContract(contractId.toHexString(), payload, credentials);
+      expect(true).toBe(false);
     } catch (e) {
       expect(e.output.statusCode).toEqual(409);
     } finally {

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -562,7 +562,7 @@ describe('endContract', () => {
     );
   });
 
-  it('should throw a 403 error if there are time stamped events after contract end date', async () => {
+  it('should throw a 403 error if there are timestamped events after contract end date', async () => {
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
     const credential = { _id: new ObjectID(), company: { _id: companyId } };

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -16,6 +16,7 @@ const Contract = require('../../../src/models/Contract');
 const Role = require('../../../src/models/Role');
 const User = require('../../../src/models/User');
 const Customer = require('../../../src/models/Customer');
+const EventHistory = require('../../../src/models/EventHistory');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const ContractRepository = require('../../../src/repositories/ContractRepository');
 const SinonMongoose = require('../sinonMongoose');
@@ -444,8 +445,10 @@ describe('endContract', () => {
   let updateAbsencesOnContractEnd;
   let unassignReferentOnContractEnd;
   let updateEndDateStub;
+  let countDocumentHistories;
   beforeEach(() => {
     findOneContract = sinon.stub(Contract, 'findOne');
+    countDocumentHistories = sinon.stub(EventHistory, 'countDocuments');
     findOneAndUpdateContract = sinon.stub(Contract, 'findOneAndUpdate');
     updateUserInactivityDate = sinon.stub(UserHelper, 'updateUserInactivityDate');
     removeRepetitionsOnContractEnd = sinon.stub(EventHelper, 'removeRepetitionsOnContractEnd');
@@ -465,6 +468,7 @@ describe('endContract', () => {
     removeRepetitionsOnContractEnd.restore();
     unassignInterventionsOnContractEnd.restore();
     removeEventsExceptInterventionsOnContractEnd.restore();
+    countDocumentHistories.restore();
     updateAbsencesOnContractEnd.restore();
     unassignReferentOnContractEnd.restore();
     updateEndDateStub.restore();
@@ -536,6 +540,24 @@ describe('endContract', () => {
           }],
         },
         { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
+      ]
+    );
+    SinonMongoose.calledWithExactly(
+      countDocumentHistories,
+      [
+        {
+          query: 'countDocuments',
+          args: [
+            {
+              'event.auxiliary': contract.user,
+              action: { $in: EventHistory.TIME_STAMPING_ACTIONS },
+              $or: [
+                { 'update.startHour.to': { $gte: payload.endDate } },
+                { 'update.endHour.to': { $gte: payload.endDate } },
+              ],
+            },
+          ],
+        },
       ]
     );
   });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES 
- Si mes changements impactent l'application formation : -np 
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles :  coach/ admin client

- Cas d'usage : ETQ coach ou admin client,  je veux mettre fin au contrat d'une auxiliaire, si des interventions sont horodatées après la date de fin de contrat il n'est pas possible de mettre fin au contrat.

- Pour tester: 
   - ajouter une intervention sur le planning d'une auxiliaire
   - l'horodater depuis l'app erp
   - mettre fin au contrat de l'auxiliaire a une date antérieure à l'événement horodaté --> 403

- En front: le message d'erreur renvoyé est: `erreur lors de la mise a jour du contrat`, est-ce que nous n'afficherions pas un message plus explicite pour l'utilisateur? 