### PR TITLE
COM-2196 fix access to interb2b course

### DIFF
--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -198,7 +198,7 @@ exports.authorizeGetCourse = async (req) => {
       .populate({ path: 'trainees', select: 'company' })
       .lean();
     const someTraineesAreInCompany = courseWithTrainees.trainees
-      .some(trainee => !UtilsHelper.areObjectIdsEquals(trainee.company, userCompany));
+      .some(trainee => UtilsHelper.areObjectIdsEquals(trainee.company, userCompany));
     if (!someTraineesAreInCompany) throw Boom.forbidden();
 
     return null;

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -228,9 +228,9 @@ const coursesList = [
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
     trainer: coachFromAuthCompany._id,
-    misc: 'inter_b2b with accessRules',
+    misc: 'inter_b2b',
     type: 'inter_b2b',
-    trainee: [traineeFromOtherCompany._id],
+    trainees: [traineeFromOtherCompany._id],
     contact: {
       name: 'Romain Delendarroze',
       email: 'romainlebg77@gmail.com',
@@ -241,7 +241,7 @@ const coursesList = [
   { // course without authCompany in access rules (11ème position)
     _id: new ObjectID(),
     subProgram: subProgramsList[0]._id,
-    misc: 'inter_b2b with accessRules',
+    misc: 'inter_b2b',
     type: 'inter_b2b',
     format: 'strictly_e_learning',
     trainees: [traineeFromOtherCompany._id, coachFromAuthCompany._id],


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np

- Tests intégrations :
  - ~~Ce n'est pas une ancienne route utilisée par les apps mobiles~~
      - [] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent - j'ai modifie un test qui ne fonctionnait pas

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation : 
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- Si mes changements impactent l'application erp : -np
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile - fix du prehandler
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route : -np
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route : -np
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route : -np
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route : -np
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route : -np
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route : -np
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client / mobile

- Périmetre roles : coach/admin

- Cas d'usage : ETQ coach, s'il y a une formation inter avec que des stagiaires de mon entrprise, j'ai acces a la page. Je n'ai pas acces aux formations s'il n'y a aucun stagiaire de mon entreprise. 

Sur mobile : verifier qu'on a acces aux formations auxquelles on est inscrits