### PR TITLE
Com 2136 rebase

### DIFF
--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -436,16 +436,16 @@ exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) =
 
 exports.workingStats = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  let queryAuxiliaries;
+  let auxiliaryIds = [];
 
   if (query.auxiliary) {
-    queryAuxiliaries = { _id: { $in: UtilsHelper.formatObjectIdsArray(query.auxiliary) } };
+    auxiliaryIds = UtilsHelper.formatObjectIdsArray(query.auxiliary);
   } else {
     const users = await UserCompany.find({ company: companyId }, { user: 1 }).lean();
-    queryAuxiliaries = { _id: { $in: users.map(u => u.user) } };
+    auxiliaryIds = users.map(u => u.user);
   }
 
-  const auxiliaries = await User.find(queryAuxiliaries).populate('contracts').lean();
+  const auxiliaries = await User.find({ _id: { $in: auxiliaryIds } }).populate('contracts').lean();
   const { startDate, endDate } = query;
   const distanceMatrix = await DistanceMatrix.find({ company: companyId }).lean();
   const auxiliariesIds = auxiliaries.map(aux => aux._id);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -32,6 +32,7 @@ const Repetition = require('../models/Repetition');
 const User = require('../models/User');
 const DistanceMatrix = require('../models/DistanceMatrix');
 const EventRepository = require('../repositories/EventRepository');
+const UserCompany = require('../models/UserCompany');
 
 momentRange.extendMoment(moment);
 
@@ -435,11 +436,15 @@ exports.getContract = (contracts, startDate, endDate) => contracts.find((cont) =
 
 exports.workingStats = async (query, credentials) => {
   const companyId = get(credentials, 'company._id', null);
-  const queryAuxiliaries = { company: companyId };
-  if (query.auxiliary) {
-    const ids = UtilsHelper.formatObjectIdsArray(query.auxiliary);
-    queryAuxiliaries._id = { $in: ids };
-  }
+  const queryAuxiliaries = {};
+  let ids = [];
+
+  if (!query.auxiliary) {
+    const users = await UserCompany.find({ company: companyId }, { user: 1 });
+    for (const user of users) ids.push(user.user);
+  } else ids = UtilsHelper.formatObjectIdsArray(query.auxiliary);
+
+  queryAuxiliaries._id = { $in: ids };
   const auxiliaries = await User.find(queryAuxiliaries).populate('contracts').lean();
   const { startDate, endDate } = query;
   const distanceMatrix = await DistanceMatrix.find({ company: companyId }).lean();

--- a/src/routes/preHandlers/events.js
+++ b/src/routes/preHandlers/events.js
@@ -49,7 +49,7 @@ exports.authorizeEventGet = async (req) => {
   if (req.query.auxiliary) {
     const auxiliariesIds = [...new Set(UtilsHelper.formatIdsArray(req.query.auxiliary))];
     const auxiliariesCount = await UserCompany.countDocuments({ user: { $in: auxiliariesIds }, company: companyId });
-    if (auxiliariesCount !== auxiliariesIds.length) throw Boom.forbidden();
+    if (auxiliariesCount !== auxiliariesIds.length) throw Boom.notFound();
   }
 
   if (req.query.sector) {

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -383,7 +383,7 @@ describe('GET /events/working-stats', () => {
       expect(response.statusCode).toEqual(200);
     });
 
-    it('should return a 403 if auxiliary is not from the same company', async () => {
+    it('should return a 404 if auxiliary is not from the same company', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/events/working-stats?auxiliary=${auxiliaryFromOtherCompany._id}&startDate=${startDate}
@@ -391,7 +391,7 @@ describe('GET /events/working-stats', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(404);
     });
   });
 

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -145,14 +145,14 @@ describe('GET /events', () => {
       expect(response.statusCode).toEqual(403);
     });
 
-    it('should return a 403 if auxiliary is not from the same company', async () => {
+    it('should return a 404 if auxiliary is not from the same company', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/events?auxiliary=${auxiliaryFromOtherCompany._id}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(response.statusCode).toEqual(403);
+      expect(response.statusCode).toEqual(404);
     });
 
     it('should return a 403 if sector is not from the same company', async () => {

--- a/tests/unit/helpers/events.test.js
+++ b/tests/unit/helpers/events.test.js
@@ -1928,7 +1928,7 @@ describe('workingStats', () => {
     getPayFromEventsStub.returns(hours);
     getPayFromAbsencesStub.returns(absencesHours);
     findUser.returns(SinonMongoose.stubChainedQueries([auxiliaries]));
-    findUserCompany.returns(users);
+    findUserCompany.returns(SinonMongoose.stubChainedQueries([users], ['lean']));
     findDistanceMatrix.returns(SinonMongoose.stubChainedQueries([distanceMatrix], ['lean']));
 
     const result = await EventHelper.workingStats(queryWithoutAuxiliary, credentials);


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### Effectuer les tests suivants: 
- ETQ coach, sur le planning auxiliaires, afficher les heures travaillées par rapport aux heures contrats a coté de l’avatar de l’auxiliaire
- ETQ auxiliaire, sur le planning auxiliaires, afficher les heures travaillées par rapport aux heures contrats a coté de l’avatar de l’auxiliaire

Sur postman:
- faire appel a la route GET /events/working-stats avec:
   - en query: startDate, endDate et une auxiliaire de la même structure --> 200
   - en query: startDate, endDate et une auxiliaire d'une autre structure --> 404
   - en query: startDate, endDate --> 200 et affiche toutes les statistiques des auxiliaires de la même structure que l'utilisateur connecté 

