### PR TITLE
COM-2203: block access to user without company

### DIFF
--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -123,18 +123,19 @@ const checkUpdateRestrictions = (payload) => {
 exports.authorizeUserGetById = async (req) => {
   const { credentials } = req.auth;
   const user = req.pre.user || req.payload;
-  const companyId = get(credentials, 'company._id', null);
+  const loggedCompanyId = get(credentials, 'company._id', null);
+  const loggedUserId = credentials._id;
   const isVendorUser = get(credentials, 'role.vendor', null);
   const establishmentId = get(req, 'payload.establishment');
 
   if (establishmentId) {
-    const establishment = await Establishment.countDocuments({ _id: establishmentId, company: companyId });
+    const establishment = await Establishment.countDocuments({ _id: establishmentId, company: loggedCompanyId });
     if (!establishment) throw Boom.forbidden();
   }
 
-  const isClientFromDifferentCompany = !isVendorUser && user.company &&
-    !UtilsHelper.areObjectIdsEquals(user.company, companyId);
-  if (isClientFromDifferentCompany) throw Boom.forbidden();
+  const isVendorOrSameCompany = isVendorUser || UtilsHelper.areObjectIdsEquals(user._id, loggedUserId) ||
+    UtilsHelper.areObjectIdsEquals(user.company, loggedCompanyId);
+  if (!isVendorOrSameCompany) throw Boom.forbidden();
 
   return null;
 };

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -134,7 +134,7 @@ exports.authorizeUserGetById = async (req) => {
 
   const isClientFromDifferentCompany = !isLoggedUserVendor && user.company &&
     !UtilsHelper.areObjectIdsEquals(user.company, loggedCompanyId);
-  if (isClientFromDifferentCompany) throw Boom.forbidden();
+  if (isClientFromDifferentCompany) throw Boom.notFound();
 
   return null;
 };

--- a/src/routes/preHandlers/users.js
+++ b/src/routes/preHandlers/users.js
@@ -124,9 +124,7 @@ exports.authorizeUserGetById = async (req) => {
   const { credentials } = req.auth;
   const user = req.pre.user || req.payload;
   const loggedCompanyId = get(credentials, 'company._id', null);
-  const loggedUserId = credentials._id;
   const isLoggedUserVendor = get(credentials, 'role.vendor', null);
-  const isLoggedUserClient = get(credentials, 'role.client', null);
   const establishmentId = get(req, 'payload.establishment');
 
   if (establishmentId) {
@@ -136,9 +134,7 @@ exports.authorizeUserGetById = async (req) => {
 
   const isClientFromDifferentCompany = !isLoggedUserVendor && user.company &&
     !UtilsHelper.areObjectIdsEquals(user.company, loggedCompanyId);
-  const isNotLoggedUser = !isLoggedUserClient && !isLoggedUserVendor &&
-    !UtilsHelper.areObjectIdsEquals(user._id, loggedUserId);
-  if (isClientFromDifferentCompany || isNotLoggedUser) throw Boom.forbidden();
+  if (isClientFromDifferentCompany) throw Boom.forbidden();
 
   return null;
 };

--- a/tests/integration/seed/usersSeed.js
+++ b/tests/integration/seed/usersSeed.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require('uuid');
+const get = require('lodash/get');
 const { ObjectID } = require('mongodb');
 const moment = require('moment');
 const User = require('../../../src/models/User');
@@ -177,7 +178,6 @@ const usersSeedList = [
     _id: new ObjectID(),
     identity: { firstname: 'no_role_trainee', lastname: 'test' },
     local: { email: 'no_role_trainee@alenvi.io', password: '123456!eR' },
-    role: {},
     refreshToken: uuidv4(),
     origin: WEBAPP,
   },
@@ -185,7 +185,13 @@ const usersSeedList = [
     _id: new ObjectID(),
     identity: { firstname: 'trainee_to_auxiliary', lastname: 'test' },
     local: { email: 'trainee_to_auxiliary@alenvi.io', password: '123456!eR' },
-    role: {},
+    refreshToken: uuidv4(),
+    origin: WEBAPP,
+  },
+  {
+    _id: new ObjectID(),
+    identity: { firstname: 'user_without_company', lastname: 'test' },
+    local: { email: 'user_without_company@alenvi.io', password: '123456!eR' },
     refreshToken: uuidv4(),
     origin: WEBAPP,
   },
@@ -257,7 +263,7 @@ const contracts = [
 ];
 
 const sectorHistories = usersSeedList
-  .filter(user => user.role.client === rolesList.find(role => role.name === 'auxiliary')._id)
+  .filter(user => get(user, 'role.client') === rolesList.find(role => role.name === 'auxiliary')._id)
   .map(user => ({
     auxiliary: user._id,
     sector: userSectors[0]._id,

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -854,7 +854,7 @@ describe('GET /users/:id', () => {
         headers: { Cookie: `alenvi_token=${authToken}` },
       });
 
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(404);
     });
   });
 

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -856,6 +856,16 @@ describe('GET /users/:id', () => {
 
       expect(res.statusCode).toBe(403);
     });
+
+    it('should return a 403 error if user has no company', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/users/${usersSeedList[8]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
   });
 
   describe('VENDOR_ADMIN', () => {

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -856,16 +856,6 @@ describe('GET /users/:id', () => {
 
       expect(res.statusCode).toBe(403);
     });
-
-    it('should return a 403 error if user has no company', async () => {
-      const res = await app.inject({
-        method: 'GET',
-        url: `/users/${usersSeedList[8]._id}`,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(res.statusCode).toBe(403);
-    });
   });
 
   describe('VENDOR_ADMIN', () => {
@@ -896,6 +886,18 @@ describe('GET /users/:id', () => {
       });
 
       expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 403 if it is not me - no role no company', async () => {
+      authToken = await getTokenByCredentials(userList[11].local);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/users/${usersSeedList[8]._id}`,
+        headers: { 'x-access-token': authToken },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
 
     const roles = [{ name: 'helper', expectedCode: 403 }, { name: 'planning_referent', expectedCode: 403 }];


### PR DESCRIPTION
### TESTS
- [ ] Mon code est testé unitairement -np

- Tests intégrations :
  - ~~Ce n'est pas une ancienne route utilisée par les apps mobiles~~
      - [] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [x] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a: empêcher l'accès à un utilisateur sans compagnie ce qui n'est pas un cas possible en mobile
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- ~~J'ai ajouté un champ possible dans la route :~~
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- ~~J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
-~~ J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : coach

- Cas d'usage : 
si depuis le répertoire apprenant côté coach, j'essaie d'accéder à un apprenant qui n'est pas de ma strucuture ou qui n'a pas de structure je reçois une 404.
TEST : 
accéder à un apprenant depuis le côté vendeur => ça fonctionne
accéder à un apprenant de ma structure côté client => ça fonctionne
accéder à un apprenant d'une autre structure côté client => 404
accéder à un apprenant sans structure côté client => 404
se connecter à l'app de formation et faire une activité avec son compte => ça fonctionne
se connecter à l'app de formation et faire une activité avec un compte rattaché à aucune structure => ça fonctionne