### PR TITLE
Com 2130

### DIFF
--- a/src/routes/preHandlers/payDocuments.js
+++ b/src/routes/preHandlers/payDocuments.js
@@ -1,6 +1,6 @@
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
-const User = require('../../models/User');
+const UserCompany = require('../../models/UserCompany');
 const PayDocument = require('../../models/PayDocument');
 const translate = require('../../helpers/translate');
 
@@ -8,7 +8,7 @@ const { language } = translate;
 
 exports.authorizePayDocumentCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
-  const user = await User.countDocuments({ _id: req.payload.user, company: companyId });
+  const user = await UserCompany.countDocuments({ user: req.payload.user, company: companyId });
   if (!user) throw Boom.forbidden();
 
   return null;
@@ -24,7 +24,7 @@ exports.authorizePayDocumentDeletion = async (req) => {
 
 exports.authorizeGetPayDocuments = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
-  const user = await User.countDocuments({ _id: req.query.user, company: companyId });
+  const user = await UserCompany.countDocuments({ user: req.query.user, company: companyId });
   if (!user) throw Boom.forbidden();
 
   return null;

--- a/src/routes/preHandlers/payDocuments.js
+++ b/src/routes/preHandlers/payDocuments.js
@@ -9,7 +9,7 @@ const { language } = translate;
 exports.authorizePayDocumentCreation = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const user = await UserCompany.countDocuments({ user: req.payload.user, company: companyId });
-  if (!user) throw Boom.forbidden();
+  if (!user) throw Boom.notFound(translate[language].userNotFound);
 
   return null;
 };
@@ -25,7 +25,7 @@ exports.authorizePayDocumentDeletion = async (req) => {
 exports.authorizeGetPayDocuments = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const user = await UserCompany.countDocuments({ user: req.query.user, company: companyId });
-  if (!user) throw Boom.forbidden();
+  if (!user) throw Boom.notFound(translate[language].userNotFound);
 
   return null;
 };

--- a/tests/integration/payDocuments.test.js
+++ b/tests/integration/payDocuments.test.js
@@ -116,7 +116,7 @@ describe('POST /paydocuments', () => {
         headers: { ...form.getHeaders(), Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
   });
 
@@ -195,7 +195,7 @@ describe('GET /paydocuments', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
   });
 

--- a/tests/integration/seed/payDocumentsSeed.js
+++ b/tests/integration/seed/payDocumentsSeed.js
@@ -23,10 +23,7 @@ const payDocumentUserCompany = {
 
 const user = getUser('auxiliary_without_company');
 
-const userCompanyWithoutCompany = {
-  user: user._id,
-  company: authCompany._id,
-};
+const userCompanyWithoutCompany = { user: user._id, company: authCompany._id };
 
 const otherCompanyId = new ObjectID();
 
@@ -97,7 +94,7 @@ const populateDB = async () => {
   await populateDBForAuthentication();
 
   await User.create([payDocumentUser, userFromOtherCompany]);
-  await UserCompany.create([payDocumentUserCompany, userCompanyWithoutCompany]);
+  await UserCompany.insertMany([payDocumentUserCompany, userCompanyWithoutCompany]);
   await PayDocument.insertMany(payDocumentsList);
 };
 

--- a/tests/integration/seed/payDocumentsSeed.js
+++ b/tests/integration/seed/payDocumentsSeed.js
@@ -2,6 +2,7 @@ const { ObjectID } = require('mongodb');
 const { v4: uuidv4 } = require('uuid');
 const PayDocument = require('../../../src/models/PayDocument');
 const User = require('../../../src/models/User');
+const UserCompany = require('../../../src/models/UserCompany');
 const { populateDBForAuthentication, rolesList, authCompany, getUser } = require('./authenticationSeed');
 const { PAYSLIP, CERTIFICATE, OTHER, WEBAPP } = require('../../../src/helpers/constants');
 
@@ -13,6 +14,18 @@ const payDocumentUser = {
   refreshToken: uuidv4(),
   company: authCompany._id,
   origin: WEBAPP,
+};
+
+const payDocumentUserCompany = {
+  user: payDocumentUser._id,
+  company: authCompany._id,
+};
+
+const user = getUser('auxiliary_without_company');
+
+const userCompanyWithoutCompany = {
+  user: user._id,
+  company: authCompany._id,
 };
 
 const otherCompanyId = new ObjectID();
@@ -77,12 +90,14 @@ const payDocumentsList = [{
 }];
 
 const populateDB = async () => {
-  await User.deleteMany({});
-  await PayDocument.deleteMany({});
+  await User.deleteMany();
+  await UserCompany.deleteMany();
+  await PayDocument.deleteMany();
 
   await populateDBForAuthentication();
 
   await User.create([payDocumentUser, userFromOtherCompany]);
+  await UserCompany.create([payDocumentUserCompany, userCompanyWithoutCompany]);
   await PayDocument.insertMany(payDocumentsList);
 };
 
@@ -90,5 +105,7 @@ module.exports = {
   populateDB,
   payDocumentsList,
   payDocumentUser,
+  payDocumentUserCompany,
   userFromOtherCompany,
+  userCompanyWithoutCompany,
 };


### PR DESCRIPTION
Refacto du lien structure/utilisateur - Gestion des documents de paie

- Commenter le champ `company` du modele User
- Dans le service: /src/helpers/authorization : 
      - importer const UserCompany = require('../models/UserCompany’);
      - dans validate:  
           - commenter:` .populate({ path: 'company' })`
           - ajouter: const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();
           - transformer tous les user.company en `userCompany.company` => pour userRights (l.41) et credentials.company (l.58) plutôt mettre`get(userCompany, 'company') || null`

Tester Route GET /paydocuments
- récupérer la fiche de paie d’un auxiliaire de la même structure —> 200
- Récupérer la fiche de paie d’un auxiliaire d’une autre structure —> 404

Tester Route POST /paydocuments
- Ajouter la fiche de paie a un auxiliaire de la même structure 
- Ajouter une fiche de paie a un auxiliaire d’une autre structure 

Modifier le fichier `importPaySlipFrom123Pay`: 
```
const formatPdf = async (file, auxiliaryId, displayedDate) => generateFormData({
  file: await createAndReadFile(file),
  nature: 'payslip',
  date: displayedDate.toISOString(),
  // user: auxiliaryId.toHexString(),
  user: id d'un auxiliaire d'une autre structure
  mimeType: 'application/pdf',
});

// for (let i = 1; i < paySlips.length - 1; i++) { // il y a 1 lignes en trop au début et à la fin du fichier
for (let i = 1; i < 2; i++) { // il y a 1 lignes en trop au début et à la fin du fichier
```

L'executer avec:
- l'id d'un auxiliaire venant de la même structure que la personne authentifiée --> 200
- l'id d'un auxiliaire venant d'une autre structure --> 404
