### PR TITLE
Com 2094 clean

### DIFF
--- a/src/helpers/customers.js
+++ b/src/helpers/customers.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 const has = require('lodash/has');
 const get = require('lodash/get');
 const keyBy = require('lodash/keyBy');
+const omit = require('lodash/omit');
 const Customer = require('../models/Customer');
 const Event = require('../models/Event');
 const Drive = require('../models/Google/Drive');
@@ -155,29 +156,25 @@ exports.updateCustomerEvents = async (customerId, payload) => {
 const formatPayload = async (customerId, customerPayload, company) => {
   if (has(customerPayload, 'payment.iban')) return exports.formatPaymentPayload(customerId, customerPayload, company);
 
-  return { $set: flat(customerPayload, { safe: true }) };
+  return { $set: flat(omit(customerPayload, 'referent'), { safe: true }) };
 };
 
-exports.updateCustomer = async (customerId, customerPayload, credentials) => {
+exports.updateCustomer = async (customerId, payload, credentials) => {
   const { company } = credentials;
 
-  if (customerPayload.stoppedAt) {
-    await EventsHelper.deleteCustomerEvents(customerId, customerPayload.stoppedAt, null, credentials);
+  if (payload.stoppedAt) await EventsHelper.deleteCustomerEvents(customerId, payload.stoppedAt, null, credentials);
+
+  if (has(payload, 'referent')) {
+    await ReferentHistoriesHelper.updateCustomerReferent(customerId, payload.referent, company);
   }
 
-  if (has(customerPayload, 'referent')) {
-    await ReferentHistoriesHelper.updateCustomerReferent(customerId, customerPayload.referent, company);
-
-    return Customer.findOne({ _id: customerId }).lean();
+  if (has(payload, 'contact.primaryAddress') || has(payload, 'contact.secondaryAddress')) {
+    await exports.updateCustomerEvents(customerId, payload);
   }
 
-  if (has(customerPayload, 'contact.primaryAddress') || has(customerPayload, 'contact.secondaryAddress')) {
-    await exports.updateCustomerEvents(customerId, customerPayload);
-  }
+  const formattedPayload = await formatPayload(customerId, payload, company);
 
-  const payload = await formatPayload(customerId, customerPayload, company);
-
-  return Customer.findOneAndUpdate({ _id: customerId }, payload, { new: true }).lean();
+  return Customer.findOneAndUpdate({ _id: customerId }, formattedPayload, { new: true }).lean();
 };
 
 exports.createCustomer = async (payload, credentials) => {

--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -22,12 +22,6 @@ exports.dayDiff = (date1, date2) => {
   return diff || 0;
 };
 
-exports.dayDiffRegardlessOfHour = (date1, date2) => {
-  const milliSecondsDiff = this.getStartOfDay(date1) - this.getStartOfDay(date2);
-
-  return milliSecondsDiff / 1000 / 60 / 60 / 24;
-};
-
 exports.addDays = (date, days) => {
   const newDate = new Date(date);
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -21,12 +21,11 @@ const Repetition = require('../models/Repetition');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
-const DatesHelper = require('./dates');
 
 momentRange.extendMoment(moment);
 
 exports.formatRepeatedPayload = async (event, sector, momentDay) => {
-  const step = DatesHelper.dayDiffRegardlessOfHour(momentDay, event.startDate);
+  const step = momentDay.diff(event.startDate, 'd');
   let payload = {
     ...cloneDeep(omit(event, '_id')), // cloneDeep necessary to copy repetition
     startDate: moment(event.startDate).add(step, 'd'),
@@ -41,9 +40,9 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
   return new Event(payload);
 };
 
-exports.createRepetitionsEveryDay = async (payload, sector, startDate = null, endDate = null) => {
-  const start = startDate || moment(payload.startDate).add(1, 'd');
-  const end = endDate || moment(payload.startDate).add(90, 'd');
+exports.createRepetitionsEveryDay = async (payload, sector) => {
+  const start = moment(payload.startDate).add(1, 'd');
+  const end = moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -20,7 +20,6 @@ const FundingsHelper = require('../../../src/helpers/fundings');
 const GDriveStorageHelper = require('../../../src/helpers/gDriveStorage');
 const SubscriptionsHelper = require('../../../src/helpers/subscriptions');
 const EventsHelper = require('../../../src/helpers/events');
-const EventsRepetitionHelper = require('../../../src/helpers/eventsRepetition');
 const EventRepository = require('../../../src/repositories/EventRepository');
 const SinonMongoose = require('../sinonMongoose');
 
@@ -534,13 +533,9 @@ describe('updateCustomer', () => {
   let formatPaymentPayload;
   let updateCustomerEvents;
   let updateCustomerReferent;
-  let deleteListEvent;
-  let countDocumentsEventHistory;
-  let findRepetition;
+  let deleteCustomerEvents;
   let findOneUser;
-  let createRepetitionsEveryDay;
   let nowStub;
-  let deleteOneRepetition;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
   beforeEach(() => {
     findOneCustomer = sinon.stub(Customer, 'findOne');
@@ -548,13 +543,9 @@ describe('updateCustomer', () => {
     formatPaymentPayload = sinon.stub(CustomerHelper, 'formatPaymentPayload');
     updateCustomerEvents = sinon.stub(CustomerHelper, 'updateCustomerEvents');
     updateCustomerReferent = sinon.stub(ReferentHistoriesHelper, 'updateCustomerReferent');
-    deleteListEvent = sinon.stub(EventsHelper, 'deleteCustomerEvents');
-    countDocumentsEventHistory = sinon.stub(EventHistory, 'countDocuments');
-    findRepetition = sinon.stub(Repetition, 'find');
+    deleteCustomerEvents = sinon.stub(EventsHelper, 'deleteCustomerEvents');
     findOneUser = sinon.stub(User, 'findOne');
-    createRepetitionsEveryDay = sinon.stub(EventsRepetitionHelper, 'createRepetitionsEveryDay');
     nowStub = sinon.stub(Date, 'now');
-    deleteOneRepetition = sinon.stub(Repetition, 'deleteOne');
   });
   afterEach(() => {
     findOneCustomer.restore();
@@ -562,13 +553,9 @@ describe('updateCustomer', () => {
     formatPaymentPayload.restore();
     updateCustomerEvents.restore();
     updateCustomerReferent.restore();
-    deleteListEvent.restore();
-    countDocumentsEventHistory.restore();
-    findRepetition.restore();
+    deleteCustomerEvents.restore();
     findOneUser.restore();
-    createRepetitionsEveryDay.restore();
     nowStub.restore();
-    deleteOneRepetition.restore();
   });
 
   it('should unset the referent of a customer', async () => {
@@ -585,7 +572,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(findOneAndUpdateCustomer);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(updateCustomerReferent, customer._id, payload.referent, credentials.company);
     SinonMongoose.calledWithExactly(
@@ -616,7 +603,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(findOneCustomer);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
     SinonMongoose.calledWithExactly(
@@ -656,7 +643,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(findOneCustomer);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
     SinonMongoose.calledWithExactly(
@@ -678,7 +665,7 @@ describe('updateCustomer', () => {
     sinon.assert.calledWithExactly(updateCustomerEvents, customerId, payload);
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -705,7 +692,7 @@ describe('updateCustomer', () => {
     sinon.assert.calledWithExactly(updateCustomerEvents, customerId, payload);
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -732,7 +719,7 @@ describe('updateCustomer', () => {
     sinon.assert.calledWithExactly(updateCustomerEvents, customerId, payload);
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -764,7 +751,7 @@ describe('updateCustomer', () => {
     sinon.assert.calledWithExactly(updateCustomerEvents, customerId, payload);
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -778,31 +765,19 @@ describe('updateCustomer', () => {
     );
   });
 
-  it('should deleted customer\'s events + repetition but not create events when customer is stopped'
-    + 'but last event created by repetition is after stopping date', async () => {
+  it('should deleted customer\'s events when customer is stopped', async () => {
     const customerId = new ObjectID();
-    const repetitions = [{
-      type: 'intervention',
-      customer: customerId,
-      frequency: 'every_day',
-      parentId: new ObjectID(),
-      startDate: '2021-07-01T09:00:00Z',
-      endDate: '2021-07-01T10:00:00Z',
-    }];
     const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
     const payload = { stoppedAt: '2019-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
 
     findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
-    countDocumentsEventHistory.returns(0);
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions], ['lean']));
     nowStub.returns('2021-06-25T16:34:04.144Z');
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
     expect(result).toBe(customerResult);
-    sinon.assert.calledOnceWithExactly(deleteListEvent, customerId, '2019-06-25T16:34:04.144Z', null, credentials);
+    sinon.assert.calledOnceWithExactly(deleteCustomerEvents, customerId, '2019-06-25T16:34:04.144Z', null, credentials);
     sinon.assert.notCalled(findOneUser);
-    sinon.assert.calledOnceWithExactly(deleteOneRepetition, { _id: repetitions[0]._id });
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -816,110 +791,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
-  });
-
-  it('should deleted customer\'s events + repetition and create events when customer is stopped'
-    + 'and last event created by repetition is before stopping date', async () => {
-    const auxiliaryId = new ObjectID();
-    const customerId = new ObjectID();
-    const repetitions = [
-      {
-        _id: new ObjectID(),
-        type: 'intervention',
-        customer: customerId,
-        frequency: 'every_day',
-        parentId: new ObjectID(),
-        startDate: '2019-12-01T09:00:00Z',
-        endDate: '2019-12-01T10:00:00Z',
-        auxiliary: auxiliaryId,
-      },
-      {
-        _id: new ObjectID(),
-        type: 'intervention',
-        customer: customerId,
-        frequency: 'every_day',
-        parentId: new ObjectID(),
-        startDate: '2021-12-25T09:00:00Z',
-        endDate: '2021-12-25T10:00:00Z',
-        sector: new ObjectID(),
-      },
-    ];
-    const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
-    const payload = { stoppedAt: '2022-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
-    const auxiliary = { sector: new ObjectID() };
-
-    findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['populate', 'lean']));
-    countDocumentsEventHistory.returns(0);
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions], ['lean']));
-    findOneUser.returns(SinonMongoose.stubChainedQueries([auxiliary], ['populate', 'lean']));
-    nowStub.returns('2021-06-25T16:34:04.144Z');
-
-    const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
-
-    expect(result).toBe(customerResult);
-    sinon.assert.calledOnceWithExactly(deleteListEvent, customerId, '2022-06-25T16:34:04.144Z', null, credentials);
-    SinonMongoose.calledWithExactly(
-      findOneUser,
-      [
-        { query: 'findOneUser', args: [{ _id: auxiliaryId }] },
-        {
-          query: 'populate',
-          args: [{ path: 'sector', select: '_id sector', match: { company: credentials.company._id } }],
-        },
-        { query: 'lean', args: [{ autopopulate: true, virtuals: true }] },
-      ]
-    );
-    sinon.assert.calledWithExactly(
-      createRepetitionsEveryDay.getCall(0),
-      repetitions[0],
-      auxiliary.sector,
-      new Date('2021-09-24T16:34:04.144Z'),
-      '2022-06-25T16:34:04.144Z'
-    );
-    sinon.assert.calledWithExactly(
-      createRepetitionsEveryDay.getCall(1),
-      repetitions[1],
-      repetitions[1].sector,
-      new Date('2022-03-26T09:00:00.000Z'),
-      '2022-06-25T16:34:04.144Z'
-    );
-    sinon.assert.calledWithExactly(deleteOneRepetition.getCall(0), { _id: repetitions[0]._id });
-    sinon.assert.calledWithExactly(deleteOneRepetition.getCall(1), { _id: repetitions[1]._id });
-    SinonMongoose.calledWithExactly(
-      findOneAndUpdateCustomer,
-      [
-        {
-          query: 'findOneAndUpdate',
-          args: [{ _id: customerId }, { $set: flat(payload, { safe: true }) }, { new: true }],
-        },
-        { query: 'lean' },
-      ]
-    );
-    sinon.assert.notCalled(formatPaymentPayload);
-    sinon.assert.notCalled(updateCustomerEvents);
-    sinon.assert.notCalled(updateCustomerReferent);
-  });
-
-  it('should not delete events on stop if some are timeStamped', async () => {
-    try {
-      const customerId = new ObjectID();
-      const payload = { stoppedAt: '2021-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
-      const customerResult = { identity: { firstname: 'Molly', lastname: 'LeGrosChat' } };
-
-      countDocumentsEventHistory.returns(1);
-      findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
-
-      await CustomerHelper.updateCustomer(customerId, payload, credentials);
-    } catch (e) {
-      expect(e.output.statusCode).toEqual(409);
-    } finally {
-      sinon.assert.notCalled(deleteListEvent);
-      sinon.assert.notCalled(findOneUser);
-      sinon.assert.notCalled(findOneAndUpdateCustomer);
-      sinon.assert.notCalled(formatPaymentPayload);
-      sinon.assert.notCalled(updateCustomerEvents);
-      sinon.assert.notCalled(updateCustomerReferent);
-    }
   });
 
   it('should update a customer', async () => {
@@ -935,7 +806,7 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
-    sinon.assert.notCalled(deleteListEvent);
+    sinon.assert.notCalled(deleteCustomerEvents);
     sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,

--- a/tests/unit/helpers/customers.test.js
+++ b/tests/unit/helpers/customers.test.js
@@ -533,8 +533,6 @@ describe('updateCustomer', () => {
   let updateCustomerEvents;
   let updateCustomerReferent;
   let deleteCustomerEvents;
-  let findOneUser;
-  let nowStub;
   const credentials = { company: { _id: new ObjectID(), prefixNumber: 101 } };
   beforeEach(() => {
     findOneAndUpdateCustomer = sinon.stub(Customer, 'findOneAndUpdate');
@@ -542,8 +540,6 @@ describe('updateCustomer', () => {
     updateCustomerEvents = sinon.stub(CustomerHelper, 'updateCustomerEvents');
     updateCustomerReferent = sinon.stub(ReferentHistoriesHelper, 'updateCustomerReferent');
     deleteCustomerEvents = sinon.stub(EventsHelper, 'deleteCustomerEvents');
-    findOneUser = sinon.stub(User, 'findOne');
-    nowStub = sinon.stub(Date, 'now');
   });
   afterEach(() => {
     findOneAndUpdateCustomer.restore();
@@ -551,8 +547,6 @@ describe('updateCustomer', () => {
     updateCustomerEvents.restore();
     updateCustomerReferent.restore();
     deleteCustomerEvents.restore();
-    findOneUser.restore();
-    nowStub.restore();
   });
 
   it('should unset the referent of a customer', async () => {
@@ -569,7 +563,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(updateCustomerReferent, customer._id, payload.referent, credentials.company);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -602,7 +595,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -641,7 +633,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     sinon.assert.calledOnceWithExactly(formatPaymentPayload, customerId, payload, credentials.company);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
@@ -663,7 +654,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -690,7 +680,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -717,7 +706,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -749,7 +737,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(formatPaymentPayload);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -768,13 +755,11 @@ describe('updateCustomer', () => {
     const payload = { stoppedAt: '2019-06-25T16:34:04.144Z', stopReason: 'hospitalization' };
 
     findOneAndUpdateCustomer.returns(SinonMongoose.stubChainedQueries([customerResult], ['lean']));
-    nowStub.returns('2021-06-25T16:34:04.144Z');
 
     const result = await CustomerHelper.updateCustomer(customerId, payload, credentials);
 
     expect(result).toBe(customerResult);
     sinon.assert.calledOnceWithExactly(deleteCustomerEvents, customerId, '2019-06-25T16:34:04.144Z', null, credentials);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [
@@ -804,7 +789,6 @@ describe('updateCustomer', () => {
     sinon.assert.notCalled(updateCustomerEvents);
     sinon.assert.notCalled(updateCustomerReferent);
     sinon.assert.notCalled(deleteCustomerEvents);
-    sinon.assert.notCalled(findOneUser);
     SinonMongoose.calledWithExactly(
       findOneAndUpdateCustomer,
       [

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -81,44 +81,6 @@ describe('isSameOrAfter', () => {
   });
 });
 
-describe('dayDiffRegardlessOfHour', () => {
-  it('should return number of days between two dates regardless of hours', () => {
-    const date1 = '2021-01-05T10:04:34';
-    const date2 = '2021-01-01T09:15:24';
-
-    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
-
-    expect(result).toBe(4);
-  });
-
-  it('should return number of days between two dates regardless of hours', () => {
-    const date1 = '2021-01-05T10:04:34';
-    const date2 = '2021-01-04T11:04:54';
-
-    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
-
-    expect(result).toBe(1);
-  });
-
-  it('should return number of days between two dates regardless of hours', () => {
-    const date1 = '2021-01-05T10:04:34';
-    const date2 = '2021-01-05T11:04:54';
-
-    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
-
-    expect(result).toBe(0);
-  });
-
-  it('should return number of days between two dates regardless of hours', () => {
-    const date1 = '2021-01-04T10:04:34';
-    const date2 = '2021-01-05T11:04:54';
-
-    const result = DatesHelper.dayDiffRegardlessOfHour(date1, date2);
-
-    expect(result).toBe(-1);
-  });
-});
-
 describe('dayDiff', () => {
   it('should return number of days between two dates', () => {
     const date1 = '2021-01-05T10:04:34';


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : 

- Périmetre roles : 

- Cas d'usage : 
