### PR TITLE
Com 2210

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -427,4 +427,13 @@ module.exports = {
   CONDITION_IMPROVEMENT: 'condition_improvement',
   // FILES
   TMP_FILES_PATH: 'src/data/pdf/tmp/',
+
+  // DOCUMENTS
+  DOCUMENT_TYPE_LIST: [
+    'contract',
+    'contractVersion',
+    'debitMandate',
+    'quote',
+    'gcs',
+  ],
 };

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -52,7 +52,7 @@ const CompanySchema = mongoose.Schema({
       folderId: String,
       debitMandate: driveResourceSchemaDefinition,
       quote: driveResourceSchemaDefinition,
-      cgs: driveResourceSchemaDefinition,
+      gcs: driveResourceSchemaDefinition,
     },
   },
 }, { timestamps: true });

--- a/src/routes/companies.js
+++ b/src/routes/companies.js
@@ -11,7 +11,7 @@ const {
   list,
   show,
 } = require('../controllers/companyController');
-const { TWO_WEEKS } = require('../helpers/constants');
+const { TWO_WEEKS, DOCUMENT_TYPE_LIST } = require('../helpers/constants');
 const { COMPANY_BILLING_PERIODS, COMPANY_TYPES, TRADE_NAME_REGEX, APE_CODE_REGEX } = require('../models/Company');
 const { authorizeCompanyUpdate, companyExists } = require('./preHandlers/companies');
 const { addressValidation, formDataPayload } = require('./validations/utils');
@@ -107,13 +107,7 @@ exports.plugin = {
           params: Joi.object({ _id: Joi.objectId().required(), driveId: Joi.string().required() }),
           payload: Joi.object({
             fileName: Joi.string().required(),
-            type: Joi.string().required().valid(
-              'contract',
-              'contractVersion',
-              'debitMandate',
-              'quote',
-              'gcs'
-            ),
+            type: Joi.string().required().valid(...DOCUMENT_TYPE_LIST),
             file: Joi.any().required(),
           }),
         },

--- a/src/routes/companies.js
+++ b/src/routes/companies.js
@@ -80,6 +80,10 @@ exports.plugin = {
                   driveId: Joi.string().allow(null),
                   link: Joi.string().allow(null),
                 }),
+                gcs: Joi.object().keys({
+                  driveId: Joi.string().allow(null),
+                  link: Joi.string().allow(null),
+                }),
               }),
             }),
           }),
@@ -107,7 +111,8 @@ exports.plugin = {
               'contract',
               'contractVersion',
               'debitMandate',
-              'quote'
+              'quote',
+              'gcs'
             ),
             file: Joi.any().required(),
           }),


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : sur la page "configuration bénéficiaire", je peux ajouter un modèle de conditions générales de services
- Cas de tests : 
    - Verifier que le telechargement se passe bien
    - Verifier que l’on peut telecharger le document
    - Verifier que l’on peut supprimer le document


