### PR TITLE
COM-2187: block creation for event after stopping date

### DIFF
--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -18,6 +18,7 @@ const {
 const Event = require('../models/Event');
 const User = require('../models/User');
 const Repetition = require('../models/Repetition');
+const Customer = require('../models/Customer');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
@@ -46,8 +47,11 @@ exports.createRepetitionsEveryDay = async (payload, sector) => {
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 
+  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
+    .lean();
   for (let i = 0, l = range.length; i < l; i++) {
     const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
+    if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
     if (repeatedEvent) repeatedEvents.push(repeatedEvent);
   }
 
@@ -60,10 +64,13 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
   const range = Array.from(moment().range(start, end).by('days'));
   const repeatedEvents = [];
 
+  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
+    .lean();
   for (let i = 0, l = range.length; i < l; i++) {
     const day = moment(range[i]).day();
     if (day !== 0 && day !== 6) {
       const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
+      if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
       if (repeatedEvent) repeatedEvents.push(repeatedEvent);
     }
   }
@@ -77,8 +84,11 @@ exports.createRepetitionsByWeek = async (payload, sector, step) => {
   const range = Array.from(moment().range(start, end).by('weeks', { step }));
   const repeatedEvents = [];
 
+  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
+    .lean();
   for (let i = 0, l = range.length; i < l; i++) {
     const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
+    if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
     if (repeatedEvent) repeatedEvents.push(repeatedEvent);
   }
 

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -41,34 +41,12 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
   return new Event(payload);
 };
 
-exports.createRepetitionsEveryDay = async (payload, sector) => {
-  const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
-  const range = Array.from(moment().range(start, end).by('days'));
+exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetition) => {
   const repeatedEvents = [];
-
   const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
     .lean();
   for (let i = 0, l = range.length; i < l; i++) {
-    const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
-    if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
-    if (repeatedEvent) repeatedEvents.push(repeatedEvent);
-  }
-
-  await Event.insertMany(repeatedEvents);
-};
-
-exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
-  const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
-  const range = Array.from(moment().range(start, end).by('days'));
-  const repeatedEvents = [];
-
-  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
-    .lean();
-  for (let i = 0, l = range.length; i < l; i++) {
-    const day = moment(range[i]).day();
-    if (day !== 0 && day !== 6) {
+    if (!isWeekDayRepetition || ![0, 6].includes(moment(range[i]).day())) {
       const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
       if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
       if (repeatedEvent) repeatedEvents.push(repeatedEvent);
@@ -78,21 +56,28 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
   await Event.insertMany(repeatedEvents);
 };
 
+exports.createRepetitionsEveryDay = async (payload, sector) => {
+  const start = moment(payload.startDate).add(1, 'd');
+  const end = moment(payload.startDate).add(90, 'd');
+  const range = Array.from(moment().range(start, end).by('days'));
+
+  await exports.createRepeatedEvents(payload, range, sector, false);
+};
+
+exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
+  const start = moment(payload.startDate).add(1, 'd');
+  const end = moment(payload.startDate).add(90, 'd');
+  const range = Array.from(moment().range(start, end).by('days'));
+
+  await exports.createRepeatedEvents(payload, range, sector, true);
+};
+
 exports.createRepetitionsByWeek = async (payload, sector, step) => {
   const start = moment(payload.startDate).add(step, 'w');
   const end = moment(payload.startDate).add(90, 'd');
   const range = Array.from(moment().range(start, end).by('weeks', { step }));
-  const repeatedEvents = [];
 
-  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
-    .lean();
-  for (let i = 0, l = range.length; i < l; i++) {
-    const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
-    if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
-    if (repeatedEvent) repeatedEvents.push(repeatedEvent);
-  }
-
-  await Event.insertMany(repeatedEvents);
+  await exports.createRepeatedEvents(payload, range, sector, false);
 };
 
 exports.createRepetitions = async (eventFromDb, payload, credentials) => {

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -45,6 +45,7 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
   const repeatedEvents = [];
   const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
     .lean();
+
   for (let i = 0, l = range.length; i < l; i++) {
     if (!isWeekDayRepetition || ![0, 6].includes(moment(range[i]).day())) {
       const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -283,7 +283,7 @@ describe('createRepetitionsEveryWeekDay', () => {
     insertMany.restore();
   });
 
-  it('should create repetition every day', async () => {
+  it('should create repetition every week day', async () => {
     const sector = new ObjectID();
     const event = { startDate: '2019-01-10T09:00:00', endDate: '2019-01-10T11:00:00' };
 
@@ -356,9 +356,7 @@ describe('createRepetitionsByWeek', () => {
       startDate.setDate(startDate.getDate() + i + 1);
       formatRepeatedPayload.onCall(i).returns(new Event({ company: new ObjectID(), startDate }));
     }
-    customerFindOne.returns(
-      SinonMongoose.stubChainedQueries([null], ['lean'])
-    );
+    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
 
     await EventsRepetitionHelper.createRepetitionsByWeek(event, sector, 1);
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -202,7 +202,7 @@ describe('formatRepeatedPayload', () => {
   });
 });
 
-describe('createRepetitionsEveryDay', () => {
+describe('createRepeatedEvents', () => {
   let formatRepeatedPayload;
   let customerFindOne;
   let insertMany;
@@ -215,256 +215,175 @@ describe('createRepetitionsEveryDay', () => {
     formatRepeatedPayload.restore();
     customerFindOne.restore();
     insertMany.restore();
+  });
+
+  it('should create repetition for each range', async () => {
+    const sector = new ObjectID();
+    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const range = [
+      '2019-01-11T09:00:00.000Z',
+      '2019-01-12T09:00:00.000Z',
+      '2019-01-13T09:00:00.000Z',
+    ];
+    const repeatedEvents = [
+      new Event({ company: new ObjectID(), startDate: range[0] }),
+      new Event({ company: new ObjectID(), startDate: range[1] }),
+      new Event({ company: new ObjectID(), startDate: range[2] }),
+    ];
+
+    formatRepeatedPayload.onCall(0).returns(repeatedEvents[0]);
+    formatRepeatedPayload.onCall(1).returns(repeatedEvents[1]);
+    formatRepeatedPayload.onCall(2).returns(repeatedEvents[2]);
+    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+
+    await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, false);
+
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(0), event, sector, '2019-01-11T09:00:00.000Z');
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-12T09:00:00.000Z');
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(2), event, sector, '2019-01-13T09:00:00.000Z');
+    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
+    SinonMongoose.calledWithExactly(
+      customerFindOne,
+      [
+        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should not create repetition on week-end for week day repetition', async () => {
+    const sector = new ObjectID();
+    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const range = [
+      '2019-01-11T09:00:00.000Z',
+      '2019-01-12T09:00:00.000Z',
+      '2019-01-13T09:00:00.000Z',
+      '2019-01-14T09:00:00.000Z',
+    ];
+    const fridayEvent = new Event({ company: new ObjectID(), startDate: range[0] });
+    const mondayEvent = new Event({ company: new ObjectID(), startDate: range[3] });
+
+    formatRepeatedPayload.onCall(0).returns(fridayEvent);
+    formatRepeatedPayload.onCall(1).returns(mondayEvent);
+    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
+
+    await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, true);
+
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(0), event, sector, '2019-01-11T09:00:00.000Z');
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-14T09:00:00.000Z');
+    sinon.assert.calledOnceWithExactly(insertMany, [fridayEvent, mondayEvent]);
+    SinonMongoose.calledWithExactly(
+      customerFindOne,
+      [
+        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+
+  it('should not insert events after stopping date', async () => {
+    const sector = new ObjectID();
+    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const range = [
+      '2019-01-11T09:00:00.000Z',
+      '2019-01-12T09:00:00.000Z',
+      '2019-01-13T09:00:00.000Z',
+    ];
+    const customer = { _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') };
+    const repeatedEvents = [
+      new Event({ company: new ObjectID(), startDate: range[0] }),
+      new Event({ company: new ObjectID(), startDate: range[1] }),
+      new Event({ company: new ObjectID(), startDate: range[2] }),
+    ];
+
+    formatRepeatedPayload.onCall(0).returns(repeatedEvents[0]);
+    formatRepeatedPayload.onCall(1).returns(repeatedEvents[1]);
+    formatRepeatedPayload.onCall(2).returns(repeatedEvents[2]);
+    customerFindOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
+
+    await EventsRepetitionHelper.createRepeatedEvents(event, range, sector, false);
+
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(0), event, sector, '2019-01-11T09:00:00.000Z');
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), event, sector, '2019-01-12T09:00:00.000Z');
+    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(2), event, sector, '2019-01-13T09:00:00.000Z');
+    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents.slice(0, 2));
+    SinonMongoose.calledWithExactly(
+      customerFindOne,
+      [
+        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
+        { query: 'lean' },
+      ]
+    );
+  });
+});
+
+describe('createRepetitionsEveryDay', () => {
+  let createRepeatedEvents;
+  beforeEach(() => {
+    createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
+  });
+  afterEach(() => {
+    createRepeatedEvents.restore();
   });
 
   it('should create repetition every day', async () => {
     const sector = new ObjectID();
     const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
-    const range = Array.from(moment()
-      .range(moment(event.startDate).add(1, 'd'), moment(event.startDate).add(90, 'd')).by('days'));
-
-    const firstRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-11T09:00:00.000Z' });
-    const secondRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-12T09:00:00.000Z' });
-    const repeatedEvents = [firstRepeatedEvent, secondRepeatedEvent];
-
-    formatRepeatedPayload.onCall(0).returns(firstRepeatedEvent);
-    formatRepeatedPayload.onCall(1).returns(secondRepeatedEvent);
-
-    for (let i = 2; i < 90; i++) {
-      const repeatedEvent = new Event({ company: new ObjectID(), startDate: range[i] });
-      formatRepeatedPayload.onCall(i).returns(repeatedEvent);
-      repeatedEvents.push(repeatedEvent);
-    }
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
-
-    await EventsRepetitionHelper.createRepetitionsEveryDay(event, sector);
-
-    sinon.assert.callCount(formatRepeatedPayload, 90);
-    sinon.assert.callCount(insertMany, 1);
+    const range = [];
     for (let i = 0; i < 90; i++) {
-      sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(i), event, sector, range[i]);
+      range.push(moment(event.startDate).add(i + 1, 'd'));
     }
-    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should not create repetition after stopping date', async () => {
-    const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
-    const range = Array.from(moment()
-      .range(moment(event.startDate).add(1, 'd'), moment(event.startDate).add(3, 'd')).by('days'));
-
-    const firstRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-11T09:00:00.000Z' });
-    const secondRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-12T09:00:00.000Z' });
-    const thirdRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-13T09:00:00.000Z' });
-    const repeatedEvents = [firstRepeatedEvent, secondRepeatedEvent];
-
-    formatRepeatedPayload.onCall(0).returns(firstRepeatedEvent);
-    formatRepeatedPayload.onCall(1).returns(secondRepeatedEvent);
-    formatRepeatedPayload.onCall(2).returns(thirdRepeatedEvent);
-
-    customerFindOne.returns(
-      SinonMongoose.stubChainedQueries([{ _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') }], ['lean'])
-    );
 
     await EventsRepetitionHelper.createRepetitionsEveryDay(event, sector);
 
-    sinon.assert.callCount(formatRepeatedPayload, 3);
-    sinon.assert.callCount(insertMany, 1);
-    for (let i = 0; i < 3; i++) {
-      sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(i), event, sector, range[i]);
-    }
-    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
+    sinon.assert.calledOnceWithExactly(createRepeatedEvents, event, range, sector, false);
   });
 });
 
 describe('createRepetitionsEveryWeekDay', () => {
-  let formatRepeatedPayload;
-  let customerFindOne;
-  let insertMany;
+  let createRepeatedEvents;
   beforeEach(() => {
-    formatRepeatedPayload = sinon.stub(EventsRepetitionHelper, 'formatRepeatedPayload');
-    customerFindOne = sinon.stub(Customer, 'findOne');
-    insertMany = sinon.stub(Event, 'insertMany');
+    createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
   });
   afterEach(() => {
-    formatRepeatedPayload.restore();
-    customerFindOne.restore();
-    insertMany.restore();
+    createRepeatedEvents.restore();
   });
 
   it('should create repetition every week day', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00Z', endDate: '2019-01-10T11:00:00Z' };
-    const range = Array.from(moment()
-      .range(moment(event.startDate).add(1, 'd'), moment(event.startDate).add(90, 'd')).by('days'));
+    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
 
-    const fridayEvent = new Event({ company: new ObjectID(), startDate: '2019-01-11T09:00:00.000Z' });
-    const mondayEvent = new Event({ company: new ObjectID(), startDate: '2019-01-14T09:00:00.000Z' });
-    const repeatedEvents = [fridayEvent, mondayEvent];
-
-    formatRepeatedPayload.onCall(0).returns(fridayEvent);
-    formatRepeatedPayload.onCall(1).returns(mondayEvent);
-
-    let callCount = 2;
-    for (let i = 4; i < 90; i++) {
-      const repeatedEvent = new Event({ company: new ObjectID(), startDate: range[i] });
-      if (![0, 6].includes(moment(range[i]).day())) {
-        formatRepeatedPayload.onCall(callCount).returns(repeatedEvent);
-        repeatedEvents.push(repeatedEvent);
-        callCount += 1;
-      }
+    const range = [];
+    for (let i = 0; i < 90; i++) {
+      range.push(moment(event.startDate).add(i + 1, 'd'));
     }
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
-
     await EventsRepetitionHelper.createRepetitionsEveryWeekDay(event, sector);
 
-    sinon.assert.callCount(formatRepeatedPayload, 64);
-    sinon.assert.callCount(insertMany, 1);
-    callCount = 0;
-    for (let i = 0; i < 90; i++) {
-      if (![0, 6].includes(moment(range[i]).day())) {
-        sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(callCount), event, sector, range[i]);
-        callCount += 1;
-      }
-    }
-    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should not create repetition after stopping date', async () => {
-    const sector = new ObjectID();
-    const thursdayEvent = { startDate: '2019-01-10T09:00:00Z', endDate: '2019-01-10T11:00:00Z' };
-    const customer = { _id: thursdayEvent.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') };
-    const range = Array.from(
-      moment()
-        .range(moment(thursdayEvent.startDate).add(1, 'd'), moment(thursdayEvent.startDate).add(90, 'd'))
-        .by('days')
-    );
-
-    const fridayEvent = new Event({ company: new ObjectID(), startDate: new Date(range[0]) });
-    const mondayEvent = new Event({ company: new ObjectID(), startDate: new Date(range[3]) });
-    formatRepeatedPayload.onCall(0).returns(fridayEvent);
-    formatRepeatedPayload.onCall(1).returns(mondayEvent);
-
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([customer], ['lean']));
-
-    await EventsRepetitionHelper.createRepetitionsEveryWeekDay(thursdayEvent, sector);
-
-    sinon.assert.callCount(insertMany, 1);
-    sinon.assert.calledOnceWithExactly(insertMany, [fridayEvent]);
-
-    sinon.assert.callCount(formatRepeatedPayload, 2);
-    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(0), thursdayEvent, sector, range[0]);
-    sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(1), thursdayEvent, sector, range[3]);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: thursdayEvent.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
+    sinon.assert.calledOnceWithExactly(createRepeatedEvents, event, range, sector, true);
   });
 });
 
 describe('createRepetitionsByWeek', () => {
-  let formatRepeatedPayload;
-  let customerFindOne;
-  let insertMany;
+  let createRepeatedEvents;
   beforeEach(() => {
-    formatRepeatedPayload = sinon.stub(EventsRepetitionHelper, 'formatRepeatedPayload');
-    customerFindOne = sinon.stub(Customer, 'findOne');
-    insertMany = sinon.stub(Event, 'insertMany');
+    createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
   });
   afterEach(() => {
-    formatRepeatedPayload.restore();
-    customerFindOne.restore();
-    insertMany.restore();
+    createRepeatedEvents.restore();
   });
 
-  it('should create repetition every week', async () => {
+  it('should create repetition by week', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00Z', endDate: '2019-01-10T11:00:00Z' };
-    const range = Array.from(moment()
-      .range(moment(event.startDate).add(1, 'w'), moment(event.startDate).add(90, 'd')).by('weeks', { step: 1 }));
+    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
 
-    const firstThursdayRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-17T09:00:00.000Z' });
-    const secondThursdayRepeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-24T09:00:00.000Z' });
-    const repeatedEvents = [firstThursdayRepeatedEvent, secondThursdayRepeatedEvent];
-
-    formatRepeatedPayload.onCall(0).returns(firstThursdayRepeatedEvent);
-    formatRepeatedPayload.onCall(1).returns(secondThursdayRepeatedEvent);
-
-    for (let i = 2; i < 12; i++) {
-      const repeatedEvent = new Event({ company: new ObjectID(), startDate: range[i] });
-      formatRepeatedPayload.onCall(i).returns(repeatedEvent);
-      repeatedEvents.push(repeatedEvent);
-    }
-    customerFindOne.returns(SinonMongoose.stubChainedQueries([null], ['lean']));
-
-    await EventsRepetitionHelper.createRepetitionsByWeek(event, sector, 1);
-
-    sinon.assert.callCount(formatRepeatedPayload, 12);
-    sinon.assert.callCount(insertMany, 1);
+    const range = [];
     for (let i = 0; i < 12; i++) {
-      sinon.assert.calledWithExactly(formatRepeatedPayload.getCall(i), event, sector, range[i]);
+      range.push(moment(event.startDate).add((i + 1) * 7, 'd'));
     }
-    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
-  });
-
-  it('should not create repetition after stopping date', async () => {
-    const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00Z', endDate: '2019-01-10T11:00:00Z' };
-    const range = Array.from(moment()
-      .range(moment(event.startDate).add(1, 'w'), moment(event.startDate).add(90, 'd')).by('weeks', { step: 1 }));
-    const repeatedEvents = [];
-
-    const repeatedEvent = new Event({ company: new ObjectID(), startDate: '2019-01-17T09:00:00.000Z' });
-    formatRepeatedPayload.returns(repeatedEvent);
-
-    customerFindOne.returns(
-      SinonMongoose.stubChainedQueries([{ _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') }], ['lean'])
-    );
 
     await EventsRepetitionHelper.createRepetitionsByWeek(event, sector, 1);
 
-    sinon.assert.callCount(formatRepeatedPayload, 1);
-    sinon.assert.callCount(insertMany, 1);
-    sinon.assert.calledOnceWithExactly(formatRepeatedPayload, event, sector, range[0]);
-    sinon.assert.calledOnceWithExactly(insertMany, repeatedEvents);
-    SinonMongoose.calledWithExactly(
-      customerFindOne,
-      [
-        { query: 'findOne', args: [{ _id: event.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }] },
-        { query: 'lean' },
-      ]
-    );
+    sinon.assert.calledOnceWithExactly(createRepeatedEvents, event, range, sector, false);
   });
 });
 


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

-~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin/coach

- Cas d'usage : si je créé une répétition qui finit après la date d'arrêt d'un bénéficiaire, les interventions postérieures à la date d'arrêt ne sont pas créées
