### PR TITLE
Com 2133

### DIFF
--- a/src/helpers/pay.js
+++ b/src/helpers/pay.js
@@ -57,7 +57,7 @@ exports.hoursBalanceDetail = async (query, credentials) => {
   const startDate = moment(query.month, 'MM-YYYY').startOf('M').toDate();
   const endDate = moment(query.month, 'MM-YYYY').endOf('M').toDate();
 
-  if (query.sector) return this.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
+  if (query.sector) return exports.hoursBalanceDetailBySector(query.sector, startDate, endDate, credentials);
 
   return this.hoursBalanceDetailByAuxiliary(query.auxiliary, startDate, endDate, credentials);
 };
@@ -96,7 +96,10 @@ exports.hoursBalanceDetailBySector = async (sector, startDate, endDate, credenti
   const auxiliariesIds =
     await SectorHistoryRepository.getUsersFromSectorHistories(startDate, endDate, sectors, companyId);
   const result = [];
-  const auxiliaries = await User.find({ company: companyId, _id: { $in: auxiliariesIds.map(aux => aux.auxiliaryId) } })
+  const auxiliaries = await User.find(
+    { _id: { $in: auxiliariesIds.map(aux => aux.auxiliaryId) } },
+    { identity: 1, picture: 1 }
+  )
     .populate('contracts')
     .lean();
   for (const auxiliary of auxiliaries) {

--- a/src/routes/preHandlers/pay.js
+++ b/src/routes/preHandlers/pay.js
@@ -33,7 +33,7 @@ exports.authorizeGetHoursToWork = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   const sectors = UtilsHelper.formatIdsArray(req.query.sector);
   const sectorsCount = await Sector.countDocuments({ _id: { $in: sectors }, company: companyId });
-  if (sectorsCount !== sectors.length) throw Boom.forbidden();
+  if (sectorsCount !== sectors.length) throw Boom.notFound();
 
   return null;
 };

--- a/src/routes/preHandlers/pay.js
+++ b/src/routes/preHandlers/pay.js
@@ -17,13 +17,13 @@ exports.authorizeGetDetails = async (req) => {
   const companyId = get(req, 'auth.credentials.company._id', null);
   if (req.query.auxiliary) {
     const auxiliaryCompany = await UserCompany.countDocuments({ user: req.query.auxiliary, company: companyId });
-    if (!auxiliaryCompany) throw Boom.forbidden();
+    if (!auxiliaryCompany) throw Boom.notFound();
   }
 
   if (req.query.sector) {
     const sectors = UtilsHelper.formatIdsArray(req.query.sector);
     const sectorsCount = await Sector.countDocuments({ _id: { $in: sectors }, company: companyId });
-    if (sectorsCount !== sectors.length) throw Boom.forbidden();
+    if (sectorsCount !== sectors.length) throw Boom.notFound();
   }
 
   return null;

--- a/tests/integration/pay.test.js
+++ b/tests/integration/pay.test.js
@@ -348,7 +348,7 @@ describe('PAY ROUTES - GET /hours-to-work', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     it('should return a 400 if missing sector', async () => {

--- a/tests/integration/pay.test.js
+++ b/tests/integration/pay.test.js
@@ -226,7 +226,7 @@ describe('PAY ROUTES - GET /hours-balance-details', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     it('should not get hours balance details if user is not from the same company as sector', async () => {
@@ -236,7 +236,7 @@ describe('PAY ROUTES - GET /hours-balance-details', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toBe(403);
+      expect(response.statusCode).toBe(404);
     });
 
     it('should not get hours balance details if there is both sector and auxiliary', async () => {

--- a/tests/unit/helpers/pay.test.js
+++ b/tests/unit/helpers/pay.test.js
@@ -480,7 +480,7 @@ describe('hoursBalanceDetailBySector', () => {
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ company: credentials.company._id, _id: { $in: [] } }] },
+        { query: 'find', args: [{ _id: { $in: [] } }, { identity: 1, picture: 1 }] },
         { query: 'populate', args: ['contracts'] },
         { query: 'lean', args: [] },
       ]
@@ -515,7 +515,7 @@ describe('hoursBalanceDetailBySector', () => {
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ company: credentials.company._id, _id: { $in: [auxiliaryId] } }] },
+        { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },
         { query: 'populate', args: ['contracts'] },
         { query: 'lean', args: [] },
       ]
@@ -570,7 +570,7 @@ describe('hoursBalanceDetailBySector', () => {
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ company: credentials.company._id, _id: { $in: auxiliaryIds } }] },
+        { query: 'find', args: [{ _id: { $in: auxiliaryIds } }, { identity: 1, picture: 1 }] },
         { query: 'populate', args: ['contracts'] },
         { query: 'lean', args: [] },
       ]
@@ -599,7 +599,7 @@ describe('hoursBalanceDetailBySector', () => {
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ company: credentials.company._id, _id: { $in: [auxiliaryId] } }] },
+        { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },
         { query: 'populate', args: ['contracts'] },
         { query: 'lean', args: [] },
       ]
@@ -631,7 +631,7 @@ describe('hoursBalanceDetailBySector', () => {
     SinonMongoose.calledWithExactly(
       userFind,
       [
-        { query: 'find', args: [{ company: credentials.company._id, _id: { $in: [auxiliaryId] } }] },
+        { query: 'find', args: [{ _id: { $in: [auxiliaryId] } }, { identity: 1, picture: 1 }] },
         { query: 'populate', args: ['contracts'] },
         { query: 'lean', args: [] },
       ]


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach/ admin client

- Tests a faire:  
      - afficher le détail du compteur d'heures de chaque auxiliaire sur le tableau de bord des équipes 
      - Appeler la route pay/hours-balance-details avec en query un mois et un secteur en etant connecté avec une autre entreprise → renvoie une 404
      - Appeler la route pay/hours-to-work avec en query un mois et un secteur en etant connecté avec une autre entreprise → renvoie une 404
      - reefectuer ces deux tests en commentant le champs company dans le model User 
 
Dans le service: `/src/helpers/authorization` : 
importer `const UserCompany = require('../models/UserCompany’);`
dans validate:  
commenter: `.populate({ path: 'company' })`
ajouter: `const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();`
transformer tous les `user.company` en `userCompany.company` => pour userRights (l.41) et `credentials.company` (l.58) plutôt mettre `get(userCompany, 'company') || null`
