### PR TITLE
Com 2094 - script

### DIFF
--- a/src/helpers/email.js
+++ b/src/helpers/email.js
@@ -35,12 +35,12 @@ exports.completeBillScriptEmail = async (sentNb, emails = null) => {
   return exports.sendEmail(mailOptions);
 };
 
-exports.completeEventRepScriptEmail = async (nb, repIds = null) => {
+exports.completeEventRepScriptEmail = async (nb, deletedRepetitions, repIds = null) => {
   const mailOptions = {
     from: `Compani <${SENDER_MAIL}>`,
     to: process.env.TECH_EMAILS,
     subject: 'Script traitement répétitions',
-    html: EmailOptionsHelper.completeEventRepScriptEmailBody(nb, repIds),
+    html: EmailOptionsHelper.completeEventRepScriptEmailBody(nb, deletedRepetitions, repIds),
   };
 
   return exports.sendEmail(mailOptions);

--- a/src/helpers/emailOptions.js
+++ b/src/helpers/emailOptions.js
@@ -69,11 +69,16 @@ const completeBillScriptEmailBody = (sentNb, emails) => {
   return body;
 };
 
-const completeEventRepScriptEmailBody = (nb, repIds) => {
+const completeEventRepScriptEmailBody = (nb, deletedRepetitions, repIds) => {
   let body = `<p>Script correctement exécuté. ${nb} répétitions traitées.</p>`;
   if (repIds.length) {
     body = body.concat(`<p>Répétitions à traiter manuellement ${repIds.join()}</p>`);
   }
+
+  for (const repetition of deletedRepetitions) {
+    body = body.concat(`<p>Répétition supprimée : ${repetition._id}, pour le bénéficiaire : ${repetition.customer._id}</p>`);
+  }
+
   return body;
 };
 

--- a/tests/unit/jobs/eventRepetitions.test.js
+++ b/tests/unit/jobs/eventRepetitions.test.js
@@ -61,7 +61,7 @@ describe('method', () => {
     it(`should create a J+90 event for ${freq.type} repetition object`, async () => {
       const companyId = new ObjectID();
 
-      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['populate', 'lean']));
+      findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
       findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
       const futureEvent = new Event({
@@ -118,7 +118,7 @@ describe('method', () => {
     }];
 
     findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions], ['populate', 'lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions]));
 
     const result = await eventRepetitions.method(server);
 
@@ -165,7 +165,7 @@ describe('method', () => {
     ];
     const companyId = new ObjectID();
 
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions], ['populate', 'lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetitions]));
     findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
     const futureEvent = new Event({
@@ -219,7 +219,7 @@ describe('method', () => {
 
     const companyId = new ObjectID();
 
-    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition], ['populate', 'lean']));
+    findRepetition.returns(SinonMongoose.stubChainedQueries([repetition]));
     findCompany.returns(SinonMongoose.stubChainedQueries([[{ _id: companyId }]], ['lean']));
 
     formatEventBasedOnRepetitionStub.returns(Promise.reject(error));


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- ~~Tests intégrations :~~
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### ~~FONCTIONNALITÉS APPS MOBILES~~
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### ~~CONSTANTES ET VARIABLE D'ENV~~
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : le script 🤷‍♂️ 

- Cas d'usage : 
Modification du script eventRepetition qui tourne chaque soir et qui créé les évènements basés sur les répétitions.
Désormais, si le script doit créer un évènement après la date d'arrêt du bénéficiaire, il ne le fait pas et supprime les répétitions du bénéficiaire

A TESTER :
- Vérifier qu'une répétition chaque jour est encore bien crée par le script
- Pour cela on pourra passer par Postman > Scripts > event repetitions script et changer la date pour la date du jour
- Vérifier qu'une répétition chaque jour est bien supprimée par le script si on lance le script la date d'après l'arrêt du bénéficiaire
- Pour ça on peut créer un bénéficiaire ou bien en prendre un existant
- Faire de même pour une répétition tous les jours de la semaine, toutes les semaines, toutes les deux semaines
- Vérifier que toutes les répétitions et évènements commençant après la date d'arrêt sont bien supprimés
- Vérifier qu'on a le comportement souhaité pour une répétition qui commence avant la date d'arrêt mais finie après
- vérifier le contenu de l'email envoyé (en appelant `completeEventRepScriptEmail` à la fin du script et console.log body dans `completeEventRepScriptEmailBody`)