### PR TITLE
Com 2208

### DIFF
--- a/src/helpers/customerNotes.js
+++ b/src/helpers/customerNotes.js
@@ -30,7 +30,6 @@ exports.update = async (customerNoteId, payload, credentials) => {
   const promises = [];
   const query = {
     customerNote: customerNoteId,
-    description: payload.description,
     action: NOTE_UPDATE,
     company: credentials.company._id,
     createdBy: credentials._id,
@@ -38,9 +37,17 @@ exports.update = async (customerNoteId, payload, credentials) => {
   const initialCustomerNote = await CustomerNote.findOne({ _id: customerNoteId, company: credentials.company._id })
     .lean();
 
-  if (payload.description.trim() !== initialCustomerNote.description) promises.push(createHistory(query));
+  if (payload.description.trim() !== initialCustomerNote.description) {
+    promises.push(createHistory({ ...query, description: payload.description }));
+  }
 
-  await CustomerNote.updateOne({ _id: customerNoteId, company: credentials.company._id }, { $set: payload });
+  if (payload.title.trim() !== initialCustomerNote.title) {
+    promises.push(createHistory({ ...query, title: payload.title }));
+  }
+
+  if (promises.length) {
+    await CustomerNote.updateOne({ _id: customerNoteId, company: credentials.company._id }, { $set: payload });
+  }
 
   await Promise.all(promises);
 };

--- a/src/helpers/customerNotes.js
+++ b/src/helpers/customerNotes.js
@@ -37,11 +37,11 @@ exports.update = async (customerNoteId, payload, credentials) => {
   const initialCustomerNote = await CustomerNote.findOne({ _id: customerNoteId, company: credentials.company._id })
     .lean();
 
-  if (payload.description.trim() !== initialCustomerNote.description) {
+  if (payload.description.trim() !== initialCustomerNote.description.trim()) {
     promises.push(createHistory({ ...query, description: payload.description }));
   }
 
-  if (payload.title.trim() !== initialCustomerNote.title) {
+  if (payload.title.trim() !== initialCustomerNote.title.trim()) {
     promises.push(createHistory({ ...query, title: payload.title }));
   }
 

--- a/tests/unit/helpers/customerNotes.test.js
+++ b/tests/unit/helpers/customerNotes.test.js
@@ -103,12 +103,7 @@ describe('update', () => {
 
   it('should update customer note and create an history', async () => {
     const credentials = { company: { _id: new ObjectID() }, _id: new ObjectID() };
-    const customerNote = {
-      _id: new ObjectID(),
-      title: 'test',
-      description: 'description',
-      customer: credentials._id,
-    };
+    const customerNote = { _id: new ObjectID(), title: 'test', description: 'description', customer: credentials._id };
     const payload = { title: 'titre mis a jour', description: 'description mise a jour' };
 
     findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
@@ -143,6 +138,7 @@ describe('update', () => {
         action: NOTE_UPDATE,
       }
     );
+    sinon.assert.callCount(customerNoteHistoryCreate, 2);
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: customerNote._id, company: credentials.company._id },
@@ -150,31 +146,28 @@ describe('update', () => {
     );
   });
 
-  it(
-    'should not update customer note and not create history if description and title in payload are the same as before',
-    async () => {
-      const credentials = { company: { _id: new ObjectID() }, _id: new ObjectID() };
-      const customerNote = {
-        _id: new ObjectID(),
-        title: 'test',
-        description: 'description',
-        customer: credentials._id,
-      };
-      const payload = { title: 'test', description: 'description' };
+  it('should not update note or create history if neither description nor title are changed', async () => {
+    const credentials = { company: { _id: new ObjectID() }, _id: new ObjectID() };
+    const customerNote = {
+      _id: new ObjectID(),
+      title: 'test',
+      description: 'description',
+      customer: credentials._id,
+    };
+    const payload = { title: '  test', description: 'description' };
 
-      findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
+    findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
 
-      await CustomerNotesHelper.update(customerNote._id, payload, credentials);
+    await CustomerNotesHelper.update(customerNote._id, payload, credentials);
 
-      SinonMongoose.calledWithExactly(
-        findOne,
-        [
-          { query: 'findOne', args: [{ _id: customerNote._id, company: credentials.company._id }] },
-          { query: 'lean' },
-        ]
-      );
-      sinon.assert.notCalled(customerNoteHistoryCreate);
-      sinon.assert.notCalled(updateOne);
-    }
-  );
+    SinonMongoose.calledWithExactly(
+      findOne,
+      [
+        { query: 'findOne', args: [{ _id: customerNote._id, company: credentials.company._id }] },
+        { query: 'lean' },
+      ]
+    );
+    sinon.assert.notCalled(customerNoteHistoryCreate);
+    sinon.assert.notCalled(updateOne);
+  });
 });

--- a/tests/unit/helpers/customerNotes.test.js
+++ b/tests/unit/helpers/customerNotes.test.js
@@ -109,7 +109,7 @@ describe('update', () => {
       description: 'description',
       customer: credentials._id,
     };
-    const payload = { title: 'titre', description: 'description mise a jour' };
+    const payload = { title: 'titre mis a jour', description: 'description mise a jour' };
 
     findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
     customerNoteHistoryCreate.returns(customerNote);
@@ -123,7 +123,17 @@ describe('update', () => {
         { query: 'lean' },
       ]
     );
-    sinon.assert.calledOnceWithExactly(
+    sinon.assert.calledWithExactly(
+      customerNoteHistoryCreate,
+      {
+        title: 'titre mis a jour',
+        customerNote: customerNote._id,
+        company: credentials.company._id,
+        createdBy: credentials._id,
+        action: NOTE_UPDATE,
+      }
+    );
+    sinon.assert.calledWithExactly(
       customerNoteHistoryCreate,
       {
         description: 'description mise a jour',
@@ -136,12 +146,12 @@ describe('update', () => {
     sinon.assert.calledOnceWithExactly(
       updateOne,
       { _id: customerNote._id, company: credentials.company._id },
-      { $set: { title: 'titre', description: 'description mise a jour' } }
+      { $set: { title: 'titre mis a jour', description: 'description mise a jour' } }
     );
   });
 
   it(
-    'should not update customer note and not create history if description in payload is the same as before',
+    'should not update customer note and not create history if description and title in payload are the same as before',
     async () => {
       const credentials = { company: { _id: new ObjectID() }, _id: new ObjectID() };
       const customerNote = {
@@ -150,7 +160,7 @@ describe('update', () => {
         description: 'description',
         customer: credentials._id,
       };
-      const payload = { description: 'description' };
+      const payload = { title: 'test', description: 'description' };
 
       findOne.returns(SinonMongoose.stubChainedQueries([customerNote], ['lean']));
 
@@ -164,11 +174,7 @@ describe('update', () => {
         ]
       );
       sinon.assert.notCalled(customerNoteHistoryCreate);
-      sinon.assert.calledOnceWithExactly(
-        updateOne,
-        { _id: customerNote._id, company: credentials.company._id },
-        { $set: { description: 'description' } }
-      );
+      sinon.assert.notCalled(updateOne);
     }
   );
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : -np
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES -np
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES -np
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV -np
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface :  client

- Périmetre roles : coach/admin/auxiliaire

- Cas d'usage : lorsque l'on modifie le titre d'une note, l'historique est créé
