### PR TITLE
COM-2179 - remove getStartOfDay and getEndOfDay

### DIFF
--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -1,9 +1,11 @@
+const moment = require('moment');
+
 exports.isBefore = (date1, date2, ref = '') => {
   let formattedDate1 = date1;
   let formattedDate2 = date2;
   if (ref === 'd') {
-    formattedDate1 = exports.getStartOfDay(date1);
-    formattedDate2 = exports.getStartOfDay(date2);
+    formattedDate1 = moment(date1).startOf('d').toDate();
+    formattedDate2 = moment(date2).startOf('d').toDate();
   }
 
   return new Date(formattedDate1) < new Date(formattedDate2);
@@ -13,8 +15,8 @@ exports.isSameOrBefore = (date1, date2, ref = '') => {
   let formattedDate1 = date1;
   let formattedDate2 = date2;
   if (ref === 'd') {
-    formattedDate1 = exports.getStartOfDay(date1);
-    formattedDate2 = exports.getStartOfDay(date2);
+    formattedDate1 = moment(date1).startOf('d').toDate();
+    formattedDate2 = moment(date2).startOf('d').toDate();
   }
 
   return new Date(formattedDate1) <= new Date(formattedDate2);
@@ -25,10 +27,6 @@ exports.isAfter = (date1, date2) => new Date(date1) > new Date(date2);
 exports.isSameOrAfter = (date1, date2) => new Date(date1) >= new Date(date2);
 
 exports.diff = (date1, date2) => new Date(date1) - new Date(date2);
-
-exports.getStartOfDay = date => (new Date(date)).setHours(0, 0, 0, 0);
-
-exports.getEndOfDay = date => (new Date(date)).setHours(23, 59, 59, 999);
 
 exports.dayDiff = (date1, date2) => {
   const milliSecondsDiff = new Date(date1) - new Date(date2);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -21,7 +21,6 @@ const {
 } = require('./constants');
 const translate = require('./translate');
 const UtilsHelper = require('./utils');
-const DatesHelper = require('./dates');
 const EventHistoriesHelper = require('./eventHistories');
 const EventsValidationHelper = require('./eventsValidation');
 const EventsRepetitionHelper = require('./eventsRepetition');
@@ -146,9 +145,9 @@ exports.getListQuery = (query, credentials) => {
     rules.push({ customer: { $in: customerCondition } });
   }
 
-  if (startDate) rules.push({ endDate: { $gt: new Date(DatesHelper.getStartOfDay(startDate)) } });
+  if (startDate) rules.push({ endDate: { $gt: moment(startDate).startOf('d').toDate() } });
 
-  if (endDate) rules.push({ startDate: { $lt: new Date(DatesHelper.getEndOfDay(endDate)) } });
+  if (endDate) rules.push({ startDate: { $lt: moment(endDate).endOf('d').toDate() } });
 
   if (Object.keys(query).includes('isCancelled')) rules.push({ isCancelled });
 

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -1,6 +1,7 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
 const cloneDeep = require('lodash/cloneDeep');
+const moment = require('moment');
 const Event = require('../../models/Event');
 const CreditNote = require('../../models/CreditNote');
 const Customer = require('../../models/Customer');
@@ -22,7 +23,6 @@ const {
   ILLNESS,
   INTERVENTION,
 } = require('../../helpers/constants');
-const DatesHelper = require('../../helpers/dates');
 
 const { language } = translate;
 
@@ -201,7 +201,7 @@ exports.authorizeTimeStamping = async (req) => {
     _id: req.params._id,
     type: INTERVENTION,
     auxiliary: get(req, 'auth.credentials._id'),
-    startDate: { $gte: DatesHelper.getStartOfDay(new Date()), $lte: DatesHelper.getEndOfDay(new Date()) },
+    startDate: { $gte: moment().startOf('d').toDate(), $lte: moment().endOf('d').toDate() },
   }).lean();
   if (!event) throw Boom.notFound();
 

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -12,7 +12,6 @@ const EventHelper = require('../../../src/helpers/events');
 const DistanceMatrixHelper = require('../../../src/helpers/distanceMatrix');
 const ContractHelper = require('../../../src/helpers/contracts');
 const UtilsHelper = require('../../../src/helpers/utils');
-const DatesHelper = require('../../../src/helpers/dates');
 const EventsRepetitionHelper = require('../../../src/helpers/eventsRepetition');
 const EventHistoriesHelper = require('../../../src/helpers/eventHistories');
 const EventsValidationHelper = require('../../../src/helpers/eventsValidation');
@@ -1422,16 +1421,6 @@ describe('unassignConflictInterventions', () => {
 });
 
 describe('getListQuery', () => {
-  let getStartOfDay;
-  let getEndOfDay;
-  beforeEach(() => {
-    getStartOfDay = sinon.stub(DatesHelper, 'getStartOfDay');
-    getEndOfDay = sinon.stub(DatesHelper, 'getEndOfDay');
-  });
-  afterEach(() => {
-    getStartOfDay.restore();
-    getEndOfDay.restore();
-  });
   it('should return only company in rules if query is empty', () => {
     const query = {};
     const credentials = { company: { _id: new ObjectID() } };
@@ -1439,8 +1428,6 @@ describe('getListQuery', () => {
     const listQuery = EventHelper.getListQuery(query, credentials);
 
     expect(listQuery).toEqual({ $and: [{ company: credentials.company._id }] });
-    sinon.assert.notCalled(getStartOfDay);
-    sinon.assert.notCalled(getEndOfDay);
   });
 
   it('should return all conditions in rules that are in query', () => {
@@ -1455,9 +1442,6 @@ describe('getListQuery', () => {
     };
     const credentials = { company: { _id: new ObjectID() } };
 
-    getStartOfDay.returns('2021-04-27T22:00:00.000Z');
-    getEndOfDay.returns('2021-04-28T21:59:59.999Z');
-
     const listQuery = EventHelper.getListQuery(query, credentials);
 
     expect(listQuery).toEqual({
@@ -1471,8 +1455,6 @@ describe('getListQuery', () => {
         { isCancelled: false },
       ],
     });
-    sinon.assert.calledOnceWithExactly(getStartOfDay, '2021-04-28T10:00:00.000Z');
-    sinon.assert.calledOnceWithExactly(getEndOfDay, '2021-04-28T12:00:00.000Z');
   });
 });
 


### PR DESCRIPTION
Correction d'un bug remonté par Romain : sur la page d'horodatage, je recupere les evenements de la veille et d'aujourd'hui
C'est un soui qui vient de l'absence de gestion de timezone sur un newDate classique + le serveur de la prod est sur l'UTC

Je suis donc revenue sur l'utilisation de moment -> il faudra changer ca quand on aura choisi la librairies de remplacement