### PR TITLE
COM-2238 

### DIFF
--- a/src/helpers/billSlips.js
+++ b/src/helpers/billSlips.js
@@ -84,7 +84,7 @@ exports.formatFundingInfo = (info, billingDoc) => {
     createdAt: info.createdAt,
     date: moment(info.date).format('DD/MM/YYYY'),
     customer: get(info, 'customer.identity.lastname'),
-    folderNumber: matchingVersion.folderNumber,
+    folderNumber: matchingVersion.folderNumber || '',
     tppParticipationRate: UtilsHelper.formatPercentage((100 - matchingVersion.customerParticipationRate) / 100),
     customerParticipationRate: UtilsHelper.formatPercentage(matchingVersion.customerParticipationRate / 100),
     careHours: UtilsHelper.formatHour(matchingVersion.careHours),


### PR DESCRIPTION

- Périmetre interface : client

- Périmetre roles : coach/admin client

- Bug : dans le bordereau tiers payeurs dans la colonne dossier il y a marque 'undefined' si le beneficiaire n'a pas de numéro dossier --> remplacer undefined par ' ' .
