### PR TITLE
COM-2159 create all event in repetition whem startDate is before curr…

### DIFF
--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -23,6 +23,7 @@ const Customer = require('../models/Customer');
 const EventsHelper = require('./events');
 const RepetitionsHelper = require('./repetitions');
 const EventsValidationHelper = require('./eventsValidation');
+const DatesHelper = require('./dates');
 
 momentRange.extendMoment(moment);
 
@@ -62,24 +63,33 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
 };
 
 exports.createRepetitionsEveryDay = async (payload, sector) => {
+  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
+  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+
   const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = moment(payload.startDate).add(numberOfDays, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
 
   await exports.createRepeatedEvents(payload, range, sector, false);
 };
 
 exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
+  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
+  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+
   const start = moment(payload.startDate).add(1, 'd');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = moment(payload.startDate).add(numberOfDays, 'd');
   const range = Array.from(moment().range(start, end).by('days'));
 
   await exports.createRepeatedEvents(payload, range, sector, true);
 };
 
 exports.createRepetitionsByWeek = async (payload, sector, step) => {
+  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
+  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+
   const start = moment(payload.startDate).add(step, 'w');
-  const end = moment(payload.startDate).add(90, 'd');
+  const end = moment(payload.startDate).add(numberOfDays, 'd');
   const range = Array.from(moment().range(start, end).by('weeks', { step }));
 
   await exports.createRepeatedEvents(payload, range, sector, false);

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -62,14 +62,14 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
   await Event.insertMany(repeatedEvents);
 };
 
-const getNumberOfEventToCreate = (startDate) => {
+const getNumberOfDays = (startDate) => {
   const dayDiffWithStartDate = DatesHelper.dayDiff(new Date(), startDate);
 
   return dayDiffWithStartDate > 0 ? dayDiffWithStartDate + 90 : 90;
 };
 
 exports.createRepetitionsEveryDay = async (payload, sector) => {
-  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
+  const numberOfDays = getNumberOfDays(payload.startDate);
 
   const start = moment(payload.startDate).add(1, 'd');
   const end = moment(payload.startDate).add(numberOfDays, 'd');
@@ -79,7 +79,7 @@ exports.createRepetitionsEveryDay = async (payload, sector) => {
 };
 
 exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
-  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
+  const numberOfDays = getNumberOfDays(payload.startDate);
 
   const start = moment(payload.startDate).add(1, 'd');
   const end = moment(payload.startDate).add(numberOfDays, 'd');
@@ -89,7 +89,7 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
 };
 
 exports.createRepetitionsByWeek = async (payload, sector, step) => {
-  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
+  const numberOfDays = getNumberOfDays(payload.startDate);
 
   const start = moment(payload.startDate).add(step, 'w');
   const end = moment(payload.startDate).add(numberOfDays, 'd');

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -63,7 +63,7 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
 };
 
 const getNumberOfEventToCreate = (startDate) => {
-  const dayDiffWithStartDate = DatesHelper.dayDiff(moment(), startDate);
+  const dayDiffWithStartDate = DatesHelper.dayDiff(new Date(), startDate);
 
   return dayDiffWithStartDate > 0 ? dayDiffWithStartDate + 90 : 90;
 };

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -63,7 +63,9 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
 };
 
 const getNumberOfDays = (startDate) => {
-  const dayDiffWithStartDate = DatesHelper.dayDiff(new Date(), startDate);
+  const formattedCurrentDate = moment().startOf('d').toDate();
+  const formattedStartDate = moment(startDate).startOf('d').toDate();
+  const dayDiffWithStartDate = DatesHelper.dayDiff(formattedCurrentDate, formattedStartDate);
 
   return dayDiffWithStartDate > 0 ? dayDiffWithStartDate + 90 : 90;
 };

--- a/src/helpers/eventsRepetition.js
+++ b/src/helpers/eventsRepetition.js
@@ -62,9 +62,14 @@ exports.createRepeatedEvents = async (payload, range, sector, isWeekDayRepetitio
   await Event.insertMany(repeatedEvents);
 };
 
+const getNumberOfEventToCreate = (startDate) => {
+  const dayDiffWithStartDate = DatesHelper.dayDiff(moment(), startDate);
+
+  return dayDiffWithStartDate > 0 ? dayDiffWithStartDate + 90 : 90;
+};
+
 exports.createRepetitionsEveryDay = async (payload, sector) => {
-  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
-  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
 
   const start = moment(payload.startDate).add(1, 'd');
   const end = moment(payload.startDate).add(numberOfDays, 'd');
@@ -74,8 +79,7 @@ exports.createRepetitionsEveryDay = async (payload, sector) => {
 };
 
 exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
-  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
-  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
 
   const start = moment(payload.startDate).add(1, 'd');
   const end = moment(payload.startDate).add(numberOfDays, 'd');
@@ -85,8 +89,7 @@ exports.createRepetitionsEveryWeekDay = async (payload, sector) => {
 };
 
 exports.createRepetitionsByWeek = async (payload, sector, step) => {
-  const durationFromStartdayToNow = DatesHelper.dayDiff(moment(), payload.startDate);
-  const numberOfDays = durationFromStartdayToNow > 0 ? durationFromStartdayToNow + 90 : 90;
+  const numberOfDays = getNumberOfEventToCreate(payload.startDate);
 
   const start = moment(payload.startDate).add(step, 'w');
   const end = moment(payload.startDate).add(numberOfDays, 'd');

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -616,10 +616,15 @@ describe('GET /events/unassigned-hours', () => {
 
 describe('POST /events', () => {
   let authToken = null;
+  let DatesHelperDayDiff;
   describe('PLANNING_REFERENT', () => {
     beforeEach(populateDB);
     beforeEach(async () => {
       authToken = await getToken('planning_referent');
+      DatesHelperDayDiff = sinon.stub(DatesHelper, 'dayDiff');
+    });
+    afterEach(() => {
+      DatesHelperDayDiff.restore();
     });
 
     it('should create an internal hour', async () => {
@@ -748,9 +753,6 @@ describe('POST /events', () => {
     });
 
     it('should create a repetition', async () => {
-      const DateHelperDayDiff = sinon.stub(DatesHelper, 'dayDiff');
-      DateHelperDayDiff.returns(0);
-
       const payload = {
         type: INTERVENTION,
         startDate: '2019-01-23T10:00:00',
@@ -767,6 +769,8 @@ describe('POST /events', () => {
         },
         repetition: { frequency: EVERY_DAY },
       };
+
+      DatesHelperDayDiff.returns(0);
 
       const response = await app.inject({
         method: 'POST',

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -1,4 +1,5 @@
 const expect = require('expect');
+const sinon = require('sinon');
 const { ObjectID } = require('mongodb');
 const moment = require('moment');
 const qs = require('qs');
@@ -747,6 +748,9 @@ describe('POST /events', () => {
     });
 
     it('should create a repetition', async () => {
+      const DateHelperDayDiff = sinon.stub(DatesHelper, 'dayDiff');
+      DateHelperDayDiff.returns(0);
+
       const payload = {
         type: INTERVENTION,
         startDate: '2019-01-23T10:00:00',

--- a/tests/unit/helpers/dates.test.js
+++ b/tests/unit/helpers/dates.test.js
@@ -130,7 +130,7 @@ describe('isSameOrAfter', () => {
 });
 
 describe('dayDiff', () => {
-  it('should return number of days between two dates', () => {
+  it('should return a positive number of days between to dates as the first date is later than the second', () => {
     const date1 = '2021-01-05T10:04:34';
     const date2 = '2021-01-01T09:15:24';
 
@@ -139,7 +139,7 @@ describe('dayDiff', () => {
     expect(result).toBe(4);
   });
 
-  it('should return number of days between two dates', () => {
+  it('should return 0 as the date difference is smaller than 24h', () => {
     const date1 = '2021-01-05T10:04:34';
     const date2 = '2021-01-04T11:04:54';
 
@@ -148,7 +148,7 @@ describe('dayDiff', () => {
     expect(result).toBe(0);
   });
 
-  it('should return number of days between two dates', () => {
+  it('should return 0 as the two dates are the same day ', () => {
     const date1 = '2021-01-05T10:04:34';
     const date2 = '2021-01-05T11:04:54';
 
@@ -157,7 +157,7 @@ describe('dayDiff', () => {
     expect(result).toBe(0);
   });
 
-  it('should return number of days between two dates', () => {
+  it('should return a negative number of days between two dates as the first date is earlier than the seconde ', () => {
     const date1 = '2021-01-04T10:04:34';
     const date2 = '2021-01-05T11:04:54';
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -353,7 +353,7 @@ describe('createRepeatedEvents', () => {
   });
 });
 
-describe('createRepetitionsEveryDay #tag', () => {
+describe('createRepetitionsEveryDay', () => {
   let createRepeatedEvents;
   let dayDiff;
   beforeEach(() => {
@@ -365,7 +365,7 @@ describe('createRepetitionsEveryDay #tag', () => {
     dayDiff.restore();
   });
 
-  it('should create repetition every day from first event to 90 days after', async () => {
+  it('should create repetition every day from today', async () => {
     const sector = new ObjectID();
     const event = {
       startDate: '2019-01-10T09:00:00.000Z',
@@ -389,7 +389,7 @@ describe('createRepetitionsEveryDay #tag', () => {
     );
   });
 
-  it('should create repetition every day from first event to current time plus 90 days #tag', async () => {
+  it('should create repetition every day with first event in the past', async () => {
     const sector = new ObjectID();
     const event = {
       startDate: '2019-01-10T09:00:00.000Z',
@@ -426,7 +426,7 @@ describe('createRepetitionsEveryWeekDay', () => {
     dayDiff.restore();
   });
 
-  it('should create repetition every week day from first event to 90 days after', async () => {
+  it('should create repetition every week day with first event in the future', async () => {
     const sector = new ObjectID();
     const event = {
       startDate: '2019-01-10T09:00:00.000Z',
@@ -450,7 +450,7 @@ describe('createRepetitionsEveryWeekDay', () => {
     );
   });
 
-  it('should create repetition every week day from first event to current time plus 90 days', async () => {
+  it('should create repetition every week day with first event in the past', async () => {
     const sector = new ObjectID();
     const event = {
       startDate: '2019-01-10T09:00:00.000Z',
@@ -475,7 +475,7 @@ describe('createRepetitionsEveryWeekDay', () => {
   });
 });
 
-describe('createRepetitionsByWeek #tag', () => {
+describe('createRepetitionsByWeek', () => {
   let createRepeatedEvents;
   let dayDiff;
   beforeEach(() => {
@@ -487,7 +487,7 @@ describe('createRepetitionsByWeek #tag', () => {
     dayDiff.restore();
   });
 
-  it('should create repetition by week from first event to 90 days after', async () => {
+  it('should create repetition by week with first event in the future', async () => {
     const sector = new ObjectID();
     const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
     const range = Array.from(
@@ -507,7 +507,7 @@ describe('createRepetitionsByWeek #tag', () => {
     );
   });
 
-  it('should create repetition by week from first event to current time plus 90 days', async () => {
+  it('should create repetition by week with first event in the past', async () => {
     const sector = new ObjectID();
     const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
     const range = Array.from(
@@ -527,7 +527,7 @@ describe('createRepetitionsByWeek #tag', () => {
     );
   });
 
-  it('should create repetition every two weeks from first event to 90 days after', async () => {
+  it('should create repetition every two weeks from today', async () => {
     const sector = new ObjectID();
     const event = { startDate: '2019-01-10T09:00:00.000Z', endDate: '2019-01-10T11:00:00Z', customer: new ObjectID() };
 

--- a/tests/unit/helpers/eventsRepetition.test.js
+++ b/tests/unit/helpers/eventsRepetition.test.js
@@ -11,7 +11,7 @@ const Customer = require('../../../src/models/Customer');
 const EventsHelper = require('../../../src/helpers/events');
 const EventsRepetitionHelper = require('../../../src/helpers/eventsRepetition');
 const EventsValidationHelper = require('../../../src/helpers/eventsValidation');
-const datesHelper = require('../../../src/helpers/dates');
+const DatesHelper = require('../../../src/helpers/dates');
 const RepetitionHelper = require('../../../src/helpers/repetitions');
 const {
   INTERVENTION,
@@ -358,7 +358,7 @@ describe('createRepetitionsEveryDay', () => {
   let dayDiff;
   beforeEach(() => {
     createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
-    dayDiff = sinon.stub(datesHelper, 'dayDiff');
+    dayDiff = sinon.stub(DatesHelper, 'dayDiff');
   });
   afterEach(() => {
     createRepeatedEvents.restore();
@@ -419,7 +419,7 @@ describe('createRepetitionsEveryWeekDay', () => {
   let dayDiff;
   beforeEach(() => {
     createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
-    dayDiff = sinon.stub(datesHelper, 'dayDiff');
+    dayDiff = sinon.stub(DatesHelper, 'dayDiff');
   });
   afterEach(() => {
     createRepeatedEvents.restore();
@@ -480,7 +480,7 @@ describe('createRepetitionsByWeek', () => {
   let dayDiff;
   beforeEach(() => {
     createRepeatedEvents = sinon.stub(EventsRepetitionHelper, 'createRepeatedEvents');
-    dayDiff = sinon.stub(datesHelper, 'dayDiff');
+    dayDiff = sinon.stub(DatesHelper, 'dayDiff');
   });
   afterEach(() => {
     createRepeatedEvents.restore();


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations : pas possible pour moi de lancer les tests. Mon ticket devrait pas les impacter

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- Si mes changements impactent l'application erp :
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- J'ai ajouté un modèle spécifique à une structure:
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- J'ai changé un modèle utilisé par l'app mobile:
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- J'ai ajouté une variable d'environnement :
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client, Compani outils

- Périmetre roles : admin / coach / aux

- Cas d'usage : fix du manque de creation d'evenement si la date de debut de la repetition est avant now().
