### PR TITLE
COM-2171: userCompany in getlearnerlist

### DIFF
--- a/tests/unit/helpers/users.test.js
+++ b/tests/unit/helpers/users.test.js
@@ -19,8 +19,9 @@ const UserCompaniesHelper = require('../../../src/helpers/userCompanies');
 const User = require('../../../src/models/User');
 const Contract = require('../../../src/models/Contract');
 const Role = require('../../../src/models/Role');
-const { HELPER, AUXILIARY_WITHOUT_COMPANY, WEBAPP } = require('../../../src/helpers/constants');
 const Company = require('../../../src/models/Company');
+const UserCompany = require('../../../src/models/UserCompany');
+const { HELPER, AUXILIARY_WITHOUT_COMPANY, WEBAPP } = require('../../../src/helpers/constants');
 
 const { language } = translate;
 
@@ -229,13 +230,16 @@ describe('getUsersListWithSectorHistories', () => {
 describe('getLearnerList', () => {
   let findUser;
   let findRole;
+  let findUserCompany;
   beforeEach(() => {
     findUser = sinon.stub(User, 'find');
     findRole = sinon.stub(Role, 'find');
+    findUserCompany = sinon.stub(UserCompany, 'find');
   });
   afterEach(() => {
     findUser.restore();
     findRole.restore();
+    findUserCompany.restore();
   });
 
   it('should get all learners', async () => {
@@ -286,12 +290,14 @@ describe('getLearnerList', () => {
       { _id: new ObjectID(), activityHistories: [{ _id: new ObjectID() }] },
       { _id: new ObjectID(), activityHistories: [{ _id: new ObjectID() }] },
     ];
+    const usersCompany = [{ user: users[0]._id }, { user: users[1]._id }];
     const usersWithVirtuals = [
       { _id: users[0]._id, activityHistoryCount: 1, lastActivityHistory: users[0].activityHistories[0] },
       { _id: users[1]._id, activityHistoryCount: 1, lastActivityHistory: users[1].activityHistories[0] },
     ];
 
-    findRole.returns(rolesToExclude);
+    findUserCompany.returns(SinonMongoose.stubChainedQueries([usersCompany], ['lean']));
+    findRole.returns(SinonMongoose.stubChainedQueries([rolesToExclude], ['lean']));
     findUser.returns(SinonMongoose.stubChainedQueries(
       [users],
       ['populate', 'setOptions', 'lean']
@@ -300,14 +306,21 @@ describe('getLearnerList', () => {
     const result = await UsersHelper.getLearnerList(query, credentials);
 
     expect(result).toEqual(usersWithVirtuals);
-    sinon.assert.calledOnceWithExactly(findRole, { name: { $in: [HELPER, AUXILIARY_WITHOUT_COMPANY] } });
+    SinonMongoose.calledWithExactly(
+      findRole,
+      [{ query: 'find', args: [{ name: { $in: [HELPER, AUXILIARY_WITHOUT_COMPANY] } }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledWithExactly(
+      findUserCompany,
+      [{ query: 'find', args: [{ company: query.company }, { user: 1 }] }, { query: 'lean' }]
+    );
     SinonMongoose.calledWithExactly(
       findUser,
       [
         {
           query: 'find',
           args: [
-            { company: query.company, 'role.client': { $not: { $in: [roleId1, roleId2] } } },
+            { _id: { $in: [users[0]._id, users[1]._id] }, 'role.client': { $not: { $in: [roleId1, roleId2] } } },
             'identity.firstname identity.lastname picture',
             { autopopulate: false },
           ],
@@ -331,11 +344,13 @@ describe('getLearnerList', () => {
       { _id: new ObjectID(), activityHistories: [{ _id: new ObjectID() }] },
       { _id: new ObjectID(), activityHistories: [{ _id: new ObjectID() }] },
     ];
+    const usersCompany = [{ user: users[0]._id }, { user: users[1]._id }];
     const usersWithVirtuals = [
       { _id: users[0]._id, activityHistoryCount: 1, lastActivityHistory: users[0].activityHistories[0] },
       { _id: users[1]._id, activityHistoryCount: 1, lastActivityHistory: users[1].activityHistories[0] },
     ];
 
+    findUserCompany.returns(SinonMongoose.stubChainedQueries([usersCompany], ['lean']));
     findUser.returns(SinonMongoose.stubChainedQueries(
       [users],
       ['populate', 'setOptions', 'lean']
@@ -346,12 +361,16 @@ describe('getLearnerList', () => {
     expect(result).toEqual(usersWithVirtuals);
     sinon.assert.notCalled(findRole);
     SinonMongoose.calledWithExactly(
+      findUserCompany,
+      [{ query: 'find', args: [{}, { user: 1 }] }, { query: 'lean' }]
+    );
+    SinonMongoose.calledWithExactly(
       findUser,
       [
         {
           query: 'find',
           args: [
-            { company: { $exists: true } },
+            { _id: { $in: [users[0]._id, users[1]._id] } },
             'identity.firstname identity.lastname picture',
             { autopopulate: false },
           ],


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client/vendeur

- Périmetre roles : ROF/formateur/client_admin

- Cas d'usage : 
TESTS:
on obtient bien la liste d'utilisateurs : 
- avec un filtre sur la structure spécifique : 
  - Côté client coach, sur le répertoire apprenants
  - Coté client coach, sur l’onglet suivi d’une formation INTRA pour la liste des personnes possibles pour l'emargement
  - Coté vendeur rof, sur l’onglet suivi d’une formation INTRA pour la liste des personnes possibles pour l'emargement
  - Coté vendeur formateur, sur l’onglet suivi d’une formation INTRA pour la liste des personnes possibles pour l'emargement
- avec un filtre sur n’importe quelle structure : 
  - Coté client coach, sur l’onglet suivi d’une formation INTER_B2B pour la liste des personnes possibles pour l'emargement
  - Coté vendeur rof, sur l’onglet suivi d’une formation INTER_B2B pour la liste des personnes possibles pour l'emargement
  - Coté vendeur formateur, sur l’onglet suivi d’une formation INTER_B2B pour la liste des personnes possibles pour l'émargement
- sans structure
  - Côté vendeur ROF, sur le répertoire apprenants

sur postman appelé la route users/learners : 
- avec en query company + id d'alenvi : on récupère bien que ceux de l’entreprise
- avec en query hasCompany=true : on récupère bien tout ceux qui ont une entreprise

En commentant company et en modifiant authorization : 
- refaire les appels postman et vérifier qu'on a bien le même résultat (avec company=null dans ce cas là)
