### PR TITLE
COM-2075 - refacto get events groupBy

### DIFF
--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,4 +1,13 @@
-exports.isBefore = (date1, date2) => new Date(date1) < new Date(date2);
+exports.isBefore = (date1, date2, ref = '') => {
+  let formattedDate1 = date1;
+  let formattedDate2 = date2;
+  if (ref === 'd') {
+    formattedDate1 = exports.getStartOfDay(date1);
+    formattedDate2 = exports.getStartOfDay(date2);
+  }
+
+  return new Date(formattedDate1) < new Date(formattedDate2);
+};
 
 exports.isSameOrBefore = (date1, date2, ref = '') => {
   let formattedDate1 = date1;

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,6 +1,15 @@
 exports.isBefore = (date1, date2) => new Date(date1) < new Date(date2);
 
-exports.isSameOrBefore = (date1, date2) => new Date(date1) <= new Date(date2);
+exports.isSameOrBefore = (date1, date2, ref = '') => {
+  let formattedDate1 = date1;
+  let formattedDate2 = date2;
+  if (ref === 'd') {
+    formattedDate1 = exports.getStartOfDay(date1);
+    formattedDate2 = exports.getStartOfDay(date2);
+  }
+
+  return new Date(formattedDate1) <= new Date(formattedDate2);
+};
 
 exports.isAfter = (date1, date2) => new Date(date1) > new Date(date2);
 
@@ -67,5 +76,3 @@ exports.formatDateAndTime = (date, format = '') => {
 };
 
 exports.descendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);
-
-exports.ascendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -67,3 +67,5 @@ exports.formatDateAndTime = (date, format = '') => {
 };
 
 exports.descendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);
+
+exports.ascendingSort = key => (a, b) => new Date(b[key]) - new Date(a[key]);

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -27,9 +27,9 @@ exports.getMatchingVersion = (date, obj, dateKey) => {
   if (obj.versions.length === 0) return null;
 
   const matchingVersion = [...obj.versions]
-    .filter(ver => moment(ver.startDate).isSameOrBefore(date, 'd') &&
-      (!ver.endDate || moment(ver.endDate).isSameOrAfter(date, 'd')))
-    .sort((a, b) => new Date(b[dateKey]) - new Date(a[dateKey]))[0];
+    .filter(ver => DatesHelper.isSameOrBefore(ver.startDate, date, 'd') &&
+      (!ver.endDate || DatesHelper.isSameOrAfter(ver.endDate, date, 'd')))
+    .sort(DatesHelper.descendingSort(dateKey))[0];
   if (!matchingVersion) return null;
 
   return {
@@ -44,7 +44,8 @@ exports.getMatchingObject = (date, list, dateKey) => {
   if (list.length === 0) return null;
 
   const filteredAndSortedList = list
-    .filter(h => DatesHelper.isBefore(h.startDate, date) && (!h.endDate || DatesHelper.isSameOrAfter(h.endDate, date)))
+    .filter(h => DatesHelper.isBefore(h.startDate, date, 'd') &&
+      (!h.endDate || DatesHelper.isSameOrAfter(h.endDate, date, 'd')))
     .sort(DatesHelper.descendingSort(dateKey));
   if (!filteredAndSortedList.length) return null;
 

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -4,6 +4,7 @@ const { ObjectID } = require('mongodb');
 const Intl = require('intl');
 const moment = require('../extensions/moment');
 const { CIVILITY_LIST } = require('./constants');
+const DatesHelper = require('./dates');
 
 exports.getLastVersion = (versions, dateKey) => {
   if (!Array.isArray(versions)) throw new Error('versions must be an array !');
@@ -36,6 +37,18 @@ exports.getMatchingVersion = (date, obj, dateKey) => {
     ...omit(matchingVersion, ['_id', 'createdAt']),
     versionId: matchingVersion._id,
   };
+};
+
+exports.getMatchingObject = (date, list, dateKey) => {
+  if (!Array.isArray(list)) throw new Error('List must be an array !');
+  if (list.length === 0) return null;
+
+  const filteredAndSortedList = list
+    .filter(h => DatesHelper.isBefore(h.startDate, date) && (!h.endDate || DatesHelper.isSameOrAfter(h.endDate, date)))
+    .sort(DatesHelper.descendingSort(dateKey));
+  if (!filteredAndSortedList.length) return null;
+
+  return filteredAndSortedList[0];
 };
 
 exports.getDateQuery = (dates) => {

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -7,8 +7,6 @@ const { CIVILITY_LIST } = require('./constants');
 const DatesHelper = require('./dates');
 
 exports.getLastVersion = (versions, dateKey) => {
-  if (!Array.isArray(versions)) throw new Error('versions must be an array !');
-  if (typeof dateKey !== 'string') throw new Error('sortKey must be a string !');
   if (versions.length === 0) return null;
   if (versions.length === 1) return versions[0];
   return [...versions].sort((a, b) => new Date(b[dateKey]) - new Date(a[dateKey]))[0];
@@ -23,7 +21,6 @@ exports.mergeLastVersionWithBaseObject = (baseObj, dateKey) => {
 
 // `obj` should by sort in descending order
 exports.getMatchingVersion = (date, obj, dateKey) => {
-  if (!Array.isArray(obj.versions)) throw new Error('versions must be an array !');
   if (obj.versions.length === 0) return null;
 
   const matchingVersion = [...obj.versions]
@@ -40,7 +37,6 @@ exports.getMatchingVersion = (date, obj, dateKey) => {
 };
 
 exports.getMatchingObject = (date, list, dateKey) => {
-  if (!Array.isArray(list)) throw new Error('List must be an array !');
   if (list.length === 0) return null;
 
   const filteredAndSortedList = list
@@ -65,16 +61,9 @@ exports.getDateQuery = (dates) => {
   return { $lt: dates.endDate };
 };
 
-exports.getFixedNumber = (number, toFixedNb) => {
-  if (Number.isNaN(Number(number))) throw new Error('You must provide a number !');
-  return number.toFixed(toFixedNb);
-};
+exports.getFixedNumber = (number, toFixedNb) => number.toFixed(toFixedNb);
 
-exports.removeSpaces = (str) => {
-  if (!str) return '';
-  if (typeof str !== 'string') throw new Error('Parameter must be a string !');
-  return str.split(' ').join('');
-};
+exports.removeSpaces = str => (str ? str.split(' ').join('') : '');
 
 const roundFrenchPrice = (number) => {
   const nf = new Intl.NumberFormat(

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -22,10 +22,9 @@ exports.formatEvent = (event) => {
 
   const { auxiliary, subscription, customer } = event;
   if (auxiliary) {
-    formattedEvent.auxiliary = {
-      ...omit(auxiliary, 'sectorHistories'),
-      sector: UtilsHelper.getMatchingObject(event.startDate, auxiliary.sectorHistories, 'startDate'),
-    };
+    const matchingSectorHistory =
+      UtilsHelper.getMatchingObject(event.startDate, auxiliary.sectorHistories, 'startDate');
+    formattedEvent.auxiliary = { ...omit(auxiliary, 'sectorHistories'), sector: matchingSectorHistory.sector };
   }
 
   if (subscription) {
@@ -40,17 +39,17 @@ exports.getEventsGroupedBy = async (rules, groupByFunc, companyId) => {
     .populate({
       path: 'auxiliary',
       match: { company: companyId },
-      populate: { path: 'sectorHistories', match: { company: companyId } },
+      populate: { path: 'sectorHistories', match: { company: companyId }, populate: { path: 'sector' } },
       select: 'identity administrative.driveFolder company picture sectorHistories',
     })
     .populate({
       path: 'customer',
       match: { company: companyId },
-      populate: { path: 'subscriptions.service', match: { company: companyId } },
+      populate: { path: 'subscriptions.service' },
       select: 'identity contact subscriptions',
     })
-    .populate({ path: 'internalHour', match: { company: companyId } })
-    .populate({ path: 'extension', match: { company: companyId } })
+    .populate({ path: 'internalHour' })
+    .populate({ path: 'extension' })
     .lean();
 
   return groupBy(events.map(exports.formatEvent), groupByFunc);

--- a/src/repositories/EventRepository.js
+++ b/src/repositories/EventRepository.js
@@ -2,8 +2,11 @@ const { ObjectID } = require('mongodb');
 const moment = require('moment');
 const omit = require('lodash/omit');
 const get = require('lodash/get');
+const groupBy = require('lodash/groupBy');
+const { cloneDeep } = require('lodash');
 const Event = require('../models/Event');
 const UtilsHelper = require('../helpers/utils');
+const DatesHelper = require('../helpers/dates');
 const SectorHistory = require('../models/SectorHistory');
 const {
   INTERNAL_HOUR,
@@ -15,144 +18,51 @@ const {
 } = require('../helpers/constants');
 const { populateReferentHistories } = require('./utils');
 
-const getEventsGroupedBy = async (rules, groupById, companyId) => Event.aggregate([
-  { $match: rules },
-  {
-    $lookup: {
-      from: 'users',
-      as: 'auxiliary',
-      let: { auxiliaryId: '$auxiliary', eventStartDate: '$startDate' },
-      pipeline: [
-        { $match: { $expr: { $and: [{ $eq: ['$_id', '$$auxiliaryId'] }] } } },
-        {
-          $lookup: {
-            from: 'sectorhistories',
-            as: 'sector',
-            let: { auxiliaryId: '$_id', companyId: '$company', eventStartDate: '$$eventStartDate' },
-            pipeline: [
-              {
-                $match: {
-                  $or: [
-                    {
-                      endDate: { $exists: true },
-                      $expr: {
-                        $and: [
-                          { $eq: ['$auxiliary', '$$auxiliaryId'] },
-                          { $eq: ['$company', '$$companyId'] },
-                          { $lte: ['$startDate', '$$eventStartDate'] },
-                          { $gte: ['$endDate', '$$eventStartDate'] },
-                        ],
-                      },
-                    },
-                    {
-                      endDate: { $exists: false },
-                      $expr: {
-                        $and: [
-                          { $eq: ['$auxiliary', '$$auxiliaryId'] },
-                          { $eq: ['$company', '$$companyId'] },
-                          { $lte: ['$startDate', '$$eventStartDate'] },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-              { $limit: 1 },
-              { $lookup: { from: 'sectors', as: 'lastSector', foreignField: '_id', localField: 'sector' } },
-              { $unwind: { path: '$lastSector' } },
-              { $replaceRoot: { newRoot: '$lastSector' } },
-            ],
-          },
-        },
-        { $unwind: { path: '$sector' } },
-      ],
-    },
-  },
-  { $unwind: { path: '$auxiliary', preserveNullAndEmptyArrays: true } },
-  {
-    $lookup: {
-      from: 'customers',
-      localField: 'customer',
-      foreignField: '_id',
-      as: 'customer',
-    },
-  },
-  { $unwind: { path: '$customer', preserveNullAndEmptyArrays: true } },
-  {
-    $addFields: {
-      subscription: {
-        $filter: { input: '$customer.subscriptions', as: 'sub', cond: { $eq: ['$$sub._id', '$subscription'] } },
-      },
-    },
-  },
-  { $unwind: { path: '$subscription', preserveNullAndEmptyArrays: true } },
-  {
-    $lookup: {
-      from: 'services',
-      localField: 'subscription.service',
-      foreignField: '_id',
-      as: 'subscription.service',
-    },
-  },
-  { $unwind: { path: '$subscription.service', preserveNullAndEmptyArrays: true } },
-  {
-    $lookup: {
-      from: 'internalhours',
-      localField: 'internalHour',
-      foreignField: '_id',
-      as: 'internalHour',
-    },
-  },
-  { $unwind: { path: '$internalHour', preserveNullAndEmptyArrays: true } },
-  {
-    $lookup: {
-      from: 'events',
-      localField: 'extension',
-      foreignField: '_id',
-      as: 'extension',
-    },
-  },
-  { $unwind: { path: '$extension', preserveNullAndEmptyArrays: true } },
-  {
-    $project: {
-      _id: 1,
-      customer: { _id: 1, identity: 1, contact: 1 },
-      auxiliary: {
-        _id: 1,
-        identity: 1,
-        administrative: { driveFolder: 1, transportInvoice: 1 },
-        company: 1,
-        picture: 1,
-        sector: 1,
-      },
-      type: 1,
-      startDate: 1,
-      endDate: 1,
-      subscription: 1,
-      internalHour: 1,
-      absence: 1,
-      absenceNature: 1,
-      extension: 1,
-      address: 1,
-      misc: 1,
-      attachment: 1,
-      repetition: 1,
-      isCancelled: 1,
-      cancel: 1,
-      isBilled: 1,
-      bills: 1,
-      sector: 1,
-    },
-  },
-  {
-    $group: { _id: groupById, events: { $push: '$$ROOT' } },
-  },
-]).option({ company: companyId });
+exports.formatEvent = (event) => {
+  const formattedEvent = cloneDeep(event);
+
+  const { auxiliary, subscription, customer } = event;
+  if (auxiliary) {
+    formattedEvent.auxiliary = {
+      ...omit(auxiliary, 'sectorHistories'),
+      sector: auxiliary.sectorHistories.filter(h => DatesHelper.isBefore(h.startDate, event.startDate))[0],
+    };
+  }
+
+  if (subscription) {
+    formattedEvent.subscription = customer.subscriptions.find(s => UtilsHelper.areObjectIdsEquals(subscription, s._id));
+  }
+
+  return formattedEvent;
+};
+
+exports.getEventsGroupedBy = async (rules, groupByFunc, companyId) => {
+  const events = await Event
+    .find(rules, {})
+    .populate({
+      path: 'auxiliary',
+      match: { company: companyId },
+      populate: { path: 'sectorHistories', match: { company: companyId } },
+      select: 'identity administrative.driveFolder: administrative.transportInvoice company picture sectorHistories',
+    })
+    .populate({
+      path: 'customer',
+      match: { company: companyId },
+      populate: { path: 'subscriptions.service', match: { company: companyId } },
+      select: 'identity contact subscriptions',
+    })
+    .populate({ path: 'internalHour', match: { company: companyId } })
+    .populate({ path: 'extension', match: { company: companyId } })
+    .lean();
+
+  return groupBy(events.map(exports.formatEvent), groupByFunc);
+};
 
 exports.getEventsGroupedByAuxiliaries = async (rules, companyId) =>
-  getEventsGroupedBy(rules, { $ifNull: ['$auxiliary._id', '$sector'] }, companyId);
+  exports.getEventsGroupedBy(rules, ev => (ev.auxiliary ? ev.auxiliary._id : ev.sector), companyId);
 
-exports.getEventsGroupedByCustomers = async (rules, companyId) => getEventsGroupedBy(rules, '$customer._id', companyId);
+exports.getEventsGroupedByCustomers = async (rules, companyId) =>
+  exports.getEventsGroupedBy(rules, 'customer._id', companyId);
 
 exports.getEventList = (rules, companyId) => Event.find(rules)
   .populate({

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -88,6 +88,7 @@ const checkAuxiliaryPermission = (credentials, event) => {
   const eventIsUnassignedAndFromSameSector = sector && UtilsHelper.areObjectIdsEquals(sector, credentials.sector);
 
   if (!isOwnEvent && !eventIsUnassignedAndFromSameSector) throw Boom.forbidden();
+
   return null;
 };
 

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -37,10 +37,11 @@ const {
   INVOICED_AND_PAID,
   AUXILIARY_INITIATIVE,
 } = require('../../src/helpers/constants');
+const UtilsHelper = require('../../src/helpers/utils');
+const DatesHelper = require('../../src/helpers/dates');
 const Repetition = require('../../src/models/Repetition');
 const Event = require('../../src/models/Event');
 const EventHistory = require('../../src/models/EventHistory');
-const { isSameOrAfter, isSameOrBefore } = require('../../src/helpers/dates');
 
 describe('NODE ENV', () => {
   it('should be "test"', () => {
@@ -69,8 +70,8 @@ describe('GET /events', () => {
       expect(response.statusCode).toEqual(200);
       expect(response.result.data.events).toBeDefined();
       response.result.data.events.forEach((event) => {
-        expect(isSameOrAfter(event.endDate, startDate)).toBeTruthy();
-        expect(isSameOrBefore(event.startDate, endDate)).toBeTruthy();
+        expect(DatesHelper.isSameOrAfter(event.startDate, startDate)).toBeTruthy();
+        expect(DatesHelper.isSameOrBefore(event.startDate, endDate)).toBeTruthy();
         expect(event.isCancelled).toEqual(false);
         if (event.type === 'intervention') expect(event.subscription._id).toBeDefined();
       });
@@ -85,11 +86,9 @@ describe('GET /events', () => {
 
       expect(response.statusCode).toEqual(200);
       expect(response.result.data.events).toBeDefined();
-      expect(response.result.data.events[0]._id).toBeDefined();
-      expect(response.result.data.events[0].events).toBeDefined();
-      response.result.data.events[0].events.forEach((event) => {
-        expect(event.customer._id).toEqual(response.result.data.events[0]._id);
-      });
+      const { events } = response.result.data;
+      const customerId = Object.keys(events)[0];
+      events[customerId].forEach(e => expect(UtilsHelper.areObjectIdsEquals(e.customer._id, customerId)).toBeTruthy());
     });
 
     it('should return a list of events groupedBy auxiliaries', async () => {
@@ -101,12 +100,9 @@ describe('GET /events', () => {
 
       expect(response.statusCode).toEqual(200);
       expect(response.result.data.events).toBeDefined();
-      expect(response.result.data.events[0]._id).toBeDefined();
-      expect(response.result.data.events[0].events).toBeDefined();
-      const index = response.result.data.events.findIndex(event => event.events[0].auxiliary);
-      response.result.data.events[index].events.forEach((event) => {
-        expect(event.auxiliary._id).toEqual(response.result.data.events[index]._id);
-      });
+      const { events } = response.result.data;
+      const auxId = Object.keys(events)[0];
+      events[auxId].forEach(e => expect(UtilsHelper.areObjectIdsEquals(e.auxiliary._id, auxId)).toBeTruthy());
     });
 
     it('should return a 200 if same id send twice - sectors', async () => {

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -3,19 +3,25 @@ const DatesHelper = require('../../../src/helpers/dates');
 
 describe('isBefore', () => {
   it('should return true if date1 is before date2', () => {
-    const isBefore = DatesHelper.isBefore('2020-01-01', new Date());
+    const isBefore = DatesHelper.isBefore('2020-01-01T09:00:00', '2020-01-01T11:00:00');
 
     expect(isBefore).toBe(true);
   });
 
   it('should return false if date1 is after date2', () => {
-    const isBefore = DatesHelper.isBefore('2020-01-01', '2019-02-03');
+    const isBefore = DatesHelper.isBefore('2020-01-01T09:00:00', '2020-01-01T07:00:00');
 
     expect(isBefore).toBe(false);
   });
 
   it('should return false if date1 is equal to date2', () => {
-    const isBefore = DatesHelper.isBefore('2020-01-01', '2020-01-01');
+    const isBefore = DatesHelper.isBefore('2020-01-01T09:00:00', '2020-01-01T09:00:00');
+
+    expect(isBefore).toBe(false);
+  });
+
+  it('should return false if date1 and date2 are on same day, comparing days', () => {
+    const isBefore = DatesHelper.isBefore('2020-01-01T09:00:00', '2020-01-01T07:00:00', 'd');
 
     expect(isBefore).toBe(false);
   });
@@ -23,19 +29,25 @@ describe('isBefore', () => {
 
 describe('isSameOrBefore', () => {
   it('should return true if date1 is before date2', () => {
-    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', new Date());
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01T09:00:00', '2021-01-11T09:00:00');
 
     expect(isBefore).toBe(true);
   });
 
   it('should return false if date1 is after date2', () => {
-    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', '2019-02-03');
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01T09:00:00', '2019-02-03');
 
     expect(isBefore).toBe(false);
   });
 
+  it('should return true if date1 is after date2 but on same day, comparing days', () => {
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01T11:00:00', '2020-01-01T09:00:00', 'd');
+
+    expect(isBefore).toBe(true);
+  });
+
   it('should return true if date1 is equal to date2', () => {
-    const isBefore = DatesHelper.isSameOrBefore('2020-01-01', '2020-01-01');
+    const isBefore = DatesHelper.isSameOrBefore('2020-01-01T09:00:00', '2020-01-01T09:00:00');
 
     expect(isBefore).toBe(true);
   });

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -20,15 +20,6 @@ describe('getLastVersion', () => {
     expect(UtilsHelper.getLastVersion(versions, 'createdAt')._id).toEqual(1);
   });
 
-  it('should throw an error if version is not an array', () => {
-    expect(() => UtilsHelper.getLastVersion({ toto: 'lala' }, 'createdAt'))
-      .toThrow(new Error('versions must be an array !'));
-  });
-
-  it('should throw an error if the key is not a string', () => {
-    expect(() => UtilsHelper.getLastVersion([{ toto: 'lala' }], 3)).toThrow(new Error('sortKey must be a string !'));
-  });
-
   it('should return null if versions is empty', () => {
     expect(UtilsHelper.getLastVersion([], 'toto')).toBeNull();
   });
@@ -73,11 +64,6 @@ describe('mergeLastVersionWithBaseObject', () => {
 });
 
 describe('getMatchingVersion', () => {
-  it('should throw an error if version is not an array', () => {
-    expect(() => UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', { versions: 'lala' }, 'startDate'))
-      .toThrow(new Error('versions must be an array !'));
-  });
-
   it('should return null if versions is empty', () => {
     expect(UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', { versions: [] }, 'startDate')).toBeNull();
   });
@@ -122,11 +108,6 @@ describe('getMatchingVersion', () => {
 });
 
 describe('getMatchingObject', () => {
-  it('should throw an error if list is not an array', () => {
-    expect(() => UtilsHelper.getMatchingObject('2021-09-21T00:00:00', { versions: 'lala' }, 'startDate'))
-      .toThrow(new Error('List must be an array !'));
-  });
-
   it('should return null if versions is empty', () => {
     expect(UtilsHelper.getMatchingObject('2021-09-21T00:00:00', [], 'startDate')).toBeNull();
   });
@@ -157,11 +138,6 @@ describe('getFixedNumber', () => {
     const result = UtilsHelper.getFixedNumber(10, 2);
     expect(result).toBe('10.00');
   });
-  it('should return an error if number parameter is not a number', () => {
-    expect(() => {
-      UtilsHelper.getFixedNumber('test', 3);
-    }).toThrow(new Error('You must provide a number !'));
-  });
 });
 
 describe('removeSpaces', () => {
@@ -169,11 +145,7 @@ describe('removeSpaces', () => {
     const result = UtilsHelper.removeSpaces('he llo  world  ');
     expect(result).toBe('helloworld');
   });
-  it('should return an error if parameter is not a string', () => {
-    expect(() => {
-      UtilsHelper.removeSpaces(3);
-    }).toThrow(new Error('Parameter must be a string !'));
-  });
+
   it('should return an empty string if parameter is missing', () => {
     const result = UtilsHelper.removeSpaces();
     expect(result).toBe('');

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -10,12 +10,8 @@ const UtilsHelper = require('../../../src/helpers/utils');
 describe('getLastVersion', () => {
   it('should return the last version based on the date key', () => {
     const versions = [
-      { startDate: moment().toISOString(), createdAt: moment().toISOString(), _id: 1 },
-      {
-        startDate: moment().add(1, 'd').toISOString(),
-        createdAt: moment().subtract(1, 'd').toISOString(),
-        _id: 2,
-      },
+      { startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 },
+      { startDate: '2021-09-24T00:00:00', createdAt: '2021-09-18T00:00:00', _id: 2 },
     ];
 
     expect(UtilsHelper.getLastVersion(versions, 'startDate')).toBeDefined();
@@ -38,54 +34,63 @@ describe('getLastVersion', () => {
   });
 
   it('should return the single element is versions only contains one element', () => {
-    const versions = [{ startDate: moment().toISOString(), createdAt: moment().toISOString(), _id: 1 }];
+    const versions = [{ startDate: '2021-09-21T00:00:00', createdAt: '2021-09-21T00:00:00', _id: 1 }];
 
     const result = UtilsHelper.getLastVersion(versions, 'startDate');
+
     expect(result).toBeDefined();
     expect(result._id).toEqual(1);
   });
 });
 
 describe('mergeLastVersionWithBaseObject', () => {
-  it('should merge last version of given object with that same object', () => {
-    const baseObj = { tpp: '123456', frequency: 'once', versions: [{ createdAt: moment().toISOString() }] };
-    const getLastVersionStub = sinon.stub(UtilsHelper, 'getLastVersion');
+  let getLastVersion;
+  beforeEach(() => {
+    getLastVersion = sinon.stub(UtilsHelper, 'getLastVersion');
+  });
+  afterEach(() => {
+    getLastVersion.restore();
+  });
 
-    getLastVersionStub.returns(baseObj.versions[0]);
+  it('should merge last version of given object with that same object', () => {
+    const baseObj = { tpp: '123456', frequency: 'once', versions: [{ createdAt: '2021-09-21T00:00:00' }] };
+
+    getLastVersion.returns(baseObj.versions[0]);
+
     const result = UtilsHelper.mergeLastVersionWithBaseObject(baseObj, 'createdAt');
+
     expect(result).toEqual(expect.objectContaining({ ...baseObj.versions[0], ...omit(baseObj, ['versions']) }));
-    sinon.assert.called(getLastVersionStub);
-    getLastVersionStub.restore();
+    sinon.assert.calledWithExactly(getLastVersion, baseObj.versions, 'createdAt');
   });
 
   it('should throw an error if last version cannot be found', () => {
-    const baseObj = { tpp: '123456', frequency: 'once', versions: [{ createdAt: moment().toISOString() }] };
-    const getLastVersionStub = sinon.stub(UtilsHelper, 'getLastVersion').returns(null);
+    const baseObj = { tpp: '123456', frequency: 'once', versions: [{ createdAt: '2021-09-21T00:00:00' }] };
+    getLastVersion.returns(null);
+
     expect(() => UtilsHelper.mergeLastVersionWithBaseObject(baseObj, 'createdAt'))
       .toThrowError('Unable to find last version from base object !');
-    getLastVersionStub.restore();
   });
 });
 
 describe('getMatchingVersion', () => {
   it('should throw an error if version is not an array', () => {
-    expect(() => UtilsHelper.getMatchingVersion(moment().toISOString(), { versions: 'lala' }, 'startDate'))
+    expect(() => UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', { versions: 'lala' }, 'startDate'))
       .toThrow(new Error('versions must be an array !'));
   });
 
   it('should return null if versions is empty', () => {
-    expect(UtilsHelper.getMatchingVersion(moment().toISOString(), { versions: [] }, 'startDate')).toBeNull();
+    expect(UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', { versions: [] }, 'startDate')).toBeNull();
   });
 
   it('should return the matching version', () => {
     const obj = {
       versions: [
-        { startDate: moment().toISOString(), _id: 1 },
-        { startDate: moment().add(2, 'd').toISOString(), _id: 2 },
+        { startDate: '2021-09-12T00:00:00', _id: 1 },
+        { startDate: '2021-10-21T00:00:00', _id: 2 },
       ],
     };
 
-    const result = UtilsHelper.getMatchingVersion(moment().add(1, 'd').toISOString(), obj, 'startDate');
+    const result = UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', obj, 'startDate');
     expect(result).toBeDefined();
     expect(result.versionId).toEqual(1);
   });
@@ -93,13 +98,13 @@ describe('getMatchingVersion', () => {
   it('should return the last matching version', () => {
     const obj = {
       versions: [
-        { startDate: moment().subtract(1, 'd').toISOString(), _id: 1 },
-        { startDate: moment().toISOString(), _id: 3 },
-        { startDate: moment().add(2, 'd').toISOString(), _id: 2 },
+        { startDate: '2021-09-01T00:00:00', _id: 1 },
+        { startDate: '2021-09-12T00:00:00', _id: 3 },
+        { startDate: '2021-10-21T00:00:00', _id: 2 },
       ],
     };
 
-    const result = UtilsHelper.getMatchingVersion(moment().add(1, 'd').toISOString(), obj, 'startDate');
+    const result = UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', obj, 'startDate');
     expect(result).toBeDefined();
     expect(result.versionId).toEqual(3);
   });
@@ -107,23 +112,23 @@ describe('getMatchingVersion', () => {
   it('should return null if no matching version', () => {
     const obj = {
       versions: [
-        { startDate: moment().toISOString(), endDate: moment().add(5, 'h').toISOString(), _id: 1 },
-        { startDate: moment().add(3, 'd').toISOString(), _id: 2 },
+        { startDate: '2021-09-12T00:00:00', endDate: '2021-09-13T00:00:00', _id: 1 },
+        { startDate: '2021-10-21T00:00:00', _id: 2 },
       ],
     };
 
-    expect(UtilsHelper.getMatchingVersion(moment().add(2, 'd').toISOString(), obj, 'startDate')).toBeNull();
+    expect(UtilsHelper.getMatchingVersion('2021-09-21T00:00:00', obj, 'startDate')).toBeNull();
   });
 });
 
 describe('getMatchingObject', () => {
   it('should throw an error if list is not an array', () => {
-    expect(() => UtilsHelper.getMatchingObject(new Date(), { versions: 'lala' }, 'startDate'))
+    expect(() => UtilsHelper.getMatchingObject('2021-09-21T00:00:00', { versions: 'lala' }, 'startDate'))
       .toThrow(new Error('List must be an array !'));
   });
 
   it('should return null if versions is empty', () => {
-    expect(UtilsHelper.getMatchingObject(new Date(), [], 'startDate')).toBeNull();
+    expect(UtilsHelper.getMatchingObject('2021-09-21T00:00:00', [], 'startDate')).toBeNull();
   });
 
   it('should return the matching object', () => {

--- a/tests/unit/helpers/utils.test.js
+++ b/tests/unit/helpers/utils.test.js
@@ -12,12 +12,8 @@ describe('getLastVersion', () => {
     const versions = [
       { startDate: moment().toISOString(), createdAt: moment().toISOString(), _id: 1 },
       {
-        startDate: moment()
-          .add(1, 'd')
-          .toISOString(),
-        createdAt: moment()
-          .subtract(1, 'd')
-          .toISOString(),
+        startDate: moment().add(1, 'd').toISOString(),
+        createdAt: moment().subtract(1, 'd').toISOString(),
         _id: 2,
       },
     ];
@@ -85,12 +81,7 @@ describe('getMatchingVersion', () => {
     const obj = {
       versions: [
         { startDate: moment().toISOString(), _id: 1 },
-        {
-          startDate: moment()
-            .add(2, 'd')
-            .toISOString(),
-          _id: 2,
-        },
+        { startDate: moment().add(2, 'd').toISOString(), _id: 2 },
       ],
     };
 
@@ -116,23 +107,43 @@ describe('getMatchingVersion', () => {
   it('should return null if no matching version', () => {
     const obj = {
       versions: [
-        {
-          startDate: moment().toISOString(),
-          endDate: moment()
-            .add(5, 'h')
-            .toISOString(),
-          _id: 1,
-        },
-        {
-          startDate: moment()
-            .add(3, 'd')
-            .toISOString(),
-          _id: 2,
-        },
+        { startDate: moment().toISOString(), endDate: moment().add(5, 'h').toISOString(), _id: 1 },
+        { startDate: moment().add(3, 'd').toISOString(), _id: 2 },
       ],
     };
 
     expect(UtilsHelper.getMatchingVersion(moment().add(2, 'd').toISOString(), obj, 'startDate')).toBeNull();
+  });
+});
+
+describe('getMatchingObject', () => {
+  it('should throw an error if list is not an array', () => {
+    expect(() => UtilsHelper.getMatchingObject(new Date(), { versions: 'lala' }, 'startDate'))
+      .toThrow(new Error('List must be an array !'));
+  });
+
+  it('should return null if versions is empty', () => {
+    expect(UtilsHelper.getMatchingObject(new Date(), [], 'startDate')).toBeNull();
+  });
+
+  it('should return the matching object', () => {
+    const obj = [
+      { startDate: '2021-09-12T00:00:00', _id: 1 },
+      { startDate: '2021-10-12T00:00:00', _id: 2 },
+    ];
+
+    const result = UtilsHelper.getMatchingObject('2021-09-21T00:00:00', obj, 'startDate');
+    expect(result).toBeDefined();
+    expect(result._id).toEqual(1);
+  });
+
+  it('should return null if no matching version', () => {
+    const obj = [
+      { startDate: '2021-09-12T00:00:00', endDate: '2021-09-13T00:00:00', _id: 1 },
+      { startDate: '2021-10-12T00:00:00', _id: 2 },
+    ];
+
+    expect(UtilsHelper.getMatchingObject('2021-09-21T00:00:00', obj, 'startDate')).toBeNull();
   });
 });
 

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -28,7 +28,7 @@ describe('formatEvents', () => {
       startDate: '2021-03-12T09:00:00',
     };
 
-    getMatchingObject.returns({ startDate: '2021-02-12T09:00:00' });
+    getMatchingObject.returns({ sector: { startDate: '2021-02-12T09:00:00' } });
 
     const formattedEvent = EventRepository.formatEvent(event);
 

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -1,0 +1,50 @@
+const expect = require('expect');
+const { ObjectID } = require('mongodb');
+const EventRepository = require('../../../src/repositories/EventRepository');
+
+describe('formatEvents', () => {
+  it('should format event', () => {
+    const event = { _id: new ObjectID(), internalHour: new ObjectID() };
+    expect(EventRepository.formatEvent(event)).toEqual(event);
+  });
+
+  it('should format event auxiliary', () => {
+    const event = {
+      _id: new ObjectID(),
+      internalHour: new ObjectID(),
+      auxiliary: { sectorHistories: [{ startDate: '2021-02-12T09:00:00' }, { startDate: '2021-01-12T09:00:00' }] },
+      startDate: '2021-03-12T09:00:00',
+    };
+
+    const formattedEvent = EventRepository.formatEvent(event);
+
+    expect(formattedEvent).toEqual({
+      _id: event._id,
+      internalHour: event.internalHour,
+      startDate: '2021-03-12T09:00:00',
+      auxiliary: { sector: { startDate: '2021-02-12T09:00:00' } },
+    });
+  });
+
+  it('should format event histories', () => {
+    const subId = new ObjectID();
+    const otherSubId = new ObjectID();
+    const event = {
+      _id: new ObjectID(),
+      internalHour: new ObjectID(),
+      startDate: '2021-03-12T09:00:00',
+      customer: { subscriptions: [{ _id: subId }, { _id: otherSubId }] },
+      subscription: subId,
+    };
+
+    const formattedEvent = EventRepository.formatEvent(event);
+
+    expect(formattedEvent).toEqual({
+      _id: event._id,
+      internalHour: event.internalHour,
+      startDate: '2021-03-12T09:00:00',
+      customer: { subscriptions: [{ _id: subId }, { _id: otherSubId }] },
+      subscription: { _id: subId },
+    });
+  });
+});

--- a/tests/unit/repositories/EventRepositories.test.js
+++ b/tests/unit/repositories/EventRepositories.test.js
@@ -26,7 +26,7 @@ describe('formatEvents', () => {
     });
   });
 
-  it('should format event histories', () => {
+  it('should format event subscription', () => {
     const subId = new ObjectID();
     const otherSubId = new ObjectID();
     const event = {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : Client

- Périmetre roles : Auxiliaire / coach / aidant

- Cas d'usage : sur le planning auxiliaire et bénéficiaire, j'ai accès au évènements plus rapidement

Faire un test pour afficher tous les auxiliaires de la structure sur la branche dev et sur cette branche
Tester :
- le passage d'un évènement en a affecter
- l'affectation d'un évènement
- Creation d'une intervention en a affecter
