### PR TITLE
Com 2169

### DIFF
--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -25,7 +25,7 @@ const UserCompaniesHelper = require('./userCompanies');
 const { language } = translate;
 
 exports.formatQueryForUsersList = async (query) => {
-  const formattedQuery = { ...pickBy(omit(query, ['role'])) };
+  const formattedQuery = { ...pickBy(omit(query, ['role', 'company'])) };
 
   if (query.role) {
     const roleNames = Array.isArray(query.role) ? query.role : [query.role];

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -36,7 +36,7 @@ exports.formatQueryForUsersList = async (query) => {
   }
 
   if (query.company) {
-    const users = await UserCompany.find({ company: query.company }, { user: 1 });
+    const users = await UserCompany.find({ company: query.company }, { user: 1 }).lean();
 
     formattedQuery._id = { $in: users.map(u => u.user) };
   }

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -12,7 +12,6 @@ const User = require('../models/User');
 const Company = require('../models/Company');
 const UserCompany = require('../models/UserCompany');
 const Contract = require('../models/Contract');
-const UserCompany = require('../models/UserCompany');
 const translate = require('./translate');
 const GCloudStorageHelper = require('./gCloudStorage');
 const { TRAINER, AUXILIARY_ROLES, HELPER, AUXILIARY_WITHOUT_COMPANY } = require('./constants');
@@ -25,7 +24,7 @@ const UserCompaniesHelper = require('./userCompanies');
 const { language } = translate;
 
 exports.formatQueryForUsersList = async (query) => {
-  const formattedQuery = { ...pickBy(omit(query, ['role', 'company'])) };
+  const formattedQuery = pickBy(omit(query, ['role', 'company']));
 
   if (query.role) {
     const roleNames = Array.isArray(query.role) ? query.role : [query.role];

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -9,7 +9,7 @@ const UserCompany = require('../../../src/models/UserCompany');
 const Contract = require('../../../src/models/Contract');
 const Establishment = require('../../../src/models/Establishment');
 const { rolesList, populateDBForAuthentication, otherCompany, authCompany } = require('./authenticationSeed');
-const { vendorAdmin, userList } = require('../../seed/userSeed');
+const { vendorAdmin, userCompaniesList } = require('../../seed/userSeed');
 const { authCustomer } = require('../../seed/customerSeed');
 const Course = require('../../../src/models/Course');
 const { WEBAPP } = require('../../../src/helpers/constants');
@@ -229,18 +229,14 @@ const usersSeedList = [
 ];
 
 const userCompanies = [
+  ...userCompaniesList,
   { user: auxiliaryFromOtherCompany._id, company: otherCompany._id },
-  { user: userList[0]._id, company: authCompany._id },
-  { user: userList[1]._id, company: authCompany._id },
-  { user: userList[2]._id, company: authCompany._id },
-  { user: userList[3]._id, company: authCompany._id },
-  { user: userList[4]._id, company: authCompany._id },
+  { user: helperFromOtherCompany._id, company: otherCompany._id },
   { user: usersSeedList[0]._id, company: authCompany._id },
   { user: usersSeedList[1]._id, company: authCompany._id },
   { user: usersSeedList[2]._id, company: authCompany._id },
   { user: usersSeedList[4]._id, company: authCompany._id },
   { user: usersSeedList[5]._id, company: authCompany._id },
-  { user: helperFromOtherCompany._id, company: authCompany._id },
 ];
 
 const userSectors = [

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -9,7 +9,7 @@ const UserCompany = require('../../../src/models/UserCompany');
 const Contract = require('../../../src/models/Contract');
 const Establishment = require('../../../src/models/Establishment');
 const { rolesList, populateDBForAuthentication, otherCompany, authCompany } = require('./authenticationSeed');
-const { vendorAdmin } = require('../../seed/userSeed');
+const { vendorAdmin, userList } = require('../../seed/userSeed');
 const { authCustomer } = require('../../seed/customerSeed');
 const Course = require('../../../src/models/Course');
 const { WEBAPP } = require('../../../src/helpers/constants');
@@ -228,6 +228,21 @@ const usersSeedList = [
   },
 ];
 
+const userCompanies = [
+  { user: auxiliaryFromOtherCompany._id, company: otherCompany._id },
+  { user: userList[0]._id, company: authCompany._id },
+  { user: userList[1]._id, company: authCompany._id },
+  { user: userList[2]._id, company: authCompany._id },
+  { user: userList[3]._id, company: authCompany._id },
+  { user: userList[4]._id, company: authCompany._id },
+  { user: usersSeedList[0]._id, company: authCompany._id },
+  { user: usersSeedList[1]._id, company: authCompany._id },
+  { user: usersSeedList[2]._id, company: authCompany._id },
+  { user: usersSeedList[4]._id, company: authCompany._id },
+  { user: usersSeedList[5]._id, company: authCompany._id },
+  { user: helperFromOtherCompany._id, company: authCompany._id },
+];
+
 const userSectors = [
   { _id: new ObjectID(), name: 'Terre', company: authCompany._id },
   { _id: new ObjectID(), name: 'Lune', company: authCompany._id },
@@ -316,6 +331,7 @@ const populateDB = async () => {
   await Contract.insertMany(contracts);
   await Establishment.insertMany(establishmentList);
   await Course.insertMany(followingCourses);
+  await UserCompany.insertMany(userCompanies);
 };
 
 module.exports = {
@@ -332,4 +348,5 @@ module.exports = {
   auxiliaryFromOtherCompany,
   authCustomer,
   coachAndTrainer,
+  userCompanies,
 };

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -384,10 +384,8 @@ describe('GET /users', () => {
     });
 
     it('should get all coachs users (company A)', async () => {
-      const coachUsers = [...userList, ...usersSeedList].filter(u =>
-        u.role &&
-        isExistingRole(u.role.client, 'coach') &&
-        u.company === authCompany._id);
+      const coachUsers = [...userList, ...usersSeedList]
+        .filter(u => u.role && isExistingRole(u.role.client, 'coach') && u.company === authCompany._id);
 
       const res = await app.inject({
         method: 'GET',

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -379,12 +379,16 @@ describe('GET /users', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      const usersCount = await User.countDocuments({ company: otherCompany._id });
+      const usersCount = await UserCompany.countDocuments({ company: otherCompany._id });
       expect(res.result.data.users.length).toBe(usersCount);
     });
 
     it('should get all coachs users (company A)', async () => {
-      const coachUsers = [...userList, ...usersSeedList].filter(u => u.role && isExistingRole(u.role.client, 'coach'));
+      const coachUsers = [...userList, ...usersSeedList].filter(u =>
+        u.role &&
+        isExistingRole(u.role.client, 'coach') &&
+        u.company === authCompany._id);
+
       const res = await app.inject({
         method: 'GET',
         url: `/users?company=${authCompany._id}&role=coach`,

--- a/tests/seed/userSeed.js
+++ b/tests/seed/userSeed.js
@@ -129,8 +129,16 @@ const userList = [
   },
 ];
 
+const userCompaniesList = [
+  { user: userList[0]._id, company: authCompany._id },
+  { user: userList[1]._id, company: authCompany._id },
+  { user: userList[2]._id, company: authCompany._id },
+  { user: userList[3]._id, company: authCompany._id },
+  { user: userList[4]._id, company: authCompany._id },
+];
+
 const trainer = userList.find(u => u.local.email === 'trainer@alenvi.io');
 const noRoleNoCompany = userList.find(u => u.local.email === 'norole.nocompany@alenvi.io');
 const vendorAdmin = userList.find(u => u.local.email === 'vendor-admin@alenvi.io');
 
-module.exports = { userList, trainer, noRoleNoCompany, vendorAdmin };
+module.exports = { userList, trainer, noRoleNoCompany, vendorAdmin, userCompaniesList };

--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -49,7 +49,7 @@ describe('formatQueryForUsersList', () => {
 
     const result = await UsersHelper.formatQueryForUsersList(query);
 
-    expect(result).toEqual(query);
+    expect(result).toEqual(omit(query, 'company'));
     sinon.assert.notCalled(find);
     SinonMongoose.calledWithExactly(
       findUserCompany,
@@ -71,7 +71,6 @@ describe('formatQueryForUsersList', () => {
 
     const result = await UsersHelper.formatQueryForUsersList(query);
     expect(result).toEqual({
-      company: companyId,
       _id: { $in: users.map(u => u.user) },
       'role.vendor': { $in: [query.role[0]._id, query.role[1]._id] },
     });


### PR DESCRIPTION
## Refonte lien structure/utilisateur:  recuperation de la liste des utilisateurs + utilisateurs actifs

## Tests a réaliser: 
- Avec structure: 
   - ETQ Vendeur: sur la page d’une structure, on récupère la liste des coach et admin client de cette structure 
   - ETQ admin:  sur la page page coach, on récupère la liste des coach et admin client de cette structure 
   - ETQ auxiliaire: 
      - sur le répertoire équipe, on récupère la liste des auxiliaires, référent planning de la structure 
      -  sur l’agenda, on récupère la liste des auxiliaires, référent planning de la structure
      - sur le planning bénéficiaire, on récupère la liste des auxiliaires, référent planning de la structure
- Sans structure:
   - ETQ ROF Sur le répertoire formateurs, on récupère la liste des formateurs
   - ETQ ROF Sur l’onglet Organisation d’une formation, on récupère les formateurs, ROF et admin vendeur
   - ETQ ROF Sur le kanban formations, on récupère les formateurs, ROF et admin vendeur

Sur postman: 
Dans le service: `/src/helpers/authorization : `
importer `const UserCompany = require('../models/UserCompany’);`
dans `validate`:  
commenter: `.populate({ path: 'company' })`
ajouter: `const userCompany = await UserCompany.findOne({ user: user._id }).populate('company').lean();`
transformer tous les `user.company` en `userCompany.company` => pour userRights (l.41) et credentials.company (l.58) plutôt mettre get(userCompany, 'company') || null

Apres avoir fait ces modifications, avec postman, rappeler les routes  ci-dessus
