### PR TITLE
COM-2135 - Refacto userCompany in activityHistories helper

### DIFF
--- a/src/helpers/activityHistories.js
+++ b/src/helpers/activityHistories.js
@@ -1,6 +1,6 @@
 const has = require('lodash/has');
 const ActivityHistory = require('../models/ActivityHistory');
-const User = require('../models/User');
+const UserCompany = require('../models/UserCompany');
 const { STRICTLY_E_LEARNING } = require('./constants');
 
 exports.addActivityHistory = async payload => ActivityHistory.create(payload);
@@ -32,12 +32,12 @@ const filterSteps = activityHistory => ({
 });
 
 exports.list = async (query, credentials) => {
-  const users = await User.find({ company: credentials.company._id }, { _id: 1 }).lean();
+  const userCompanies = await UserCompany.find({ company: credentials.company._id }, { user: 1 }).lean();
 
   const activityHistories = await ActivityHistory
     .find({
       date: { $lte: new Date(query.endDate), $gte: new Date(query.startDate) },
-      user: { $in: users.map(u => u._id) },
+      user: { $in: userCompanies.map(uc => uc.user) },
     })
     .populate({
       path: 'activity',

--- a/tests/unit/helpers/activityHistories.test.js
+++ b/tests/unit/helpers/activityHistories.test.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const expect = require('expect');
 const { ObjectID } = require('mongodb');
 const ActivityHistory = require('../../../src/models/ActivityHistory');
-const User = require('../../../src/models/User');
+const UserCompany = require('../../../src/models/UserCompany');
 const ActivityHistoryHelper = require('../../../src/helpers/activityHistories');
 const SinonMongoose = require('../sinonMongoose');
 
@@ -32,15 +32,15 @@ describe('addActivityHistory', () => {
 });
 
 describe('list', () => {
-  let findUsers;
+  let findUserCompanies;
   let findHistories;
   beforeEach(() => {
     findHistories = sinon.stub(ActivityHistory, 'find');
-    findUsers = sinon.stub(User, 'find');
+    findUserCompanies = sinon.stub(UserCompany, 'find');
   });
   afterEach(() => {
     findHistories.restore();
-    findUsers.restore();
+    findUserCompanies.restore();
   });
 
   it('should return a list of histories', async () => {
@@ -99,15 +99,17 @@ describe('list', () => {
       },
     };
 
-    findUsers.returns(SinonMongoose.stubChainedQueries([[{ _id: firstUserId }, { _id: secondUserId }]], ['lean']));
+    findUserCompanies.returns(
+      SinonMongoose.stubChainedQueries([[{ user: firstUserId }, { user: secondUserId }]], ['lean'])
+    );
     findHistories.returns(SinonMongoose.stubChainedQueries([activityHistories]));
 
     const result = await ActivityHistoryHelper.list(query, { company: { _id: companyId } });
 
     expect(result).toEqual([filteredActivityHistories]);
     SinonMongoose.calledWithExactly(
-      findUsers,
-      [{ query: 'find', args: [{ company: companyId }, { _id: 1 }] }, { query: 'lean' }]
+      findUserCompanies,
+      [{ query: 'find', args: [{ company: companyId }, { user: 1 }] }, { query: 'lean' }]
     );
     SinonMongoose.calledWithExactly(
       findHistories,


### PR DESCRIPTION
### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin / coach

- Cas d'usage : 
Refacto userCompany du service activityHistories.
Pour tester :
  - afficher le dashboard formation sur dev et sur ma branche -> les deux sont identiques
  - sur postman, appeler la route avec un utilisateur d'une autre company -> on ne reçoit les informations que de cette structure
  - en appliquant les modifications usuelles (commenter le champ company de user + refacto validate) -> la route fonctionne bien avec mon compte et le compte de l'autre structure.

Voici la route postman : https://www.getpostman.com/collections/2cac4c813897e59ad118