### PR TITLE
Fix events

### DIFF
--- a/src/helpers/dates.js
+++ b/src/helpers/dates.js
@@ -22,9 +22,27 @@ exports.isSameOrBefore = (date1, date2, ref = '') => {
   return new Date(formattedDate1) <= new Date(formattedDate2);
 };
 
-exports.isAfter = (date1, date2) => new Date(date1) > new Date(date2);
+exports.isAfter = (date1, date2, ref = '') => {
+  let formattedDate1 = date1;
+  let formattedDate2 = date2;
+  if (ref === 'd') {
+    formattedDate1 = moment(date1).startOf('d').toDate();
+    formattedDate2 = moment(date2).startOf('d').toDate();
+  }
 
-exports.isSameOrAfter = (date1, date2) => new Date(date1) >= new Date(date2);
+  return new Date(formattedDate1) > new Date(formattedDate2);
+};
+
+exports.isSameOrAfter = (date1, date2, ref = '') => {
+  let formattedDate1 = date1;
+  let formattedDate2 = date2;
+  if (ref === 'd') {
+    formattedDate1 = moment(date1).startOf('d').toDate();
+    formattedDate2 = moment(date2).startOf('d').toDate();
+  }
+
+  return new Date(formattedDate1) >= new Date(formattedDate2);
+};
 
 exports.diff = (date1, date2) => new Date(date1) - new Date(date2);
 

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -40,7 +40,7 @@ exports.getMatchingObject = (date, list, dateKey) => {
   if (list.length === 0) return null;
 
   const filteredAndSortedList = list
-    .filter(h => DatesHelper.isBefore(h.startDate, date, 'd') &&
+    .filter(h => DatesHelper.isSameOrBefore(h.startDate, date, 'd') &&
       (!h.endDate || DatesHelper.isSameOrAfter(h.endDate, date, 'd')))
     .sort(DatesHelper.descendingSort(dateKey));
   if (!filteredAndSortedList.length) return null;

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -71,6 +71,24 @@ describe('isAfter', () => {
 
     expect(isAfter).toBe(false);
   });
+
+  it('should return true if date1 is after date2 comparing days', () => {
+    const isAfter = DatesHelper.isAfter(new Date('2020-12-25T12:00:00.000Z'), '2020-12-23T16:00:00.000Z', 'd');
+
+    expect(isAfter).toBe(true);
+  });
+
+  it('should return false if date1 is before date2 comparing days', () => {
+    const isAfter = DatesHelper.isAfter('2020-12-25T12:00:00.000Z', '2020-12-27T16:00:00.000Z', 'd');
+
+    expect(isAfter).toBe(false);
+  });
+
+  it('should return false if date1 is equal to date2 comparing days', () => {
+    const isAfter = DatesHelper.isAfter('2020-12-25T12:00:00.000Z', '2020-12-25T09:00:00.000Z', 'd');
+
+    expect(isAfter).toBe(false);
+  });
 });
 
 describe('isSameOrAfter', () => {
@@ -88,6 +106,24 @@ describe('isSameOrAfter', () => {
 
   it('should return true if date1 is equal to date2', () => {
     const isAfter = DatesHelper.isSameOrAfter('2020-01-01', '2020-01-01');
+
+    expect(isAfter).toBe(true);
+  });
+
+  it('should return true if date1 is after date2 comparing days', () => {
+    const isAfter = DatesHelper.isSameOrAfter(new Date('2020-12-25T12:00:00.000Z'), '2020-12-23T16:00:00.000Z', 'd');
+
+    expect(isAfter).toBe(true);
+  });
+
+  it('should return false if date1 is before date2 comparing days', () => {
+    const isAfter = DatesHelper.isSameOrAfter('2020-12-25T12:00:00.000Z', '2020-12-27T16:00:00.000Z', 'd');
+
+    expect(isAfter).toBe(false);
+  });
+
+  it('should return true if date1 is equal to date2 comparing days', () => {
+    const isAfter = DatesHelper.isSameOrAfter('2020-12-25T12:00:00.000Z', '2020-12-25T09:00:00.000Z', 'd');
 
     expect(isAfter).toBe(true);
   });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement : 
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/auxiliaire

- Cas d'usage : Pour une auxiliaire dont le contrat commence cette semaine, je peux afficher ses evenements (tester coach/auxiliaire)
