### PR TITLE
Com 2183 - userCompany

### DIFF
--- a/src/routes/preHandlers/courses.js
+++ b/src/routes/preHandlers/courses.js
@@ -234,14 +234,19 @@ exports.authorizeAndGetTrainee = async (req) => {
     return { _id: traineeId };
   }
 
+  const trainee = { _id: traineeId, company: userCompany.company };
+  if ([VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(loggedUserVendorRole)) return trainee;
+
   if (loggedUserClientRole) {
-    if (![COACH, CLIENT_ADMIN].includes(loggedUserClientRole)) return Boom.forbidden();
+    if (![COACH, CLIENT_ADMIN].includes(loggedUserClientRole)) return Boom.notFound();
 
     const isSameCompany = UtilsHelper.areObjectIdsEquals(userCompany.company, get(credentials, 'company._id'));
     if (!isSameCompany) return Boom.notFound();
+
+    return trainee;
   }
 
-  return { _id: traineeId, company: userCompany.company };
+  return Boom.notFound();
 };
 
 exports.authorizeAccessRuleAddition = async (req) => {

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -890,7 +890,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
         { name: 'helper', expectedCode: 403 },
         { name: 'auxiliary', expectedCode: 403 },
         { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'trainer', expectedCode: 403 },
+        { name: 'trainer', expectedCode: 200 },
         { name: 'training_organisation_manager', expectedCode: 200 },
       ];
       roles.forEach((role) => {

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -29,6 +29,7 @@ const {
   trainerAndCoach,
   vendorAdmin,
   traineeFromAuthCompanyWithFormationExpoToken,
+  userCompanies,
 } = require('./seed/coursesSeed');
 const { getToken, authCompany, getTokenByCredentials, otherCompany } = require('./seed/authenticationSeed');
 const { noRoleNoCompany } = require('../seed/userSeed');
@@ -803,7 +804,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
         authToken = await getToken('vendor_admin');
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${traineeWithoutCompany._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[0].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -816,7 +817,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
 
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${traineeWithoutCompany._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[0].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -827,7 +828,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
           .toBe(true);
       });
 
-      it('should throw 403 if invalid traineeId', async () => {
+      it('should throw 404 if invalid traineeId', async () => {
         authToken = await getToken('vendor_admin');
         const traineeId = new ObjectID();
         const response = await app.inject({
@@ -836,7 +837,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(403);
+        expect(response.statusCode).toBe(404);
       });
     });
 
@@ -845,7 +846,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
         authToken = await getToken('client_admin');
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${auxiliary._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[1].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
@@ -856,33 +857,33 @@ describe('COURSES ROUTES - GET /courses/user', () => {
         authToken = await getToken('coach');
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${auxiliary._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[1].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
         expect(response.statusCode).toBe(200);
       });
 
-      it('should return 403 if client admin and different company', async () => {
+      it('should return 404 if client admin and different company', async () => {
         authToken = await getToken('client_admin');
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${traineeWithoutCompany._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[2].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(403);
+        expect(response.statusCode).toBe(404);
       });
 
-      it('should return 403 if coach and different company', async () => {
+      it('should return 404 if coach and different company', async () => {
         authToken = await getToken('coach');
         const response = await app.inject({
           method: 'GET',
-          url: `/courses/user?traineeId=${traineeWithoutCompany._id.toHexString()}`,
+          url: `/courses/user?traineeId=${userCompanies[2].user.toHexString()}`,
           headers: { Cookie: `alenvi_token=${authToken}` },
         });
 
-        expect(response.statusCode).toBe(403);
+        expect(response.statusCode).toBe(404);
       });
 
       const roles = [
@@ -897,7 +898,7 @@ describe('COURSES ROUTES - GET /courses/user', () => {
           authToken = await getToken(role.name);
           const response = await app.inject({
             method: 'GET',
-            url: `/courses/user?traineeId=${traineeWithoutCompany._id.toHexString()}`,
+            url: `/courses/user?traineeId=${userCompanies[0].user.toHexString()}`,
             headers: { Cookie: `alenvi_token=${authToken}` },
           });
 

--- a/tests/integration/courses.test.js
+++ b/tests/integration/courses.test.js
@@ -853,8 +853,8 @@ describe('COURSES ROUTES - GET /courses/user', () => {
         expect(response.statusCode).toBe(200);
       });
 
-      it('should return 200 if coach and same company', async () => {
-        authToken = await getToken('coach');
+      it('should return 200 if coach and trainer and same company', async () => {
+        authToken = await getTokenByCredentials(trainerAndCoach.local);
         const response = await app.inject({
           method: 'GET',
           url: `/courses/user?traineeId=${userCompanies[1].user.toHexString()}`,
@@ -887,10 +887,10 @@ describe('COURSES ROUTES - GET /courses/user', () => {
       });
 
       const roles = [
-        { name: 'helper', expectedCode: 403 },
-        { name: 'auxiliary', expectedCode: 403 },
-        { name: 'auxiliary_without_company', expectedCode: 403 },
-        { name: 'trainer', expectedCode: 200 },
+        { name: 'helper', expectedCode: 404 },
+        { name: 'auxiliary', expectedCode: 404 },
+        { name: 'auxiliary_without_company', expectedCode: 404 },
+        { name: 'trainer', expectedCode: 404 },
         { name: 'training_organisation_manager', expectedCode: 200 },
       ];
       roles.forEach((role) => {

--- a/tests/integration/seed/coursesSeed.js
+++ b/tests/integration/seed/coursesSeed.js
@@ -72,6 +72,12 @@ const traineeWithoutCompany = {
   origin: WEBAPP,
 };
 
+const userCompanies = [
+  { user: traineeWithoutCompany._id, company: authCompany._id },
+  { user: auxiliary._id, company: authCompany._id },
+  { user: traineeFromOtherCompany._id, company: otherCompany._id },
+];
+
 const courseTrainer = userList.find(user => user.role.vendor === rolesList.find(role => role.name === 'trainer')._id);
 
 const trainerAndCoach = {
@@ -325,6 +331,7 @@ const populateDB = async () => {
   await Activity.insertMany(activitiesList);
   await Card.create(card);
   await ActivityHistory.insertMany(activitiesHistory);
+  await UserCompany.insertMany(userCompanies);
 };
 
 module.exports = {
@@ -348,4 +355,5 @@ module.exports = {
   trainerAndCoach,
   vendorAdmin,
   traineeFromAuthCompanyWithFormationExpoToken,
+  userCompanies,
 };


### PR DESCRIPTION
###  Refacto du lien structure/utilisateur - Récupération des formations d'un apprenant 

Commenter le champ company du modele User
Dans le service: /src/helpers/authorization : 
- importer const UserCompany = require('../models/UserCompany’);
- dans validate:  
- commenter: .populate({ path: 'company' })
- ajouter: const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();
- transformer tous les user.company en userCompany.company => pour userRights (l.41) et credentials.company (l.58) plutôt mettreget(userCompany, 'company') || null

### TESTS
#### ETQ vendeur

- Je peux accéder au formation d'un apprenant de ma structure
- Je peux accéder au formation d'un apprenant d'une autre structure
- Je peux accéder au formation d'un apprenant sans structure

#### ETQ coach client

- Je peux accéder au formation d'un apprenant de ma structure
- Je ne peux pas accéder au formation d'un apprenant d'une autre structure
- Je ne peux pas accéder au formation d'un apprenant sans structure
- Je peux accéder depuis l'app a mes formations

#### ETQ apprenant sans structure

- je peux accéder depuis l'app a mes formations
