### PR TITLE
Com 2129 - userCompany

### DIFF
--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -157,7 +157,7 @@ exports.checkEventCreationOrUpdate = async (req) => {
 
   if (req.payload.auxiliary) {
     const auxiliary = await UserCompany.countDocuments(({ user: req.payload.auxiliary, company: companyId }));
-    if (!auxiliary) throw Boom.forbidden();
+    if (!auxiliary) throw Boom.notFound();
   }
 
   if (req.payload.sector) {

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -6,7 +6,6 @@ const CreditNote = require('../../models/CreditNote');
 const Customer = require('../../models/Customer');
 const ThirdPartyPayer = require('../../models/ThirdPartyPayer');
 const Sector = require('../../models/Sector');
-const User = require('../../models/User');
 const EventHistory = require('../../models/EventHistory');
 const InternalHour = require('../../models/InternalHour');
 const UserCompany = require('../../models/UserCompany');
@@ -157,7 +156,7 @@ exports.checkEventCreationOrUpdate = async (req) => {
   }
 
   if (req.payload.auxiliary) {
-    const auxiliary = await User.countDocuments(({ _id: req.payload.auxiliary, company: companyId }));
+    const auxiliary = await UserCompany.countDocuments(({ user: req.payload.auxiliary, company: companyId }));
     if (!auxiliary) throw Boom.forbidden();
   }
 

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -988,7 +988,7 @@ describe('POST /events', () => {
       expect(response.statusCode).toEqual(403);
     });
 
-    it('should return a 403 if auxiliary is not from the same company', async () => {
+    it('should return a 404 if auxiliary is not from the same company', async () => {
       const payload = {
         type: INTERVENTION,
         startDate: '2019-01-23T10:00:00',
@@ -1012,7 +1012,7 @@ describe('POST /events', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(404);
     });
 
     it('should return a 403 if internalHour is not from the same company', async () => {
@@ -1383,7 +1383,7 @@ describe('PUT /events/{_id}', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return a 403 if auxiliary is not from the same company', async () => {
+    it('should return a 404 if auxiliary is not from the same company', async () => {
       const event = eventsList[0];
       const payload = {
         startDate: '2019-01-23T10:00:00.000Z',
@@ -1398,7 +1398,7 @@ describe('PUT /events/{_id}', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     it('should return a 404 error as event is not found', async () => {


### PR DESCRIPTION
Refacto du lien structure/utilisateur - Prehandler création / mise à jour d'un évènement affecté

A tester sur la webApp: 
- Création d’une intervention
- Affectation d’une intervention à un auxiliaire (dans la modale  - planning auxiliaire)
- Affectation d’une intervention à un auxiliaire (dans la modale  - planning bénéficiaire)
- Affectation d’une intervention à un auxiliaire (drag&drop)
- Désaffectation d’une intervention pour un auxiliaire (dans la modale  - planning auxiliaire)
- Désaffectation d’une intervention pour un auxiliaire (drag&drop)
- Changement d’auxiliaire pour une intervention (dans la modale - planning auxiliaire)
- Changement d’auxiliaire pour une intervention (dans la modale - planning bénéficiaire)
- Changement d’auxiliaire pour une intervention (drag&drop)

A tester avec Postman: 
- Commenter le champ `company` du modele User
- Dans le service: /src/helpers/authorization : 
      - importer const UserCompany = require('../models/UserCompany’);
      - dans validate:  
           - commenter:` .populate({ path: 'company' })`
           - ajouter: const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();
           - transformer tous les user.company en `userCompany.company` => pour userRights (l.41) et credentials.company (l.58) plutôt mettre`get(userCompany, 'company') || null`
- Créer un événement affecté a un auxiliaire
- Récupérer l’id de l’evenement (par exemple en faisant appel a la route GET /events )
- Se connecter ETQ admin,
- Tester la route PUT /events/{eventId} avec l’id d’un autre auxiliaire 
- Tester la route POST /events avec le payload: 

Si coach ou client admin de la même structure que la structure —> Evènement mis à jour/ Événement créé
Si coach ou client admin d’une autre structure que l’auxiliaire —> 403
