### PR TITLE
COM-2240 remove CustomerFindOne call if eventType is not intervention

### DIFF
--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -43,13 +43,16 @@ exports.formatRepeatedPayload = async (event, sector, momentDay) => {
 
 exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetition) => {
   const repeatedEvents = [];
-  const customer = await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 })
-    .lean();
+  const eventIsIntervention = payload.type === INTERVENTION;
+
+  const customer = eventIsIntervention
+    ? await Customer.findOne({ _id: payload.customer, stoppedAt: { $exists: true } }, { stoppedAt: 1 }).lean()
+    : null;
 
   for (let i = 0, l = range.length; i < l; i++) {
     if (!isWeekDayRepetition || ![0, 6].includes(moment(range[i]).day())) {
       const repeatedEvent = await exports.formatRepeatedPayload(payload, sector, range[i]);
-      if (get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
+      if (eventIsIntervention && get(repeatedEvent, 'startDate') > get(customer, 'stoppedAt')) break;
       if (repeatedEvent) repeatedEvents.push(repeatedEvent);
     }
   }

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -223,7 +223,7 @@ describe('createRepeatedEvents', () => {
     const event = {
       type: INTERVENTION,
       startDate: '2019-01-10T09:00:00.000Z',
-      endDate: '2019-01-10T11:00:00Z',
+      endDate: '2019-01-10T11:00:00.000Z',
       customer: new ObjectID(),
     };
     const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z'];
@@ -258,7 +258,7 @@ describe('createRepeatedEvents', () => {
     const event = {
       type: INTERVENTION,
       startDate: '2019-01-10T09:00:00.000Z',
-      endDate: '2019-01-10T11:00:00Z',
+      endDate: '2019-01-10T11:00:00.000Z',
       customer: new ObjectID(),
     };
     const range = [
@@ -293,11 +293,11 @@ describe('createRepeatedEvents', () => {
     const event = {
       type: INTERVENTION,
       startDate: '2019-01-10T09:00:00.000Z',
-      endDate: '2019-01-10T11:00:00Z',
+      endDate: '2019-01-10T11:00:00.000Z',
       customer: new ObjectID(),
     };
     const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z'];
-    const customer = { _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') };
+    const customer = { _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00.000Z') };
     const repeatedEvents = [
       new Event({ company: new ObjectID(), startDate: range[0] }),
       new Event({ company: new ObjectID(), startDate: range[1] }),
@@ -330,7 +330,7 @@ describe('createRepeatedEvents', () => {
       const event = {
         type,
         startDate: '2019-01-10T09:00:00.000Z',
-        endDate: '2019-01-10T11:00:000Z',
+        endDate: '2019-01-10T11:00:00.000Z',
       };
 
       const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z'];
@@ -363,7 +363,11 @@ describe('createRepetitionsEveryDay', () => {
 
   it('should create repetition every day', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const event = {
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00.000Z',
+      customer: new ObjectID(),
+    };
     const range = Array.from(
       moment().range(moment('2019-01-11T09:00:00.000Z'), moment('2019-04-10T09:00:00.000Z')).by('days')
     );
@@ -391,7 +395,11 @@ describe('createRepetitionsEveryWeekDay', () => {
 
   it('should create repetition every week day', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const event = {
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00.000Z',
+      customer: new ObjectID(),
+    };
     const range = Array.from(
       moment().range(moment('2019-01-11T09:00:00.000Z'), moment('2019-04-10T09:00:00.000Z')).by('days')
     );

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -18,6 +18,7 @@ const {
   NEVER,
   EVERY_WEEK,
   INTERNAL_HOUR,
+  UNAVAILABILITY,
 } = require('../../../src/helpers/constants');
 const SinonMongoose = require('../sinonMongoose');
 
@@ -219,7 +220,12 @@ describe('createRepeatedEvents', () => {
 
   it('should create repetition for each range', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const event = {
+      type: INTERVENTION,
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00Z',
+      customer: new ObjectID(),
+    };
     const range = [
       '2019-01-11T09:00:00.000Z',
       '2019-01-12T09:00:00.000Z',
@@ -253,7 +259,12 @@ describe('createRepeatedEvents', () => {
 
   it('should not create repetition on week-end for week day repetition', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const event = {
+      type: INTERVENTION,
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00Z',
+      customer: new ObjectID(),
+    };
     const range = [
       '2019-01-11T09:00:00.000Z',
       '2019-01-12T09:00:00.000Z',
@@ -283,7 +294,12 @@ describe('createRepeatedEvents', () => {
 
   it('should not insert events after stopping date', async () => {
     const sector = new ObjectID();
-    const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
+    const event = {
+      type: INTERVENTION,
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00Z',
+      customer: new ObjectID(),
+    };
     const range = [
       '2019-01-11T09:00:00.000Z',
       '2019-01-12T09:00:00.000Z',
@@ -314,6 +330,30 @@ describe('createRepeatedEvents', () => {
         { query: 'lean' },
       ]
     );
+  });
+
+  it('should not call customerFindOne if eventType is not intervention', async () => {
+    const sector = new ObjectID();
+    const eventInternalHour = {
+      type: INTERNAL_HOUR,
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00Z',
+    };
+    const eventUnavailability = {
+      type: UNAVAILABILITY,
+      startDate: '2019-01-10T09:00:00.000Z',
+      endDate: '2019-01-10T11:00:00Z',
+    };
+    const range = [
+      '2019-01-11T09:00:00.000Z',
+      '2019-01-12T09:00:00.000Z',
+      '2019-01-13T09:00:00.000Z',
+    ];
+
+    await EventsRepetitionHelper.createRepeatedEvents(eventInternalHour, range, sector, false);
+    await EventsRepetitionHelper.createRepeatedEvents(eventUnavailability, range, sector, false);
+
+    sinon.assert.notCalled(customerFindOne);
   });
 });
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -226,11 +226,7 @@ describe('createRepeatedEvents', () => {
       endDate: '2019-01-10T11:00:00Z',
       customer: new ObjectID(),
     };
-    const range = [
-      '2019-01-11T09:00:00.000Z',
-      '2019-01-12T09:00:00.000Z',
-      '2019-01-13T09:00:00.000Z',
-    ];
+    const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z'];
     const repeatedEvents = [
       new Event({ company: new ObjectID(), startDate: range[0] }),
       new Event({ company: new ObjectID(), startDate: range[1] }),
@@ -300,10 +296,7 @@ describe('createRepeatedEvents', () => {
       endDate: '2019-01-10T11:00:00Z',
       customer: new ObjectID(),
     };
-    const range = [
-      '2019-01-11T09:00:00.000Z',
-      '2019-01-12T09:00:00.000Z',
-      '2019-01-13T09:00:00.000Z',
+    const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z',
     ];
     const customer = { _id: event.customer, stoppedAt: new Date('2019-01-12T11:00:00Z') };
     const repeatedEvents = [
@@ -344,15 +337,12 @@ describe('createRepeatedEvents', () => {
       startDate: '2019-01-10T09:00:00.000Z',
       endDate: '2019-01-10T11:00:00Z',
     };
-    const range = [
-      '2019-01-11T09:00:00.000Z',
-      '2019-01-12T09:00:00.000Z',
-      '2019-01-13T09:00:00.000Z',
-    ];
+    const range = ['2019-01-11T09:00:00.000Z', '2019-01-12T09:00:00.000Z', '2019-01-13T09:00:00.000Z'];
 
     await EventsRepetitionHelper.createRepeatedEvents(eventInternalHour, range, sector, false);
     await EventsRepetitionHelper.createRepeatedEvents(eventUnavailability, range, sector, false);
 
+    sinon.assert.callCount(insertMany, 2);
     sinon.assert.notCalled(customerFindOne);
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : JE N'AI PAS LA POSSIBILITER DE FAIRE TOURNER LES TESTS D'INTE AVEC MON PROCESSEUR 👎 

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : compani outils

- Périmetre roles : coach, aux

- Cas d'usage :  Lors de la creation des evenements d'une repetition. On fait un check pour ne pas créé d'evenement si le beneficiaire est arreté. On fait egalement ce check pour les repet de type heure interne et indiso (qui n'ont pas de benef). 
Ce ticket vise à ne faire le check que pour les interventions.
