### PR TITLE
Com 2161

### DIFF
--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -132,9 +132,7 @@ const canEndContract = async (contract, lastVersion, contractToEnd) => {
     startDate: { $gte: contractToEnd.endDate },
   });
 
-  if (hasBilledEvents) {
-    throw Boom.forbidden(translate[language].contractHasBilledEventAfterEndDate);
-  }
+  if (hasBilledEvents) throw Boom.forbidden(translate[language].contractHasBilledEventAfterEndDate);
 
   const hasTimeStampedEvents = await EventHistory.countDocuments({
     'event.auxiliary': contract.user,
@@ -145,9 +143,7 @@ const canEndContract = async (contract, lastVersion, contractToEnd) => {
     ],
   });
 
-  if (hasTimeStampedEvents) {
-    throw Boom.forbidden(translate[language].contractHasTimeStampedEventAfterEndDate);
-  }
+  if (hasTimeStampedEvents) throw Boom.forbidden(translate[language].contractHasTimeStampedEventAfterEndDate);
 
   if (DatesHelper.isBefore(contractToEnd.endDate, lastVersion.startDate)) {
     throw Boom.conflict(translate[language].contractEndDateBeforeStartDate);

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -131,7 +131,6 @@ const canEndContract = async (contract, lastVersion, contractToEnd) => {
     isBilled: true,
     startDate: { $gte: contractToEnd.endDate },
   });
-  console.log('Evenements factures: ', hasBilledEvents);
 
   if (hasBilledEvents) {
     throw Boom.forbidden(translate[language].contractHasBilledEventAfterEndDate);

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -89,7 +89,7 @@ module.exports = {
     staffRegisteredFound: 'Staff Registered Found.',
     contractHasTimeStampedEventAfterEndDate: 'There are timestamped events after the end date of the contract.',
     contractEndDateBeforeStartDate: 'End date is before last version start date.',
-    contractHasBilledEventAfterEndDate: 'Events are billed after the end date of the contract.',
+    contractHasBilledEventAfterEndDate: 'There are billed events after contract end date.',
     /* Contracts amendments */
     contractVersionAdded: 'Contract amendment added.',
     contractVersionRemoved: 'Contract amendment removed.',

--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -89,6 +89,7 @@ module.exports = {
     staffRegisteredFound: 'Staff Registered Found.',
     contractHasTimeStampedEventAfterEndDate: 'There are timestamped events after the end date of the contract.',
     contractEndDateBeforeStartDate: 'End date is before last version start date.',
+    contractHasBilledEventAfterEndDate: 'Events are billed after the end date of the contract.',
     /* Contracts amendments */
     contractVersionAdded: 'Contract amendment added.',
     contractVersionRemoved: 'Contract amendment removed.',
@@ -419,6 +420,7 @@ module.exports = {
       'Impossible: il y a des évènements horodatés après la date de fin du contrat.',
     contractEndDateBeforeStartDate:
       'Impossible de mettre fin à un contrat avant sa date de début.',
+    contractHasBilledEventAfterEndDate: 'Impossible: il y a des évènements facturés après la date de fin de contrat.',
     /* Contracts amendments */
     contractVersionAdded: 'Avenant au contrat ajouté.',
     contractVersionRemoved: 'Avenant au contrat supprimé.',

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -502,6 +502,8 @@ describe('endContract', () => {
 
     findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
     findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
+    countDocumentHistories.returns(0);
+    eventCountDocuments.returns(0);
 
     const result = await ContractHelper.endContract(contract._id.toHexString(), payload, credentials);
 
@@ -606,6 +608,7 @@ describe('endContract', () => {
       findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
       findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
       countDocumentHistories.returns(1);
+      eventCountDocuments.returns(0);
 
       await ContractHelper.endContract(contract._id.toHexString(), contractToEnd, credential);
       expect(true).toBe(false);
@@ -688,6 +691,7 @@ describe('endContract', () => {
       findOneContract.returns(SinonMongoose.stubChainedQueries([contract], ['lean']));
       findOneAndUpdateContract.returns(SinonMongoose.stubChainedQueries([updatedContract]));
       eventCountDocuments.returns(1);
+      countDocumentHistories.returns(0);
 
       await ContractHelper.endContract(contract._id.toHexString(), contractToEnd, credential);
       expect(true).toBe(false);

--- a/tests/unit/helpers/contracts.test.js
+++ b/tests/unit/helpers/contracts.test.js
@@ -657,7 +657,7 @@ describe('endContract', () => {
     }
   });
 
-  it('should throw a 403 error if there are billed events after contract end date #tag', async () => {
+  it('should throw a 403 error if there are billed events after contract end date', async () => {
     const auxiliaryId = new ObjectID();
     const companyId = new ObjectID();
     const credential = { _id: new ObjectID(), company: { _id: companyId } };


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp : 
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/ admin client

- Cas d'usage :  l'utilisateur ne peut pas mettre fin au contrat d'un auxiliaire si des événements sont facturés après la date de fin
