### PR TITLE
Com 2189 2

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -405,9 +405,11 @@ module.exports = {
   BLENDED_COURSE_REGISTRATION: 'blended_course_registration',
   // TIMESTAMP
   MANUAL_TIME_STAMPING: 'manual_time_stamping',
+  QR_CODE_TIME_STAMPING: 'qr_code_time_stamping',
   get TIMESTAMPING_ACTION_TYPE_LIST() {
     return {
       [this.MANUAL_TIME_STAMPING]: 'Manuel',
+      [this.QR_CODE_TIME_STAMPING]: 'QR Code',
     };
   },
   QRCODE_MISSING: 'qrcode_missing',

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -236,6 +236,13 @@ exports.createTimeStampHistory = async (event, payload, credentials) => {
   const eventPayload = { ...omit(event, ['_id']), eventId: event._id };
   const updatePayload = {};
 
+  const query = {
+    company: event.company,
+    action: payload.action,
+    auxiliaries: [event.auxiliary],
+    createdBy: credentials._id,
+  };
+
   if (startDate) {
     eventPayload.startDate = startDate;
     updatePayload.startHour = { from: event.startDate, to: startDate };
@@ -246,13 +253,7 @@ exports.createTimeStampHistory = async (event, payload, credentials) => {
     updatePayload.endHour = { from: event.endDate, to: endDate };
   }
 
-  await EventHistory.create({
-    event: eventPayload,
-    company: event.company,
-    action: payload.action,
-    manualTimeStampingReason: payload.reason,
-    auxiliaries: [event.auxiliary],
-    update: updatePayload,
-    createdBy: credentials._id,
-  });
+  if (payload.reason) query.manualTimeStampingReason = payload.reason;
+
+  await EventHistory.create({ ...query, event: eventPayload, update: updatePayload });
 };

--- a/src/helpers/eventHistories.js
+++ b/src/helpers/eventHistories.js
@@ -236,13 +236,6 @@ exports.createTimeStampHistory = async (event, payload, credentials) => {
   const eventPayload = { ...omit(event, ['_id']), eventId: event._id };
   const updatePayload = {};
 
-  const query = {
-    company: event.company,
-    action: payload.action,
-    auxiliaries: [event.auxiliary],
-    createdBy: credentials._id,
-  };
-
   if (startDate) {
     eventPayload.startDate = startDate;
     updatePayload.startHour = { from: event.startDate, to: startDate };
@@ -253,7 +246,13 @@ exports.createTimeStampHistory = async (event, payload, credentials) => {
     updatePayload.endHour = { from: event.endDate, to: endDate };
   }
 
-  if (payload.reason) query.manualTimeStampingReason = payload.reason;
-
-  await EventHistory.create({ ...query, event: eventPayload, update: updatePayload });
+  await EventHistory.create({
+    event: eventPayload,
+    update: updatePayload,
+    company: event.company,
+    action: payload.action,
+    auxiliaries: [event.auxiliary],
+    createdBy: credentials._id,
+    ...(payload.reason && { manualTimeStampingReason: payload.reason }),
+  });
 };

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -15,7 +15,8 @@ const addressSchemaDefinition = require('./schemaDefinitions/address');
 const { validateQuery, validateAggregation } = require('./preHooks/validate');
 
 const EVENTS_HISTORY_ACTIONS = [
-  EVENT_CREATION, EVENT_DELETION,
+  EVENT_CREATION,
+  EVENT_DELETION,
   EVENT_UPDATE,
   MANUAL_TIME_STAMPING,
   QR_CODE_TIME_STAMPING,

--- a/src/models/EventHistory.js
+++ b/src/models/EventHistory.js
@@ -9,12 +9,18 @@ const {
   EVENT_CANCELLATION_REASONS,
   MANUAL_TIME_STAMPING,
   MANUAL_TIME_STAMPING_REASONS,
+  QR_CODE_TIME_STAMPING,
 } = require('../helpers/constants');
 const addressSchemaDefinition = require('./schemaDefinitions/address');
 const { validateQuery, validateAggregation } = require('./preHooks/validate');
 
-const EVENTS_HISTORY_ACTIONS = [EVENT_CREATION, EVENT_DELETION, EVENT_UPDATE, MANUAL_TIME_STAMPING];
-const TIME_STAMPING_ACTIONS = [MANUAL_TIME_STAMPING];
+const EVENTS_HISTORY_ACTIONS = [
+  EVENT_CREATION, EVENT_DELETION,
+  EVENT_UPDATE,
+  MANUAL_TIME_STAMPING,
+  QR_CODE_TIME_STAMPING,
+];
+const TIME_STAMPING_ACTIONS = [MANUAL_TIME_STAMPING, QR_CODE_TIME_STAMPING];
 
 const EventHistorySchema = mongoose.Schema({
   company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -28,6 +28,7 @@ const {
   CUSTOMER,
   AUXILIARY,
   TIMESTAMPING_ACTION_TYPE_LIST,
+  MANUAL_TIME_STAMPING,
 } = require('../helpers/constants');
 const {
   EVENT_TYPES,
@@ -294,7 +295,9 @@ exports.plugin = {
             action: Joi.string().required().valid(...Object.keys(TIMESTAMPING_ACTION_TYPE_LIST)),
             startDate: Joi.date(),
             endDate: Joi.date(),
-            reason: Joi.string().required().valid(...Object.keys(MANUAL_TIME_STAMPING_REASONS)),
+            reason: Joi.string()
+              .valid(...Object.keys(MANUAL_TIME_STAMPING_REASONS))
+              .when('action', { is: MANUAL_TIME_STAMPING, then: Joi.required(), otherwise: Joi.forbidden() }),
           }).xor('startDate', 'endDate'),
         },
         pre: [{ method: getEvent, assign: 'event' }, { method: authorizeTimeStamping }],

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -2086,22 +2086,34 @@ describe('PUT /{_id}/timestamping', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    const payload = { startDate: new Date(), action: 'manual_time_stamping', reason: 'camera_error' };
-    const missingFields = ['action', 'reason'];
+    it('should return a 400 if missing field action', async () => {
+      const payload = { startDate: new Date() };
 
-    missingFields.forEach((field) => {
-      it(`should return a 400 if missing field ${field} on manual time stamp`, async () => {
-        authToken = await getTokenByCredentials(auxiliaries[0].local);
+      authToken = await getTokenByCredentials(auxiliaries[0].local);
 
-        const response = await app.inject({
-          method: 'PUT',
-          url: `/events/${eventsList[21]._id}/timestamping`,
-          headers: { Cookie: `alenvi_token=${authToken}` },
-          payload: omit(payload, field),
-        });
-
-        expect(response.statusCode).toBe(400);
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[21]._id}/timestamping`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
       });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return a 400 if missing field reason on manual time stamp', async () => {
+      const payload = { startDate: new Date(), action: 'manual_time_stamping' };
+
+      authToken = await getTokenByCredentials(auxiliaries[0].local);
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[21]._id}/timestamping`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
     });
 
     it('should return 400 if reason is given on qr code time stamp', async () => {

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -2044,7 +2044,7 @@ describe('PUT /{_id}/timestamping', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('should return 400 if incorrect reason', async () => {
+    it('should return 400 if incorrect reason on manual time stamp', async () => {
       authToken = await getTokenByCredentials(auxiliaries[0].local);
       const startDate = new Date();
 
@@ -2090,7 +2090,7 @@ describe('PUT /{_id}/timestamping', () => {
     const missingFields = ['action', 'reason'];
 
     missingFields.forEach((field) => {
-      it(`should return a 400 if missing field ${field}`, async () => {
+      it(`should return a 400 if missing field ${field} on manual time stamp`, async () => {
         authToken = await getTokenByCredentials(auxiliaries[0].local);
 
         const response = await app.inject({
@@ -2102,6 +2102,21 @@ describe('PUT /{_id}/timestamping', () => {
 
         expect(response.statusCode).toBe(400);
       });
+    });
+
+    it('should return 400 if reason is given on qr code time stamp', async () => {
+      authToken = await getTokenByCredentials(auxiliaries[0].local);
+      const startDate = new Date();
+      const endDate = new Date();
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/events/${eventsList[21]._id}/timestamping`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { startDate, endDate, action: 'qr_code_time_stamping', reason: 'camera_error' },
+      });
+
+      expect(response.statusCode).toBe(400);
     });
   });
 

--- a/tests/unit/helpers/eventHistories.test.js
+++ b/tests/unit/helpers/eventHistories.test.js
@@ -1024,4 +1024,32 @@ describe('createTimeStampHistory', () => {
       }
     );
   });
+
+  it('shouldn’t add manualTimeStampingReason to query if reason isn’t in payload', async () => {
+    const event = {
+      _id: new ObjectID(),
+      startDate: '2021-05-01T10:00:00',
+      endDate: '2021-05-01T12:00:00',
+      customer: new ObjectID(),
+      misc: 'test',
+      company: new ObjectID(),
+      repetition: { frequency: 'every_day', parentID: new ObjectID() },
+    };
+    const payload = { endDate: '2021-05-01T12:05:00', action: 'qr_code_time_stamping' };
+    const credentials = { _id: new ObjectID() };
+
+    await EventHistoryHelper.createTimeStampHistory(event, payload, credentials);
+
+    sinon.assert.calledOnceWithExactly(
+      create,
+      {
+        event: { ...omit(event, ['_id']), eventId: event._id, endDate: '2021-05-01T12:05:00' },
+        company: event.company,
+        action: 'qr_code_time_stamping',
+        auxiliaries: [event.auxiliary],
+        update: { endHour: { from: '2021-05-01T12:00:00', to: '2021-05-01T12:05:00' } },
+        createdBy: credentials._id,
+      }
+    );
+  });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - ~~Ce n'est pas une ancienne route utilisée par les apps mobiles~~
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### ~~MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME~~
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### ~~MODIFICATIONS SUR LES MODÈLES~~
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : compani outil

- Périmetre roles : auxiliaire

Cas d'usage :
ETQ auxiliaire, je peux horodater le début d'une intervention en scannant le QR code de mon bénéficiaire.

Pour tester :

Assurez vous que vous avez autorisé l'accès à la caméra dans vos réglages
Sur une intervention, appuyer sur 'Commencer', vous êtes redirigé vers la page d'horodatage par QR code
Si vous cliquez sur 'Je ne peux pas scanner le QR code', vous êtes redirigé vers la page d'horodatage manuel
Si vous scannez un QR code d'un autre bénéficiaire, une erreur apparait vous l'indiquant
Vous pouvez alors re-scanner le bon QR Code, ce qui vous ramène sur la page de vos interventions avec votre évènement horodaté.
Problèmes rencontrés :

Je n'ai pas réussi à afficher un fond légèrement opaque avec un carré central comme sur le figma, car je n'ai trouvé de moyen de le faire qu'avec des Views légèrement transparentes (cf le commit 34df5a6) et ces Views bloquaient les 2 boutons
Je pense que la meilleure méthode pour régler ça serait d'avoir seulement un png des bords carrés centraux. Qu'en pensez vous ?
Sur Android j'ai dû affiché des bandes noires au dessus et en dessous de la caméra car celle-ci ne remplissait pas l'écran. C'est un bug connu, ils travaillent dessus : https://github.com/expo/expo/issues/ 9078
